### PR TITLE
Fix issue causing balances to convert incorrectly

### DIFF
--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -21,7 +21,7 @@ module Hackney
         tenancies.map do |tenancy|
           t = Hackney::Income::Domain::TenancyListItem.new
           t.ref = tenancy['ref']
-          t.current_balance = tenancy['current_balance'].delete('¤').to_f
+          t.current_balance = tenancy['current_balance'].gsub(/[^\d\.-]/, '').to_f
           t.current_arrears_agreement_status = tenancy['current_arrears_agreement_status']
           t.latest_action_code = tenancy['latest_action']['code']
           t.latest_action_date = tenancy['latest_action']['date']
@@ -46,7 +46,7 @@ module Hackney
         tenancies.map do |tenancy|
           t = Hackney::Income::Domain::TenancyListItem.new
           t.ref = tenancy['ref']
-          t.current_balance = tenancy['current_balance'].delete('¤').to_f
+          t.current_balance = tenancy['current_balance'].gsub(/[^\d\.-]/, '').to_f
           t.current_arrears_agreement_status = tenancy['current_arrears_agreement_status']
           t.latest_action_code = tenancy['latest_action']['code']
           t.latest_action_date = tenancy['latest_action']['date']
@@ -96,11 +96,11 @@ module Hackney
         tenancy_item = Hackney::Income::Domain::Tenancy.new.tap do |t|
           t.ref = tenancy['tenancy_details']['ref']
           t.tenure = tenancy['tenancy_details']['tenure']
-          t.rent = tenancy['tenancy_details']['rent'].delete('¤').to_f
-          t.service = tenancy['tenancy_details']['service'].delete('¤').to_f
-          t.other_charge = tenancy['tenancy_details']['other_charge'].delete('¤').to_f
+          t.rent = tenancy['tenancy_details']['rent'].gsub(/[^\d\.-]/, '').to_f
+          t.service = tenancy['tenancy_details']['service'].gsub(/[^\d\.-]/, '').to_f
+          t.other_charge = tenancy['tenancy_details']['other_charge'].gsub(/[^\d\.-]/, '').to_f
           t.current_arrears_agreement_status = tenancy['tenancy_details']['current_arrears_agreement_status']
-          t.current_balance = tenancy['tenancy_details']['current_balance'].delete('¤').to_f
+          t.current_balance = tenancy['tenancy_details']['current_balance'].gsub(/[^\d\.-]/, '').to_f
           t.primary_contact_name = tenancy['tenancy_details']['primary_contact_name']
           t.primary_contact_long_address = tenancy['tenancy_details']['primary_contact_long_address']
           t.primary_contact_postcode = tenancy['tenancy_details']['primary_contact_postcode']
@@ -116,7 +116,7 @@ module Hackney
       def extract_action_diary(events:)
         events.map do |e|
           Hackney::Income::Domain::ActionDiaryEntry.new.tap do |t|
-            t.balance = e['balance'].delete('¤').to_f
+            t.balance = e['balance'].gsub(/[^\d\.-]/, '').to_f
             t.code = e['code']
             t.type = e['type']
             t.date = e['date']
@@ -129,7 +129,7 @@ module Hackney
       def extract_agreements(agreements:)
         agreements.map do |a|
           Hackney::Income::Domain::ArrearsAgreement.new.tap do |t|
-            t.amount = a['amount'].delete('¤').to_f
+            t.amount = a['amount'].gsub(/[^\d\.-]/, '').to_f
             t.breached = a['breached']
             t.clear_by = a['clear_by']
             t.frequency = a['frequency']

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -10,7 +10,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         [
           {
             ref: Faker::Lorem.characters(8),
-            current_balance: "¤#{Faker::Number.decimal(2)}",
+            current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
             current_arrears_agreement_status: Faker::Lorem.characters(3),
             latest_action:
             {
@@ -26,7 +26,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
           },
           {
             ref: Faker::Lorem.characters(8),
-            current_balance: Faker::Number.decimal(2),
+            current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
             current_arrears_agreement_status: Faker::Lorem.characters(3),
             latest_action:
             {
@@ -64,8 +64,10 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     end
 
     it 'should include balances' do
-      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance].delete('¤').to_f)
-      expect(subject[1].current_balance).to eq(expected_second_tenancy[:current_balance].delete('¤').to_f)
+      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance].gsub(/[^\d\.-]/, '').to_f)
+      expect(subject[0].current_balance.abs > 1000).to eq(true)
+      expect(subject[1].current_balance).to eq(expected_second_tenancy[:current_balance].gsub(/[^\d\.-]/, '').to_f)
+      expect(subject[1].current_balance.abs > 1000).to eq(true)
     end
 
     it 'should include current agreement status' do
