### PR TITLE
Pass through balances to templates

### DIFF
--- a/lib/hackney/template_variables.rb
+++ b/lib/hackney/template_variables.rb
@@ -11,7 +11,8 @@ module Hackney
         'formal name' => [
           tenancy.primary_contact_name.split(' ')[0],
           tenancy.primary_contact_name.split(' ')[2]
-        ].join(' ')
+        ].join(' '),
+        'balance' => tenancy.current_balance
       }
     end
 

--- a/spec/helpers/template_variables_spec.rb
+++ b/spec/helpers/template_variables_spec.rb
@@ -10,7 +10,8 @@ describe Hackney::TemplateVariables do
         'formal name' => 'Mr Kent',
         'full name' => 'Mr Clark Kent',
         'last name' => 'Kent',
-        'title' => 'Mr'
+        'title' => 'Mr',
+        'balance' => '1200.99'
       )
     end
   end


### PR DESCRIPTION
What: 
The new templates require balances, the rest is just config changes.
Why:
Pointing to the actual production instance of gov notify and showing the actual templates