### PR TITLE
Temporarily disable group auth

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,8 +6,8 @@ class SessionsController < ApplicationController
 
   def create
     if auth_hash.extra.raw_info.nil? || !user_has_ic_staff_permissions?
-      flash[:notice] = 'You do not have the required access permission'
-      return redirect_to login_path
+      # flash[:notice] = 'You do not have the required access permission'
+      # return redirect_to login_path
     end
 
     user = use_cases.find_or_create_user.execute(

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -48,7 +48,7 @@ describe SessionsController do
       ENV.delete('IC_STAFF_GROUP')
     end
 
-    it 'should not allow login if the requested group token is not permitted' do
+    xit 'should not allow login if the requested group token is not permitted' do
       ENV['IC_STAFF_GROUP'] = nil
 
       get :create, params: { provider: 'azureactivedirectory' }


### PR DESCRIPTION
Temporarily disable group based auth while we work out which group to auth against, should prevent sporadic issues users are seeing when attempting to log in.