@@ -104,7 +106,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       [
         {
           ref: Faker::Lorem.characters(8),
-          current_balance: "¤#{Faker::Number.decimal(2)}",
+          current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
           current_arrears_agreement_status: Faker::Lorem.characters(3),
           latest_action:
           {
@@ -193,6 +195,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
 
     it 'should return a number of tenancies assigned to the user, determined by the API' do
       expect(subject.length).to eq(2)
+      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance].gsub(/[^\d\.-]/, '').to_f)
     end
 
     it 'should include a score' do
@@ -257,11 +260,11 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         {
           ref: Faker::Lorem.characters(8),
           tenure: Faker::Lorem.characters(3),
-          rent: "¤#{Faker::Number.decimal(2)}",
-          service: "¤#{Faker::Number.decimal(2)}",
-          other_charge: "¤#{Faker::Number.decimal(2)}",
+          rent: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+          service: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+          other_charge: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
           current_arrears_agreement_status: Faker::Lorem.characters(3),
-          current_balance: "¤#{Faker::Number.decimal(2)}",
+          current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
           primary_contact_name: Faker::Name.first_name,
           primary_contact_long_address: Faker::Address.street_address,
           primary_contact_postcode: Faker::Lorem.word
@@ -283,9 +286,10 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       expect(subject).to be_instance_of(Hackney::Income::Domain::Tenancy)
       expect(subject.ref).to eq(expected_details.fetch(:ref))
       expect(subject.tenure).to eq(expected_details.fetch(:tenure))
-      expect(subject.rent).to eq(expected_details.fetch(:rent).delete('¤').to_f)
-      expect(subject.service).to eq(expected_details.fetch(:service).delete('¤').to_f)
-      expect(subject.other_charge).to eq(expected_details.fetch(:other_charge).delete('¤').to_f)
+      expect(subject.rent).to eq(expected_details.fetch(:rent).gsub(/[^\d\.-]/, '').to_f)
+      expect(subject.service).to eq(expected_details.fetch(:service).gsub(/[^\d\.-]/, '').to_f)
+      expect(subject.other_charge).to eq(expected_details.fetch(:other_charge).gsub(/[^\d\.-]/, '').to_f)
+      expect(subject.current_balance).to eq(expected_details.fetch(:current_balance).gsub(/[^\d\.-]/, '').to_f)
     end
 
     it 'should include the contact details and current state of the account' do
@@ -443,7 +447,7 @@ end
 
 def action_diary_event
   {
-    balance: "¤#{Faker::Number.decimal(2)}",
+    balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
     code: Faker::Lorem.characters(3),
     type: Faker::Lorem.characters(3),
     date: Faker::Date.forward(100),
@@ -454,7 +458,7 @@ end
 
 def arrears_agreement
   {
-    amount: "¤#{Faker::Number.decimal(2)}",
+    amount: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
     breached: Faker::Lorem.characters(3),
     clear_by: Faker::Date.forward(100),
     frequency: Faker::Lorem.characters(5),
@@ -465,7 +469,7 @@ def arrears_agreement
 end
 
 def assert_action_diary_event(expected, actual)
-  expect(expected.fetch(:balance).delete('¤').to_f).to eq(actual.balance)
+  expect(expected.fetch(:balance).gsub(/[^\d\.-]/, '').to_f).to eq(actual.balance)
   expect(expected.fetch(:code)).to eq(actual.code)
   expect(expected.fetch(:type)).to eq(actual.type)
   expect(expected.fetch(:date).strftime('%Y-%m-%d')).to eq(actual.date)
@@ -474,7 +478,7 @@ def assert_action_diary_event(expected, actual)
 end
 
 def assert_agreement(expected, actual)
-  expect(expected.fetch(:amount).delete('¤').to_f).to eq(actual.amount)
+  expect(expected.fetch(:amount).gsub(/[^\d\.-]/, '').to_f).to eq(actual.amount)
   expect(expected.fetch(:breached)).to eq(actual.breached)
   expect(expected.fetch(:clear_by).strftime('%Y-%m-%d')).to eq(actual.clear_by)
   expect(expected.fetch(:frequency)).to eq(actual.frequency)

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -10,7 +10,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         [
           {
             ref: Faker::Lorem.characters(8),
-            current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+            current_balance: Faker::Number.decimal(3),
             current_arrears_agreement_status: Faker::Lorem.characters(3),
             latest_action:
             {
@@ -26,7 +26,31 @@ describe Hackney::Income::LessDangerousTenancyGateway do
           },
           {
             ref: Faker::Lorem.characters(8),
-            current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+            current_balance: Faker::Number.decimal(3),
+            current_arrears_agreement_status: Faker::Lorem.characters(3),
+            latest_action:
+            {
+              code: Faker::Lorem.characters(10),
+              date: Faker::Date.forward(100)
+            },
+            primary_contact:
+            {
+              name: Faker::Name.first_name,
+              short_address: Faker::Address.street_address,
+              postcode: Faker::Lorem.word
+            }
+          }
+        ]
+      }
+    end
+
+    let(:stub_tenancy_balance_conversion_response) do
+      {
+        tenancies:
+        [
+          {
+            ref: Faker::Lorem.characters(8),
+            current_balance: '2,345.67',
             current_arrears_agreement_status: Faker::Lorem.characters(3),
             latest_action:
             {
@@ -47,6 +71,9 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     before do
       stub_request(:get, 'https://example.com/api/tenancies?tenancy_refs%5B%5D=FAKE/01&tenancy_refs%5B%5D=FAKE/02')
         .to_return(body: stub_tenancy_response.to_json)
+
+      stub_request(:get, 'https://example.com/api/tenancies?tenancy_refs%5B%5D=FAKE/03')
+        .to_return(body: stub_tenancy_balance_conversion_response.to_json)
     end
 
     subject { tenancy_gateway.get_tenancies_list(refs: ['FAKE/01', 'FAKE/02']) }
@@ -64,10 +91,13 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     end
 
     it 'should include balances' do
-      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance].gsub(/[^\d\.-]/, '').to_f)
-      expect(subject[0].current_balance.abs > 1000).to eq(true)
-      expect(subject[1].current_balance).to eq(expected_second_tenancy[:current_balance].gsub(/[^\d\.-]/, '').to_f)
-      expect(subject[1].current_balance.abs > 1000).to eq(true)
+      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance].to_f)
+      expect(subject[1].current_balance).to eq(expected_second_tenancy[:current_balance].to_f)
+    end
+
+    it 'should properly convert balances that are given as currencies' do
+      tenancy = tenancy_gateway.get_tenancies_list(refs: ['FAKE/03'])[0]
+      expect(tenancy.current_balance).to eq(2345.67)
     end
 
     it 'should include current agreement status' do
@@ -106,7 +136,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       [
         {
           ref: Faker::Lorem.characters(8),
-          current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+          current_balance: '¤5,675.89',
           current_arrears_agreement_status: Faker::Lorem.characters(3),
           latest_action:
           {
@@ -195,7 +225,8 @@ describe Hackney::Income::LessDangerousTenancyGateway do
 
     it 'should return a number of tenancies assigned to the user, determined by the API' do
       expect(subject.length).to eq(2)
-      expect(subject[0].current_balance).to eq(expected_first_tenancy[:current_balance].gsub(/[^\d\.-]/, '').to_f)
+      expect(subject[0].current_balance).to eq(5675.89)
+      expect(subject[1].current_balance).to eq(expected_second_tenancy[:current_balance].to_f)
     end
 
     it 'should include a score' do
@@ -260,11 +291,31 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         {
           ref: Faker::Lorem.characters(8),
           tenure: Faker::Lorem.characters(3),
-          rent: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
-          service: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
-          other_charge: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+          rent: '¤1,234.56',
+          service: '¤2,234.56',
+          other_charge: '¤3,234.56',
           current_arrears_agreement_status: Faker::Lorem.characters(3),
-          current_balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+          current_balance: '¤4,234.56',
+          primary_contact_name: Faker::Name.first_name,
+          primary_contact_long_address: Faker::Address.street_address,
+          primary_contact_postcode: Faker::Lorem.word
+        },
+        latest_action_diary_events: Array.new(5) { action_diary_event },
+        latest_arrears_agreements: Array.new(5) { arrears_agreement }
+      }
+    end
+
+    let(:triangulated_stub_tenancy_response) do
+      {
+        tenancy_details:
+        {
+          ref: Faker::Lorem.characters(8),
+          tenure: Faker::Lorem.characters(3),
+          rent: Faker::Number.decimal(5),
+          service: Faker::Number.decimal(4),
+          other_charge: Faker::Number.decimal(4),
+          current_arrears_agreement_status: Faker::Lorem.characters(3),
+          current_balance: Faker::Number.decimal(2),
           primary_contact_name: Faker::Name.first_name,
           primary_contact_long_address: Faker::Address.street_address,
           primary_contact_postcode: Faker::Lorem.word
@@ -277,19 +328,35 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     before do
       stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01')
         .to_return(body: stub_tenancy_response.to_json)
+
+      stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F02')
+        .to_return(body: triangulated_stub_tenancy_response.to_json)
     end
 
     subject { tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/01') }
     let(:expected_details) { stub_tenancy_response.fetch(:tenancy_details) }
 
-    it 'should return a single tenancy matching the reference given' do
+    it 'should return a single tenancy matching the reference given with converted currencies' do
       expect(subject).to be_instance_of(Hackney::Income::Domain::Tenancy)
       expect(subject.ref).to eq(expected_details.fetch(:ref))
       expect(subject.tenure).to eq(expected_details.fetch(:tenure))
-      expect(subject.rent).to eq(expected_details.fetch(:rent).gsub(/[^\d\.-]/, '').to_f)
-      expect(subject.service).to eq(expected_details.fetch(:service).gsub(/[^\d\.-]/, '').to_f)
-      expect(subject.other_charge).to eq(expected_details.fetch(:other_charge).gsub(/[^\d\.-]/, '').to_f)
-      expect(subject.current_balance).to eq(expected_details.fetch(:current_balance).gsub(/[^\d\.-]/, '').to_f)
+      expect(subject.rent).to eq(1234.56)
+      expect(subject.service).to eq(2234.56)
+      expect(subject.other_charge).to eq(3234.56)
+      expect(subject.current_balance).to eq(4234.56)
+    end
+
+    it 'should return a single tenancy matching the reference given' do
+      tenancy = tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/02')
+      expected_details = triangulated_stub_tenancy_response.fetch(:tenancy_details)
+
+      expect(tenancy).to be_instance_of(Hackney::Income::Domain::Tenancy)
+      expect(tenancy.ref).to eq(expected_details.fetch(:ref))
+      expect(tenancy.tenure).to eq(expected_details.fetch(:tenure))
+      expect(tenancy.rent).to eq(expected_details.fetch(:rent).to_f)
+      expect(tenancy.service).to eq(expected_details.fetch(:service).to_f)
+      expect(tenancy.other_charge).to eq(expected_details.fetch(:other_charge).to_f)
+      expect(tenancy.current_balance).to eq(expected_details.fetch(:current_balance).to_f)
     end
 
     it 'should include the contact details and current state of the account' do
@@ -447,7 +514,7 @@ end
 
 def action_diary_event
   {
-    balance: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+    balance: Faker::Number.decimal(2),
     code: Faker::Lorem.characters(3),
     type: Faker::Lorem.characters(3),
     date: Faker::Date.forward(100),
@@ -458,7 +525,7 @@ end
 
 def arrears_agreement
   {
-    amount: "¤#{Faker::Number.number(4)},#{Faker::Number.number(3)}.#{Faker::Number.number(2)}",
+    amount: Faker::Number.decimal(2),
     breached: Faker::Lorem.characters(3),
     clear_by: Faker::Date.forward(100),
     frequency: Faker::Lorem.characters(5),
@@ -469,7 +536,7 @@ def arrears_agreement
 end
 
 def assert_action_diary_event(expected, actual)
-  expect(expected.fetch(:balance).gsub(/[^\d\.-]/, '').to_f).to eq(actual.balance)
+  expect(expected.fetch(:balance).to_f).to eq(actual.balance)
   expect(expected.fetch(:code)).to eq(actual.code)
   expect(expected.fetch(:type)).to eq(actual.type)
   expect(expected.fetch(:date).strftime('%Y-%m-%d')).to eq(actual.date)
@@ -478,7 +545,7 @@ def assert_action_diary_event(expected, actual)
 end
 
 def assert_agreement(expected, actual)
-  expect(expected.fetch(:amount).gsub(/[^\d\.-]/, '').to_f).to eq(actual.amount)
+  expect(expected.fetch(:amount).to_f).to eq(actual.amount)
   expect(expected.fetch(:breached)).to eq(actual.breached)
   expect(expected.fetch(:clear_by).strftime('%Y-%m-%d')).to eq(actual.clear_by)
   expect(expected.fetch(:frequency)).to eq(actual.frequency)


### PR DESCRIPTION
We receive balances as strings from the API in currency format, ie '1,234.56'.

We convert them to floats for some processing rather than simply displaying, meaning values >1000 where incorrectly converted.

We should probably stop formatting the monetary values as currencies in the API, but this will resolve for now.