### PR TITLE
Fix broken specs and changing names on the same tenancy refs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--order rand

--- a/lib/hackney/income/anonymizer.rb
+++ b/lib/hackney/income/anonymizer.rb
@@ -2,35 +2,19 @@ module Hackney
   module Income
     module Anonymizer
       def anonymize_tenancy(tenancy:)
-        begin
-          Faker::Config.random = Random.new(tenancy.ref.to_i)
-
+        with_tenancy_seeded(tenancy) do
           tenancy.primary_contact_name = [Faker::Name.prefix, Faker::Name.unique.first_name, Faker::Name.unique.last_name].join(' ')
           tenancy.primary_contact_long_address = Faker::Address.unique.street_address
           tenancy.primary_contact_postcode = Faker::Address.unique.zip
-
-          Faker::Config.random = nil
-        rescue Faker::UniqueGenerator::RetryLimitExceeded
-          reset_unique_generator
         end
-
-        tenancy
       end
 
       def anonymize_tenancy_list_item(tenancy:)
-        begin
-          Faker::Config.random = Random.new(tenancy.ref.to_i)
-
+        with_tenancy_seeded(tenancy) do
           tenancy.primary_contact_name = [Faker::Name.prefix, Faker::Name.unique.first_name, Faker::Name.unique.last_name].join(' ')
           tenancy.primary_contact_short_address = Faker::Address.unique.street_address
           tenancy.primary_contact_postcode = Faker::Address.unique.zip
-
-          Faker::Config.random = nil
-        rescue Faker::UniqueGenerator::RetryLimitExceeded
-          reset_unique_generator
         end
-
-        tenancy
       end
 
       module_function :anonymize_tenancy
@@ -38,9 +22,28 @@ module Hackney
 
       private
 
-      def reset_unique_generator
-        Faker::UniqueGenerator.clear
+      def with_tenancy_seeded(tenancy, &block)
+        begin
+          Faker::UniqueGenerator.clear
+          Faker::Config.random = tenancy_seed(tenancy)
+
+          block.call
+        rescue Faker::UniqueGenerator::RetryLimitExceeded
+          Faker::UniqueGenerator.clear
+        ensure
+          Faker::Config.random = nil
+        end
+
+        tenancy
       end
+
+      def tenancy_seed(tenancy)
+        seed_int = tenancy.ref&.gsub('/', '')&.to_i
+        Random.new(seed_int || 0)
+      end
+
+      module_function :with_tenancy_seeded
+      module_function :tenancy_seed
     end
   end
 end

--- a/spec/lib/hackney/income/anonymizer_spec.rb
+++ b/spec/lib/hackney/income/anonymizer_spec.rb
@@ -41,14 +41,14 @@ describe Hackney::Income::Anonymizer do
 
     tenancy2 = Hackney::Income::Domain::TenancyListItem.new
 
-    tenancy2.ref = '012345/01'
+    tenancy2.ref = '023456/01'
     tenancy2.current_balance = '1168.69'
     tenancy2.primary_contact_name = 'Mr Different Name'
     tenancy2.primary_contact_short_address = 'Same'
     tenancy2.primary_contact_postcode = 'Reference number'
 
-    seeded_name_for_tenancy_ref1 = 'Ms. Brandy Romaguera'
-    seeded_name_for_tenancy_ref2 = 'Ms. Cheyenne Berge'
+    seeded_name_for_tenancy_ref1 = 'Dr. Brielle Friesen'
+    seeded_name_for_tenancy_ref2 = 'Mr. Crystal Larson'
     anonymized_tenancy1 = Hackney::Income::Anonymizer.anonymize_tenancy_list_item(tenancy: tenancy1)
     anonymized_tenancy2 = Hackney::Income::Anonymizer.anonymize_tenancy_list_item(tenancy: tenancy2)
 

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -116,7 +116,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
 
       context 'in a staging environment' do
         let(:stub_response) do
-          [example_tenancy_list_response_item]
+          [example_tenancy_list_response_item(ref: '000015/03')]
         end
 
         before do
@@ -125,9 +125,9 @@ describe Hackney::Income::LessDangerousTenancyGateway do
 
         let(:seeded_prioritised_tenancy) do
           {
-            primary_contact_name: 'Dr. Katheryn Jakubowski',
-            primary_contact_short_address: '4524 Cormier Vista',
-            primary_contact_postcode: '26778'
+            primary_contact_name: 'Mr. Reanna Mann',
+            primary_contact_short_address: '796 Jacobs Burg',
+            primary_contact_postcode: '23109-5863'
           }
         end
 
@@ -244,9 +244,9 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       let(:single_tenancy) { tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/01') }
       let(:expected_tenancy) do
         {
-          primary_contact_name: 'Ms. Trent Friesen',
-          primary_contact_long_address: '8602 Maggio Hollow',
-          primary_contact_postcode: '22677'
+          primary_contact_name: 'Ms. Mittie Torphy',
+          primary_contact_long_address: '6216 O\'Reilly Point',
+          primary_contact_postcode: '86029-1267'
         }
       end
 


### PR DESCRIPTION
Only allows one unique combination per seed, and uses tenancy ref as a consistent seed.

Anonymised tenancies will now always have the same names in the browser.

Fixes specs dependant on run order, and runs specs in random order to prevent issues like this again.