### PR TITLE
Remove another currency symbol

### DIFF
--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -19,7 +19,7 @@ module Hackney
         tenancies.map do |tenancy|
           t = Hackney::Income::Domain::TenancyListItem.new
           t.ref = tenancy['ref']
-          t.current_balance = tenancy['current_balance']
+          t.current_balance = tenancy['current_balance'].delete('¤').to_f
           t.current_arrears_agreement_status = tenancy['current_arrears_agreement_status']
           t.latest_action_code = tenancy['latest_action']['code']
           t.latest_action_date = tenancy['latest_action']['date']
@@ -42,7 +42,7 @@ module Hackney
         tenancies.each do |tenancy|
           t = Hackney::Income::Domain::TenancyListItem.new
           t.ref = tenancy['ref']
-          t.current_balance = tenancy['current_balance']
+          t.current_balance = tenancy['current_balance'].delete('¤').to_f
           t.current_arrears_agreement_status = tenancy['current_arrears_agreement_status']
           t.latest_action_code = tenancy['latest_action']['code']
           t.latest_action_date = tenancy['latest_action']['date']
@@ -84,7 +84,7 @@ module Hackney
       def extract_action_diary(events:)
         events.map do |e|
           Hackney::Income::Domain::ActionDiaryEntry.new.tap do |t|
-            t.balance = e['balance']
+            t.balance = e['balance'].delete('¤').to_f
             t.code = e['code']
             t.type = e['type']
             t.date = e['date']

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -97,7 +97,7 @@ module Hackney
       def extract_agreements(agreements:)
         agreements.map do |a|
           Hackney::Income::Domain::ArrearsAgreement.new.tap do |t|
-            t.amount = a['amount']
+            t.amount = a['amount'].delete('¤').to_f
             t.breached = a['breached']
             t.clear_by = a['clear_by']
             t.frequency = a['frequency']

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -8,7 +8,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         [
           {
             ref: Faker::Lorem.characters(8),
-            current_balance: Faker::Number.decimal(2),
+            current_balance: "¤#{Faker::Number.decimal(2)}",
             current_arrears_agreement_status: Faker::Lorem.characters(3),
             latest_action:
             {
@@ -62,8 +62,8 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     end
 
     it 'should include balances' do
-      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance])
-      expect(subject[1].current_balance).to eq(expected_second_tenancy[:current_balance])
+      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance].delete('¤').to_f)
+      expect(subject[1].current_balance).to eq(expected_second_tenancy[:current_balance].delete('¤').to_f)
     end
 
     it 'should include current agreement status' do
@@ -102,7 +102,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       [
         {
           ref: Faker::Lorem.characters(8),
-          current_balance: Faker::Number.decimal(2),
+          current_balance: "¤#{Faker::Number.decimal(2)}",
           current_arrears_agreement_status: Faker::Lorem.characters(3),
           latest_action:
           {
@@ -171,7 +171,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         {
           ref: Faker::Lorem.characters(8),
           current_arrears_agreement_status: Faker::Lorem.characters(3),
-          current_balance: Faker::Number.decimal(2),
+          current_balance: "¤#{Faker::Number.decimal(2)}",
           primary_contact_name: Faker::Name.first_name,
           primary_contact_long_address: Faker::Address.street_address,
           primary_contact_postcode: Faker::Lorem.word
@@ -224,7 +224,7 @@ end
 
 def action_diary_event
   {
-    balance: Faker::Number.decimal(2),
+    balance: "¤#{Faker::Number.decimal(2)}",
     code: Faker::Lorem.characters(3),
     type: Faker::Lorem.characters(3),
     date: Faker::Date.forward(100),
@@ -235,7 +235,7 @@ end
 
 def arrears_agreement
   {
-    amount: Faker::Number.decimal(2),
+    amount: "¤#{Faker::Number.decimal(2)}",
     breached: Faker::Lorem.characters(3),
     clear_by: Faker::Date.forward(100),
     frequency: Faker::Lorem.characters(5),
@@ -246,7 +246,7 @@ def arrears_agreement
 end
 
 def assert_action_diary_event(expected, actual)
-  expect(expected.fetch(:balance)).to eq(actual.balance)
+  expect(expected.fetch(:balance).delete('¤').to_f).to eq(actual.balance)
   expect(expected.fetch(:code)).to eq(actual.code)
   expect(expected.fetch(:type)).to eq(actual.type)
   expect(expected.fetch(:date).strftime('%Y-%m-%d')).to eq(actual.date)
@@ -255,7 +255,7 @@ def assert_action_diary_event(expected, actual)
 end
 
 def assert_agreement(expected, actual)
-  expect(expected.fetch(:amount)).to eq(actual.amount)
+  expect(expected.fetch(:amount).delete('¤').to_f).to eq(actual.amount)
   expect(expected.fetch(:breached)).to eq(actual.breached)
   expect(expected.fetch(:clear_by).strftime('%Y-%m-%d')).to eq(actual.clear_by)
   expect(expected.fetch(:frequency)).to eq(actual.frequency)


### PR DESCRIPTION
These symbols come from the currency conversion in the API, and prevent `to_f` conversions in the front end.

I am not sure if the solution is not to send them from the API (converting to currency there seems reasonable) or to strip them like this. 