### PR TITLE
Contact details for tenancy

### DIFF
--- a/app/views/common/_contact_details.html.erb
+++ b/app/views/common/_contact_details.html.erb
@@ -1,0 +1,11 @@
+<ul class="list">
+  <li>Title: <%= contact[:title] %></li>
+  <li>Full Name: <%= contact[:full_name] %></li>
+  <li>Mobile Phone: <%= contact[:telephone_2] %></li>
+  <li>Home Phone: <%= contact[:telephone_1] %></li>
+  <li>E-Mail: <%= contact[:email_address] %></li>
+  <li>
+    <%= link_to 'Send SMS', tenancy_sms_path(id: @tenancy.ref), class:'button' %>
+    <%= link_to 'Send Email', tenancy_email_path(id: @tenancy.ref), class:'button' %>
+  </li>
+</ul>

--- a/app/views/common/_contact_details.html.erb
+++ b/app/views/common/_contact_details.html.erb
@@ -1,11 +1,9 @@
 <ul class="list">
   <li>Title: <%= contact[:title] %></li>
-  <li>Full Name: <%= contact[:full_name] %></li>
-  <li>Mobile Phone: <%= contact[:telephone_2] %></li>
+  <li>First Name: <%= contact[:first_name] %></li>
+  <li>Last Name: <%= contact[:last_name] %></li>
   <li>Home Phone: <%= contact[:telephone_1] %></li>
+  <li>Mobile Phone: <%= contact[:telephone_2] %></li>
+  <li>Other Phone: <%= contact[:telephone_3] %></li>
   <li>E-Mail: <%= contact[:email_address] %></li>
-  <li>
-    <%= link_to 'Send SMS', tenancy_sms_path(id: @tenancy.ref), class:'button' %>
-    <%= link_to 'Send Email', tenancy_email_path(id: @tenancy.ref), class:'button' %>
-  </li>
 </ul>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -38,11 +38,21 @@
     <h2>Personal details</h2>
     <div class="grid-row">
       <div class="column-half">
-        <h3>Current address</h3>
+        <h3>Tenancy address</h3>
         <ul class="list">
           <li><%= @tenancy.primary_contact_long_address %></li>
           <li><%= @tenancy.primary_contact_postcode %></li>
         </ul>
+        <% if !@tenancy.contacts[0].nil? %>
+          <h3>Primary Tenant</h3>
+          <ul class="list">
+            <li><%= @tenancy.contacts[0][:full_name] %></li>
+            <li><%= @tenancy.contacts[0][:address_line_1] %></li>
+            <li><%= @tenancy.contacts[0][:address_line_2] %></li>
+            <li><%= @tenancy.contacts[0][:address_line_3] %></li>
+            <li><%= @tenancy.contacts[0][:post_code] %></li>
+          </ul>
+        <% end %>
       </div>
       <div class="column-half">
         <h3>Contact details</h3>
@@ -52,6 +62,8 @@
           <% @tenancy.contacts.each do |contact| %>
           <%= render('common/contact_details', contact: contact) %>
           <% end %>
+          <%= link_to 'Send SMS', tenancy_sms_path(id: @tenancy.ref), class:'button' %>
+          <%= link_to 'Send Email', tenancy_email_path(id: @tenancy.ref), class:'button' %>
         <% end %>
       </div>
     </div>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -44,17 +44,15 @@
           <li><%= @tenancy.primary_contact_postcode %></li>
         </ul>
       </div>
-      <div class="column-half fake">
+      <div class="column-half">
         <h3>Contact details</h3>
