### PR TITLE
Also add a display date for actions via the all actions endpoint

### DIFF
--- a/lib/hackney/income/view_actions.rb
+++ b/lib/hackney/income/view_actions.rb
@@ -13,6 +13,7 @@ module Hackney
             code: a.code,
             type: a.type,
             date: a.date,
+            display_date: a.display_date,
             comment: a.comment,
             universal_housing_username: a.universal_housing_username
           }

--- a/spec/lib/hackney/income/view_actions_spec.rb
+++ b/spec/lib/hackney/income/view_actions_spec.rb
@@ -8,7 +8,7 @@ describe Hackney::Income::ViewActions do
         t.balance = Faker::Number.decimal(2)
         t.code = Faker::Lorem.characters(3)
         t.type = Faker::Lorem.characters(3)
-        t.date = Faker::Date.forward(100)
+        t.date = Faker::Date.forward(100).to_s
         t.comment = Faker::Lorem.words(10)
         t.universal_housing_username = Faker::Lorem.words(2)
       end,
@@ -16,7 +16,7 @@ describe Hackney::Income::ViewActions do
         t.balance = Faker::Number.decimal(2)
         t.code = Faker::Lorem.characters(3)
         t.type = Faker::Lorem.characters(3)
-        t.date = Faker::Date.forward(100)
+        t.date = Faker::Date.forward(100).to_s
         t.comment = Faker::Lorem.words(10)
         t.universal_housing_username = Faker::Lorem.words(2)
       end
@@ -29,6 +29,7 @@ describe Hackney::Income::ViewActions do
         code: actions[0].code,
         type: actions[0].type,
         date: actions[0].date,
+        display_date: actions[0].display_date,
         comment: actions[0].comment,
         universal_housing_username: actions[0].universal_housing_username
       },
@@ -37,6 +38,7 @@ describe Hackney::Income::ViewActions do
         code: actions[1].code,
         type: actions[1].type,
         date: actions[1].date,
+        display_date: actions[1].display_date,
         comment: actions[1].comment,
         universal_housing_username: actions[1].universal_housing_username
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7647632/46089576-22146680-c1af-11e8-9c1a-99de8283d4ba.png)

This was resolved for tenancies#show, but not for actions#index, as the actions come from a different endpoint via a different use case, and not resolving this in the previous PR was an oversight that became obvious when testing on Staging.