### PR TITLE
Remove static ip proxy usage

### DIFF
--- a/config/initializers/static_ip_proxy.rb
+++ b/config/initializers/static_ip_proxy.rb
@@ -1,3 +1,0 @@
-if ENV.key?('QUOTAGUARDSTATIC_URL')
-  RestClient.proxy = ENV['QUOTAGUARDSTATIC_URL']
-end


### PR DESCRIPTION
We haven't needed this since switching from our internal API. Now API calls are authenticated separately, so no IP whitelist is necessary.