### PR TITLE
Prevent code fetch from causing an error, just return nil

### DIFF
--- a/lib/hackney/income/action_diary_entry_codes.rb
+++ b/lib/hackney/income/action_diary_entry_codes.rb
@@ -173,7 +173,7 @@ module Hackney
       end
 
       def self.human_readable_action_code(code)
-        all_code_options.select { |e| e.fetch(:code) == code }.first.fetch(:name)
+        all_code_options.select { |e| e.fetch(:code) == code }.first[:name]
       end
     end
   end


### PR DESCRIPTION
Probably due to receiving nil action codes or codes that are not listed. In these cases, this should now just display nil rather than causing an error.