### PR TITLE
Add display date to arrears action hash

### DIFF
--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -37,7 +37,7 @@ module Hackney
             t.balance = nil
             t.code = 'AUTO'
             t.type = event.fetch(:type)
-            t.date = event.fetch(:timestamp)
+            t.date = event.fetch(:timestamp).to_s
             t.comment = event.fetch(:description)
             t.universal_housing_username = nil
           end
@@ -49,6 +49,7 @@ module Hackney
             code: event.code,
             type: event.type,
             date: event.date,
+            display_date: event.display_date,
             comment: event.comment,
             universal_housing_username: event.universal_housing_username
           }

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -87,6 +87,7 @@ describe Hackney::Income::ViewTenancy do
         expect(subject.arrears_actions[0].fetch(:date)).to eq('2018-01-01')
         expect(subject.arrears_actions[0].fetch(:comment)).to eq('this tenant is in arrears!!!')
         expect(subject.arrears_actions[0].fetch(:universal_housing_username)).to eq('Brainiac')
+        expect(subject.arrears_actions[0].fetch(:display_date)).to eq('January 1st, 2018 00:00')
       end
 
       context 'when there have been no stored events on the tenancy' do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7647632/46086912-787ea680-c1a9-11e8-91ad-0b688214dbae.png)

A recent change meant the front was trying to display a hash rather than the domain object directly, which did not include a formatted display date. Rectified this.