### PR TITLE
Show new fields available in API data

### DIFF
--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -3,7 +3,7 @@
     <h1 class="heading-xlarge"><%= @tenancy.primary_contact_name %></h1>
     <ul>
       <li><strong>Reference number:</strong> <%= @tenancy.ref %></li>
-      <li><strong>Tenure:</strong> <%= 'FIXME' %></li>
+      <li><strong>Tenure:</strong> <%= @tenancy.tenure %></li>
     </ul>
   </div>
 </div>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -25,6 +25,14 @@
         <% end %>
       </span>
     </div>
+    <h2>Rent Charges</h2>
+    <div>
+        <ul class="list">
+          <li>Rent Charge: <%= @tenancy.rent %></li>
+          <li>Service Charge: <%= @tenancy.service %></li>
+          <li>Other Charge: <%= @tenancy.other_charge %></li>
+        </ul>
+    </div>
   </div>
   <div class="column-two-thirds">
     <h2>Personal details</h2>

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -7,7 +7,8 @@ module Hackney
         attr_accessor :ref, :current_balance, :current_arrears_agreement_status,
                       :primary_contact_name, :primary_contact_long_address,
                       :primary_contact_postcode, :transactions, :arrears_actions, :agreements,
-                      :scheduled_actions, :primary_contact_phone, :primary_contact_email
+                      :scheduled_actions, :primary_contact_phone, :primary_contact_email,
+                      :tenure, :rent, :service, :other_charge
 
         validates :ref, :current_balance, :current_arrears_agreement_status,
                   :primary_contact_name, :primary_contact_long_address,

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -95,6 +95,10 @@ module Hackney
 
         tenancy_item = Hackney::Income::Domain::Tenancy.new.tap do |t|
           t.ref = tenancy['tenancy_details']['ref']
+          t.tenure = tenancy['tenancy_details']['tenure']
+          t.rent = tenancy['tenancy_details']['rent'].delete('¤').to_f
+          t.service = tenancy['tenancy_details']['service'].delete('¤').to_f
+          t.other_charge = tenancy['tenancy_details']['other_charge'].delete('¤').to_f
           t.current_arrears_agreement_status = tenancy['tenancy_details']['current_arrears_agreement_status']
           t.current_balance = tenancy['tenancy_details']['current_balance'].delete('¤').to_f
           t.primary_contact_name = tenancy['tenancy_details']['primary_contact_name']

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -254,6 +254,10 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         tenancy_details:
         {
           ref: Faker::Lorem.characters(8),
+          tenure: Faker::Lorem.characters(3),
+          rent: "¤#{Faker::Number.decimal(2)}",
+          service: "¤#{Faker::Number.decimal(2)}",
+          other_charge: "¤#{Faker::Number.decimal(2)}",
           current_arrears_agreement_status: Faker::Lorem.characters(3),
           current_balance: "¤#{Faker::Number.decimal(2)}",
           primary_contact_name: Faker::Name.first_name,
@@ -276,6 +280,10 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     it 'should return a single tenancy matching the reference given' do
       expect(subject).to be_instance_of(Hackney::Income::Domain::Tenancy)
       expect(subject.ref).to eq(expected_details.fetch(:ref))
+      expect(subject.tenure).to eq(expected_details.fetch(:tenure))
+      expect(subject.rent).to eq(expected_details.fetch(:rent).delete('¤').to_f)
+      expect(subject.service).to eq(expected_details.fetch(:service).delete('¤').to_f)
+      expect(subject.other_charge).to eq(expected_details.fetch(:other_charge).delete('¤').to_f)
     end
 
     it 'should include the contact details and current state of the account' do
@@ -354,6 +362,10 @@ describe Hackney::Income::LessDangerousTenancyGateway do
           tenancy_details:
           {
             ref: '12345',
+            tenure: Faker::Lorem.characters(3),
+            rent: "¤#{Faker::Number.decimal(2)}",
+            service: "¤#{Faker::Number.decimal(2)}",
+            other_charge: "¤#{Faker::Number.decimal(2)}",
             current_arrears_agreement_status: Faker::Lorem.characters(3),
             current_balance: "¤#{Faker::Number.decimal(2)}",
             primary_contact_name: Faker::Name.first_name,


### PR DESCRIPTION
Some additional fields are now available, tenure type, rent, service charges and other charges. So far, these fields are always 0.00 value on staging, but they are there.
![image](https://user-images.githubusercontent.com/7647632/44988948-36848b00-af84-11e8-889d-dca6af969095.png)