-        <ul class="list">
-          <li>Mobile Phone: <%= @tenancy.primary_contact_phone %></li>
-          <li>Home Phone: <%= @tenancy.primary_contact_phone %></li>
-          <li>E-Mail: <%= @tenancy.primary_contact_email %></li>
-          <li>
-            <%= link_to 'Send SMS', tenancy_sms_path(id: @tenancy.ref), class:'button' %>
-            <%= link_to 'Send Email', tenancy_email_path(id: @tenancy.ref), class:'button' %>
-          </li>
-        </ul>
+        <% if @tenancy.contacts.empty? %>
+        Contact data appears to be missing for this tenant.
+        <% else %>
+          <% @tenancy.contacts.each do |contact| %>
+          <%= render('common/contact_details', contact: contact) %>
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/lib/hackney/income/domain/contact.rb
+++ b/lib/hackney/income/domain/contact.rb
@@ -1,0 +1,14 @@
+module Hackney
+  module Income
+    module Domain
+      class Contact
+        attr_accessor :contact_id, :email_address, :uprn, :address_line_1,
+                      :address_line_2, :address_line_3, :first_name, :last_name,
+                      :full_name, :larn, :telephone_1, :telephone_2, :telephone_3,
+                      :cautionary_alert, :property_cautionary_alert, :house_ref,
+                      :title, :full_address_display, :full_address_search,
+                      :post_code, :date_of_birth, :hackney_homes_id
+      end
+    end
+  end
+end

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -8,7 +8,7 @@ module Hackney
                       :primary_contact_name, :primary_contact_long_address,
                       :primary_contact_postcode, :transactions, :arrears_actions, :agreements,
                       :scheduled_actions, :primary_contact_phone, :primary_contact_email,
-                      :tenure, :rent, :service, :other_charge
+                      :tenure, :rent, :service, :other_charge, :contacts
 
         validates :ref, :current_balance, :current_arrears_agreement_status,
                   :primary_contact_name, :primary_contact_long_address,

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -126,7 +126,7 @@ module Hackney
             t.telephone_2 = c['telephone2']
             t.telephone_3 = c['telephone3']
             t.cautionary_alert = c['cautionary_alert']
-            t.property_cautionary_alert = c['propertyCautionary_alert']
+            t.property_cautionary_alert = c['property_cautionary_alert']
             t.house_ref = c['house_ref']
             t.title = c['title']
             t.full_address_display = c['full_address_display']

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -108,32 +108,32 @@ module Hackney
 
         contacts = JSON.parse(res.body)['data']['contacts']
 
-        return [] if contacts.blank?
+        return [] if contacts.blank? || Rails.env.staging?
 
         contacts.map do |c|
           Hackney::Income::Domain::Contact.new.tap do |t|
-            t.contact_id = c['contactId']
-            t.email_address = c['emailAddress']
+            t.contact_id = c['contact_id']
+            t.email_address = c['email_address']
             t.uprn = c['uprn']
-            t.address_line_1 = c['addressLine1']
-            t.address_line_2 = c['addressLine2']
-            t.address_line_3 = c['addressLine3']
-            t.first_name = c['firstName']
-            t.last_name = c['lastName']
-            t.full_name = c['fullName']
+            t.address_line_1 = c['address_line1']
+            t.address_line_2 = c['address_line2']
+            t.address_line_3 = c['address_line3']
+            t.first_name = c['first_name']
+            t.last_name = c['last_name']
+            t.full_name = c['full_name']
             t.larn = c['larn']
             t.telephone_1 = c['telephone1']
             t.telephone_2 = c['telephone2']
             t.telephone_3 = c['telephone3']
-            t.cautionary_alert = c['cautionaryAlert']
-            t.property_cautionary_alert = c['propertyCautionaryAlert']
-            t.house_ref = c['houseRef']
+            t.cautionary_alert = c['cautionary_alert']
+            t.property_cautionary_alert = c['propertyCautionary_alert']
+            t.house_ref = c['house_ref']
             t.title = c['title']
