### PR TITLE
Only show thirty cases at a time

### DIFF
--- a/lib/hackney/income/list_user_assigned_cases.rb
+++ b/lib/hackney/income/list_user_assigned_cases.rb
@@ -8,7 +8,7 @@ module Hackney
 
       def execute(user_id:)
         tenancies = @tenancy_assignment_gateway.assigned_tenancies(assignee_id: user_id)
-        tenancy_refs = tenancies.map { |t| t.fetch(:ref) }
+        tenancy_refs = tenancies.take(30).map { |t| t.fetch(:ref) }
 
         @tenancy_gateway.get_tenancies(tenancy_refs)
       end


### PR DESCRIPTION
Pagination coming in a separate PR, this is because case workers will currently be assigned hundreds of cases, which will display in a single page.