-            t.full_address_display = c['fullAddressDisplay']
-            t.full_address_search = c['fullAddressSearch']
-            t.post_code = c['postCode']
-            t.date_of_birth = c['dateOfBirth']
-            t.hackney_homes_id = c['hackneyHomesId']
+            t.full_address_display = c['full_address_display']
+            t.full_address_search = c['full_address_search']
+            t.post_code = c['post_code']
+            t.date_of_birth = c['date_of_birth']
+            t.hackney_homes_id = c['hackney_homes_id']
           end
         end
       end

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -98,6 +98,46 @@ module Hackney
         tenancy_item
       end
 
+      def get_contacts_for(tenancy_ref:)
+        uri = URI("#{@api_host}/tenancies/#{ERB::Util.url_encode(tenancy_ref)}/contacts")
+
+        req = Net::HTTP::Get.new(uri)
+        req['X-Api-Key'] = @api_key
+
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+
+        contacts = JSON.parse(res.body)['data']['contacts']
+
+        return [] if contacts.blank?
+
+        contacts.map do |c|
+          Hackney::Income::Domain::Contact.new.tap do |t|
+            t.contact_id = c['contactId']
+            t.email_address = c['emailAddress']
+            t.uprn = c['uprn']
+            t.address_line_1 = c['addressLine1']
+            t.address_line_2 = c['addressLine2']
+            t.address_line_3 = c['addressLine3']
+            t.first_name = c['firstName']
+            t.last_name = c['lastName']
+            t.full_name = c['fullName']
+            t.larn = c['larn']
+            t.telephone_1 = c['telephone1']
+            t.telephone_2 = c['telephone2']
+            t.telephone_3 = c['telephone3']
+            t.cautionary_alert = c['cautionaryAlert']
+            t.property_cautionary_alert = c['propertyCautionaryAlert']
+            t.house_ref = c['houseRef']
+            t.title = c['title']
+            t.full_address_display = c['fullAddressDisplay']
+            t.full_address_search = c['fullAddressSearch']
+            t.post_code = c['postCode']
+            t.date_of_birth = c['dateOfBirth']
+            t.hackney_homes_id = c['hackneyHomesId']
+          end
+        end
+      end
+
       def extract_action_diary(events:)
         events.map do |e|
           Hackney::Income::Domain::ActionDiaryEntry.new.tap do |t|

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -33,7 +33,40 @@ module Hackney
               create_tenancy(tenancy)
             end
 
+            def get_contacts_for(tenancy_ref:)
+              [
+                generate_contact
+              ]
+            end
+
             private
+
+            def generate_contact
+              Hackney::Income::Domain::Contact.new.tap do |c|
+                c.contact_id = '123456'
+                c.email_address = 'test.email@email.server.com'
+                c.uprn = '0'
+                c.address_line_1 = '123'
+                c.address_line_2 = 'Test Road'
+                c.address_line_3 = 'Delivery City'
+                c.first_name = 'Rich'
+                c.last_name = 'Foster'
+                c.full_name = 'Richard Foster'
+                c.larn = '0'
+                c.telephone_1 = '0101 1234'
+                c.telephone_2 = '077777777'
+                c.telephone_3 = nil
+                c.cautionary_alert = false
+                c.property_cautionary_alert = false
+                c.house_ref = '98765'
+                c.title = 'Mr.'
+                c.full_address_display = '123 Test Road, Delivery City'
+                c.full_address_search = 'Search'
+                c.post_code = 'E0 123'
+                c.date_of_birth = '12th March, 1976'
+                c.hackney_homes_id = '1209'
+              end
+            end
 
             def create_tenancy_list_item(attributes)
               Hackney::Income::Domain::TenancyListItem.new.tap do |t|
@@ -105,6 +138,7 @@ module Hackney
                 t.primary_contact_email = 'test@example.com'
                 t.arrears_actions = [action]
                 t.agreements = [agreement]
+                t.contacts = nil
               end
             end
           end

--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -18,6 +18,33 @@ module Hackney
         events = @events_gateway.events_for(tenancy_ref: tenancy_ref)
         transactions_balance_calculator = Hackney::Income::TransactionsBalanceCalculator.new
 
+        tenancy.contacts = @tenancy_gateway.get_contacts_for(tenancy_ref: tenancy_ref).map do |contact|
+          {
+            contact_id: contact.contact_id,
+            email_address: contact.email_address,
+            uprn: contact.uprn,
+            address_line_1: contact.address_line_1,
+            address_line_2: contact.address_line_2,
+            address_line_3: contact.address_line_3,
+            first_name: contact.first_name,
+            last_name: contact.last_name,
+            full_name: contact.full_name,
+            larn: contact.larn,
+            telephone_1: contact.telephone_1,
+            telephone_2: contact.telephone_2,
+            telephone_3: contact.telephone_3,
+            cautionary_alert: contact.cautionary_alert,
+            property_cautionary_alert: contact.property_cautionary_alert,
+            house_ref: contact.house_ref,
+            title: contact.title,
+            full_address_display: contact.full_address_display,
+            full_address_search: contact.full_address_search,
+            post_code: contact.post_code,
+            date_of_birth: contact.date_of_birth,
+            hackney_homes_id: contact.hackney_homes_id
+          }
+        end
+
         tenancy.transactions = transactions_balance_calculator.with_final_balances(
           current_balance: tenancy.current_balance.to_f,
           transactions: transactions.map do |transaction|

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -315,7 +315,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         expect(contacts[0].telephone_2).to eq(expected_contact.fetch(:telephone2))
         expect(contacts[0].telephone_3).to eq(expected_contact.fetch(:telephone3))
         expect(contacts[0].cautionary_alert).to eq(expected_contact.fetch(:cautionary_alert))
-        expect(contacts[0].property_cautionary_alert).to eq(expected_contact.fetch(:propertyCautionary_alert))
+        expect(contacts[0].property_cautionary_alert).to eq(expected_contact.fetch(:property_cautionary_alert))
         expect(contacts[0].house_ref).to eq(expected_contact.fetch(:house_ref))
         expect(contacts[0].title).to eq(expected_contact.fetch(:title))
         expect(contacts[0].full_address_display).to eq(expected_contact.fetch(:full_address_display))
@@ -377,7 +377,7 @@ def generate_contact
     telephone2: Faker::PhoneNumber.cell_phone,
     telephone3: nil,
     cautionary_alert: false,
-    propertyCautionary_alert: false,
+    property_cautionary_alert: false,
     house_ref: Faker::Lorem.characters(8),
     title: Faker::Name.prefix,
     full_address_display: Faker::Address.full_address,

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -301,28 +301,28 @@ describe Hackney::Income::LessDangerousTenancyGateway do
 
         expect(contacts[0]).to be_instance_of(Hackney::Income::Domain::Contact)
 
-        expect(contacts[0].contact_id).to eq(expected_contact.fetch(:contactId))
-        expect(contacts[0].email_address).to eq(expected_contact.fetch(:emailAddress))
+        expect(contacts[0].contact_id).to eq(expected_contact.fetch(:contact_id))
+        expect(contacts[0].email_address).to eq(expected_contact.fetch(:email_address))
         expect(contacts[0].uprn).to eq(expected_contact.fetch(:uprn))
-        expect(contacts[0].address_line_1).to eq(expected_contact.fetch(:addressLine1))
-        expect(contacts[0].address_line_2).to eq(expected_contact.fetch(:addressLine2))
-        expect(contacts[0].address_line_3).to eq(expected_contact.fetch(:addressLine3))
-        expect(contacts[0].first_name).to eq(expected_contact.fetch(:firstName))
-        expect(contacts[0].last_name).to eq(expected_contact.fetch(:lastName))
-        expect(contacts[0].full_name).to eq(expected_contact.fetch(:fullName))
+        expect(contacts[0].address_line_1).to eq(expected_contact.fetch(:address_line1))
+        expect(contacts[0].address_line_2).to eq(expected_contact.fetch(:address_line2))
+        expect(contacts[0].address_line_3).to eq(expected_contact.fetch(:address_line3))
+        expect(contacts[0].first_name).to eq(expected_contact.fetch(:first_name))
+        expect(contacts[0].last_name).to eq(expected_contact.fetch(:last_name))
+        expect(contacts[0].full_name).to eq(expected_contact.fetch(:full_name))
         expect(contacts[0].larn).to eq(expected_contact.fetch(:larn))
         expect(contacts[0].telephone_1).to eq(expected_contact.fetch(:telephone1))
         expect(contacts[0].telephone_2).to eq(expected_contact.fetch(:telephone2))
         expect(contacts[0].telephone_3).to eq(expected_contact.fetch(:telephone3))
-        expect(contacts[0].cautionary_alert).to eq(expected_contact.fetch(:cautionaryAlert))
-        expect(contacts[0].property_cautionary_alert).to eq(expected_contact.fetch(:propertyCautionaryAlert))
-        expect(contacts[0].house_ref).to eq(expected_contact.fetch(:houseRef))
+        expect(contacts[0].cautionary_alert).to eq(expected_contact.fetch(:cautionary_alert))
+        expect(contacts[0].property_cautionary_alert).to eq(expected_contact.fetch(:propertyCautionary_alert))
+        expect(contacts[0].house_ref).to eq(expected_contact.fetch(:house_ref))
         expect(contacts[0].title).to eq(expected_contact.fetch(:title))
-        expect(contacts[0].full_address_display).to eq(expected_contact.fetch(:fullAddressDisplay))
-        expect(contacts[0].full_address_search).to eq(expected_contact.fetch(:fullAddressSearch))
-        expect(contacts[0].post_code).to eq(expected_contact.fetch(:postCode))
-        expect(contacts[0].date_of_birth).to eq(expected_contact.fetch(:dateOfBirth).strftime('%Y-%m-%d'))
-        expect(contacts[0].hackney_homes_id).to eq(expected_contact.fetch(:hackneyHomesId))
+        expect(contacts[0].full_address_display).to eq(expected_contact.fetch(:full_address_display))
+        expect(contacts[0].full_address_search).to eq(expected_contact.fetch(:full_address_search))
+        expect(contacts[0].post_code).to eq(expected_contact.fetch(:post_code))
+        expect(contacts[0].date_of_birth).to eq(expected_contact.fetch(:date_of_birth).strftime('%Y-%m-%d'))
+        expect(contacts[0].hackney_homes_id).to eq(expected_contact.fetch(:hackney_homes_id))
       end
     end
 
@@ -331,6 +331,20 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/02')
         expect(contacts.size).to eq(2)
         contacts.each { |c| expect(c).to be_instance_of(Hackney::Income::Domain::Contact) }
+      end
+    end
+
+    context 'in a staging environment' do
+      before do
+        stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01/contacts')
+          .to_return(body: stub_single_response.to_json)
+
+        allow(Rails.env).to receive(:staging?).and_return(true)
+      end
+
+      it 'should not return any contact data at all' do
+        contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/01')
+        expect(contacts).to eq([])
       end
     end
   end
@@ -349,28 +363,28 @@ end
 
 def generate_contact
   {
-    contactId: Faker::Lorem.characters(8),
-    emailAddress: Faker::Internet.email,
+    contact_id: Faker::Lorem.characters(8),
+    email_address: Faker::Internet.email,
     uprn: 0,
-    addressLine1: Faker::Address.building_number,
-    addressLine2: Faker::Address.street_address,
-    addressLine3: Faker::Address.city,
-    firstName: Faker::Name.first_name,
-    lastName: Faker::Name.last_name,
-    fullName: Faker::Name.name,
+    address_line1: Faker::Address.building_number,
+    address_line2: Faker::Address.street_address,
+    address_line3: Faker::Address.city,
+    first_name: Faker::Name.first_name,
+    last_name: Faker::Name.last_name,
+    full_name: Faker::Name.name,
     larn: Faker::Lorem.characters(8),
     telephone1: Faker::PhoneNumber.phone_number,
     telephone2: Faker::PhoneNumber.cell_phone,
     telephone3: nil,
-    cautionaryAlert: false,
-    propertyCautionaryAlert: false,
-    houseRef: Faker::Lorem.characters(8),
+    cautionary_alert: false,
+    propertyCautionary_alert: false,
+    house_ref: Faker::Lorem.characters(8),
     title: Faker::Name.prefix,
-    fullAddressDisplay: Faker::Address.full_address,
-    fullAddressSearch: Faker::Address.full_address,
-    postCode: Faker::Address.postcode,
-    dateOfBirth: Faker::Date.birthday(18, 65),
-    hackneyHomesId: Faker::Lorem.characters(8)
+    full_address_display: Faker::Address.full_address,
+    full_address_search: Faker::Address.full_address,
+    post_code: Faker::Address.postcode,
+    date_of_birth: Faker::Date.birthday(18, 65),
+    hackney_homes_id: Faker::Lorem.characters(8)
   }
 end
 

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -35,6 +35,32 @@ describe Hackney::Income::ViewTenancy do
         expect(subject.primary_contact_postcode).to eq('E1 123')
       end
 
+      it 'should contain detailed contact details from the CRM' do
+        expect(subject.contacts.count).to be(1)
+        expect(subject.contacts[0].fetch(:contact_id)).to eq('123456')
+        expect(subject.contacts[0].fetch(:email_address)).to eq('test.email@email.server.com')
+        expect(subject.contacts[0].fetch(:uprn)).to eq('0')
+        expect(subject.contacts[0].fetch(:address_line_1)).to eq('123')
+        expect(subject.contacts[0].fetch(:address_line_2)).to eq('Test Road')
+        expect(subject.contacts[0].fetch(:address_line_3)).to eq('Delivery City')
+        expect(subject.contacts[0].fetch(:first_name)).to eq('Rich')
+        expect(subject.contacts[0].fetch(:last_name)).to eq('Foster')
+        expect(subject.contacts[0].fetch(:full_name)).to eq('Richard Foster')
+        expect(subject.contacts[0].fetch(:larn)).to eq('0')
+        expect(subject.contacts[0].fetch(:telephone_1)).to eq('0101 1234')
+        expect(subject.contacts[0].fetch(:telephone_2)).to eq('077777777')
+        expect(subject.contacts[0].fetch(:telephone_3)).to eq(nil)
+        expect(subject.contacts[0].fetch(:cautionary_alert)).to eq(false)
+        expect(subject.contacts[0].fetch(:property_cautionary_alert)).to eq(false)
+        expect(subject.contacts[0].fetch(:house_ref)).to eq('98765')
+        expect(subject.contacts[0].fetch(:title)).to eq('Mr.')
+        expect(subject.contacts[0].fetch(:full_address_display)).to eq('123 Test Road, Delivery City')
+        expect(subject.contacts[0].fetch(:full_address_search)).to eq('Search')
+        expect(subject.contacts[0].fetch(:post_code)).to eq('E0 123')
+        expect(subject.contacts[0].fetch(:date_of_birth)).to eq('12th March, 1976')
+        expect(subject.contacts[0].fetch(:hackney_homes_id)).to eq('1209')
+      end
+
       it 'should contain transactions related to the tenancy' do
         expect(subject.transactions).to include(
           id: '123-456-789',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7647632/46088690-322b4680-c1ad-11e8-82f5-77e98f8f9267.png)
Future PR - When sending SMS/email select from available contacts listed on the tenancy
Future PR - Improve styling where more than one contact is present (it'll add more lists below the first, currently)

I decided to simple skip the step and return as if there are no contact details in the staging environment, since no communications are sent to real numbers via staging, and names and addresses are already obfuscated for the tenancy itself.