### PR TITLE
Transaction summary

### DIFF
--- a/app/assets/javascripts/components/BalanceGraph.js
+++ b/app/assets/javascripts/components/BalanceGraph.js
@@ -37,13 +37,13 @@ function createChartOptions (transactions) {
       intersect: false,
       mode: 'nearest',
       callbacks: {
-        title: function (tooltips) {
+        beforeTitle: function (tooltips) {
           var transaction = transactions[tooltips[0].index]
           return transaction.description
         },
-        beforeTitle: function (tooltips) {
+        title: function (tooltips) {
           var transaction = transactions[tooltips[0].index]
-          return transaction.date
+          return new Date(transaction.date).toLocaleString('en-GB')
         },
         label: function (tooltip) {
           var transaction = transactions[tooltip.index]

--- a/app/assets/stylesheets/components/transactions_table.scss
+++ b/app/assets/stylesheets/components/transactions_table.scss
@@ -1,0 +1,13 @@
+.transactions-table {
+  &__group{
+    &--summary {
+    }
+  }
+
+  &__group{
+    &--breakdown {
+      display: none;
+      background-color: #e2e2e2;
+    }
+  }
+}

--- a/app/assets/stylesheets/components/transactions_table.scss
+++ b/app/assets/stylesheets/components/transactions_table.scss
@@ -1,13 +1,11 @@
 .transactions-table {
-  &__group{
-    &--summary {
-    }
-  }
-
-  &__group{
+  &__group {
     &--breakdown {
-      display: none;
       background-color: #e2e2e2;
+    }
+
+    &--hidden {
+      display: none;
     }
   }
 }

--- a/app/assets/stylesheets/components/transactions_table.scss
+++ b/app/assets/stylesheets/components/transactions_table.scss
@@ -8,4 +8,6 @@
       display: none;
     }
   }
+  td:first-child { padding-left: 5px; }
+  td:last-child { padding-right: 5px; }
 }

--- a/app/assets/stylesheets/components/transactions_table.scss
+++ b/app/assets/stylesheets/components/transactions_table.scss
@@ -9,9 +9,22 @@
     }
   }
 
-  span {
+  &__expand-link {
     font-size: 0.65em;
     color: $hackney-green;
+
+    &--hidden {
+      display: none;
+    }
+  }
+
+  &__collapse-link {
+    font-size: 0.65em;
+    color: $red;
+
+    &--hidden {
+      display: none;
+    }
   }
 
   td:first-child { padding-left: 5px; }

--- a/app/assets/stylesheets/components/transactions_table.scss
+++ b/app/assets/stylesheets/components/transactions_table.scss
@@ -8,6 +8,12 @@
       display: none;
     }
   }
+
+  span {
+    font-size: 0.65em;
+    color: $hackney-green;
+  }
+
   td:first-child { padding-left: 5px; }
   td:last-child { padding-right: 5px; }
 }

--- a/app/assets/stylesheets/hackney.scss
+++ b/app/assets/stylesheets/hackney.scss
@@ -38,6 +38,7 @@
 @import 'components/header';
 @import 'components/flash';
 @import 'components/tenancy_list';
+@import 'components/transactions_table';
 @import 'components/agreement';
 @import 'components/pagination';
 @import 'components/link';
@@ -61,9 +62,4 @@ body {
   &__right {
     text-align: right;
   }
-}
-
-.tenancy_payments_list {
-  display: none;
-  background-color: #e2e2e2;
 }

--- a/app/assets/stylesheets/hackney.scss
+++ b/app/assets/stylesheets/hackney.scss
@@ -62,3 +62,8 @@ body {
     text-align: right;
   }
 }
+
+.tenancy_payments_list {
+  display: none;
+  background-color: #e2e2e2;
+}

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -2,7 +2,7 @@ module TransactionsHelper
   def from_last_four_weeks(transactions)
     transactions.select do |transaction|
       last_four_weeks = Date.today.monday - 4.weeks
-      transaction.fetch(:timestamp) >= last_four_weeks
+      transaction.fetch(:date) >= last_four_weeks
     end
   end
 end

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -5,4 +5,11 @@ module TransactionsHelper
       transaction.fetch(:date) >= last_four_weeks
     end
   end
+
+  def from_last_year(transactions)
+    transactions.select do |transaction|
+      last_year = Date.today.monday - 1.year
+      transaction.fetch(:date) >= last_year
+    end
+  end
 end

--- a/app/helpers/transactions_helper.rb
+++ b/app/helpers/transactions_helper.rb
@@ -12,4 +12,8 @@ module TransactionsHelper
       transaction.fetch(:date) >= last_year
     end
   end
+
+  def display_amount(charge)
+    charge.positive? ? format('£%.2f', charge) : format('-£%.2f', charge.abs)
+  end
 end

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -1,4 +1,4 @@
-<table>
+<table class="transactions-table">
   <thead>
     <th>Date</th>
     <th>Transaction</th>
@@ -7,7 +7,7 @@
     <th class="numeric">Balance</th>
   </thead>
   <% transactions.each do |transaction_summary| %>
-  <tbody class="tenancy_payments_summary">
+  <tbody class="transactions-table__group--summary">
     <tr>
       <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
       <td><%= transaction_summary.fetch(:description) %></td>
@@ -20,7 +20,7 @@
       </td>
     </tr>
   </tbody>
-    <tbody class="tenancy_payments_list">
+    <tbody class="transactions-table__group--breakdown">
       <% transaction_summary[:transactions].each do |transaction| %>
       <tr>
         <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
@@ -38,7 +38,7 @@
 </table>
 
 <script>
-$('.tenancy_payments_summary').click(function () {
+$('.transactions-table__group--summary').click(function () {
   $(this).closest('tbody').next().toggle()
 })
 </script>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -1,10 +1,8 @@
 <table>
   <thead>
     <th>Date</th>
-    <th>Total Value</th>
     <th>Transaction</th>
     <th>Code</th>
-    <th>Date</th>
     <th class="numeric">Value</th>
     <th class="numeric">Balance</th>
   </thead>
@@ -12,28 +10,22 @@
   <tbody class="tenancy_payments_summary">
     <tr>
       <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
-      <td>
+      <td><%= transaction_summary.fetch(:description) %></td>
+      <td></td>
+      <td class="numeric <%= transaction_summary.fetch(:total_charge) > 0 ? 'negative' : 'positive' %>">
         <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
       </td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td></td>
+      <td class="numeric">
+        £<%= '%.2f' % transaction_summary.fetch(:final_balance) %>
+      </td>
     </tr>
   </tbody>
     <tbody class="tenancy_payments_list">
       <% transaction_summary[:transactions].each do |transaction| %>
       <tr>
         <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
-        <td>
-          <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
-        </td>
         <td><%= transaction.fetch(:description) %></td>
         <td><%= transaction.fetch(:type) %></td>
-        <td title="<%= transaction.fetch(:timestamp) %>">
-          <%= transaction.fetch(:timestamp).to_formatted_s(:long_ordinal) %>
-        </td>
         <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">
           <%= transaction.fetch(:value) > 0 ? '£%.2f' % transaction.fetch(:value) : '-£%.2f' % transaction.fetch(:value).abs %>
         </td>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -13,7 +13,8 @@
       <td>
         <%= transaction_summary.fetch(:description) %>
         <% if transaction_summary.fetch(:transactions).count > 1 %>
-        <span><br/>+ click to expand</span
+        <span class="transactions-table__expand-link"><br/>+ click to expand</span>
+        <span class="transactions-table__collapse-link transactions-table__collapse-link--hidden"><br/>- click to collapse</span>
         <% end %>
       </td>
       <td></td>
@@ -45,5 +46,7 @@
 <script>
 $('.transactions-table__group--summary').click(function () {
   $(this).closest('tbody').next().toggleClass('transactions-table__group--hidden')
+  $(this).find('.transactions-table__expand-link').toggleClass('transactions-table__expand-link--hidden')
+  $(this).find('.transactions-table__collapse-link').toggleClass('transactions-table__collapse-link--hidden')
 })
 </script>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -1,59 +1,34 @@
-
-    <% transactions.each do |transaction_summary| %>
-    <table>
-      <thead>
-        <th>Date</th>
-        <th class="numeric">Total Value</th>
-      </thead>
-      <tbody>
-    <tr>
-      <td><%= transaction_summary.fetch(:date) %></td>
-      <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
-      <td>
-        <table>
-          <thead>
-            <th>Transaction</th>
-            <th>Code</th>
-            <th>Date</th>
-            <th class="numeric">Value</th>
-            <th class="numeric">Balance</th>
-          </thead>
-          <tbody>
-              <% transaction_summary[:transactions].each do |transaction| %>
-              <tr>
-                <td><%= transaction.fetch(:description) %></td>
-                <td><%= transaction.fetch(:type) %></td>
-                <td title="<%= transaction.fetch(:timestamp) %>">
-                  <%= transaction.fetch(:timestamp).strftime('%B %e %Y') %>
-                </td>
-                <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">
-                  <%= transaction.fetch(:value) > 0 ? '£%.2f' % transaction.fetch(:value) : '-£%.2f' % transaction.fetch(:value).abs %>
-                </td>
-                <td class="numeric">
-                  £<%= '%.2f' % transaction.fetch(:final_balance) %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
-
 <table>
   <thead>
+    <th>Date</th>
+    <th class="numeric">Total Value</th>
     <th>Transaction</th>
     <th>Code</th>
     <th>Date</th>
     <th class="numeric">Value</th>
     <th class="numeric">Balance</th>
   </thead>
-  <tbody>
-    <% transactions.each do |transaction_summary| %>
+  <% transactions.each do |transaction_summary| %>
+  <tbody class="tenancy_payments_summary">
+    <tr>
+      <td><%= transaction_summary.fetch(:date) %></td>
+      <td>
+        <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
+      </td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+      <td></td>
+    </tr>
+  </tbody>
+    <tbody class="tenancy_payments_list">
       <% transaction_summary[:transactions].each do |transaction| %>
       <tr>
+        <td><%= transaction_summary.fetch(:date) %></td>
+        <td>
+          <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
+        </td>
         <td><%= transaction.fetch(:description) %></td>
         <td><%= transaction.fetch(:type) %></td>
         <td title="<%= transaction.fetch(:timestamp) %>">
@@ -67,6 +42,16 @@
         </td>
       </tr>
       <% end %>
-    <% end %>
-  </tbody>
+  <% end %>
 </table>
+
+<script>
+$('.tenancy_payments_summary').click(function () {
+  $(this).toggle()
+  $(this).closest('tbody').next().toggle()
+})
+$('.tenancy_payments_list').click(function () {
+  $(this).toggle()
+  $(this).closest('tbody').next().toggle()
+})
+</script>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -1,7 +1,7 @@
 <table>
   <thead>
     <th>Date</th>
-    <th class="numeric">Total Value</th>
+    <th>Total Value</th>
     <th>Transaction</th>
     <th>Code</th>
     <th>Date</th>
@@ -11,7 +11,7 @@
   <% transactions.each do |transaction_summary| %>
   <tbody class="tenancy_payments_summary">
     <tr>
-      <td><%= transaction_summary.fetch(:date) %></td>
+      <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
       <td>
         <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
       </td>
@@ -25,14 +25,14 @@
     <tbody class="tenancy_payments_list">
       <% transaction_summary[:transactions].each do |transaction| %>
       <tr>
-        <td><%= transaction_summary.fetch(:date) %></td>
+        <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
         <td>
           <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
         </td>
         <td><%= transaction.fetch(:description) %></td>
         <td><%= transaction.fetch(:type) %></td>
         <td title="<%= transaction.fetch(:timestamp) %>">
-          <%= transaction.fetch(:timestamp).strftime('%B %e %Y') %>
+          <%= transaction.fetch(:timestamp).to_formatted_s(:long_ordinal) %>
         </td>
         <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">
           <%= transaction.fetch(:value) > 0 ? '£%.2f' % transaction.fetch(:value) : '-£%.2f' % transaction.fetch(:value).abs %>
@@ -47,11 +47,6 @@
 
 <script>
 $('.tenancy_payments_summary').click(function () {
-  $(this).toggle()
-  $(this).closest('tbody').next().toggle()
-})
-$('.tenancy_payments_list').click(function () {
-  $(this).toggle()
   $(this).closest('tbody').next().toggle()
 })
 </script>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -7,7 +7,7 @@
     <th class="numeric">Balance</th>
   </thead>
   <% transactions.each do |transaction_summary| %>
-  <tbody class="transactions-table__group--summary">
+  <tbody class=".transactions-table__group transactions-table__group--summary">
     <tr>
       <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
       <td><%= transaction_summary.fetch(:description) %></td>
@@ -20,7 +20,7 @@
       </td>
     </tr>
   </tbody>
-    <tbody class="transactions-table__group--breakdown">
+    <tbody class=".transactions-table__group transactions-table__group--breakdown transactions-table__group--hidden">
       <% transaction_summary[:transactions].each do |transaction| %>
       <tr>
         <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
@@ -39,6 +39,6 @@
 
 <script>
 $('.transactions-table__group--summary').click(function () {
-  $(this).closest('tbody').next().toggle()
+  $(this).closest('tbody').next().toggleClass('transactions-table__group--hidden')
 })
 </script>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -7,10 +7,15 @@
     <th class="numeric">Balance</th>
   </thead>
   <% transactions.each do |transaction_summary| %>
-  <tbody class=".transactions-table__group transactions-table__group--summary">
+  <tbody class="transactions-table__group transactions-table__group--summary">
     <tr>
       <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
-      <td><%= transaction_summary.fetch(:description) %></td>
+      <td>
+        <%= transaction_summary.fetch(:description) %>
+        <% if transaction_summary.fetch(:transactions).count > 1 %>
+        <span><br/>+ click to expand</span
+        <% end %>
+      </td>
       <td></td>
       <td class="numeric <%= transaction_summary.fetch(:total_charge) > 0 ? 'negative' : 'positive' %>">
         <%= display_amount(transaction_summary.fetch(:total_charge)) %>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -23,7 +23,7 @@
     <tbody class=".transactions-table__group transactions-table__group--breakdown transactions-table__group--hidden">
       <% transaction_summary[:transactions].each do |transaction| %>
       <tr>
-        <td><%= transaction_summary.fetch(:date).to_formatted_s(:long_ordinal) %></td>
+        <td></td>
         <td><%= transaction.fetch(:description) %></td>
         <td><%= transaction.fetch(:type) %></td>
         <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -1,3 +1,47 @@
+
+    <% transactions.each do |transaction_summary| %>
+    <table>
+      <thead>
+        <th>Date</th>
+        <th class="numeric">Total Value</th>
+      </thead>
+      <tbody>
+    <tr>
+      <td><%= transaction_summary.fetch(:date) %></td>
+      <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
+      <td>
+        <table>
+          <thead>
+            <th>Transaction</th>
+            <th>Code</th>
+            <th>Date</th>
+            <th class="numeric">Value</th>
+            <th class="numeric">Balance</th>
+          </thead>
+          <tbody>
+              <% transaction_summary[:transactions].each do |transaction| %>
+              <tr>
+                <td><%= transaction.fetch(:description) %></td>
+                <td><%= transaction.fetch(:type) %></td>
+                <td title="<%= transaction.fetch(:timestamp) %>">
+                  <%= transaction.fetch(:timestamp).strftime('%B %e %Y') %>
+                </td>
+                <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">
+                  <%= transaction.fetch(:value) > 0 ? '£%.2f' % transaction.fetch(:value) : '-£%.2f' % transaction.fetch(:value).abs %>
+                </td>
+                <td class="numeric">
+                  £<%= '%.2f' % transaction.fetch(:final_balance) %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+
 <table>
   <thead>
     <th>Transaction</th>
@@ -7,20 +51,22 @@
     <th class="numeric">Balance</th>
   </thead>
   <tbody>
-    <% transactions.each do |transaction| %>
-    <tr>
-      <td><%= transaction.fetch(:description) %></td>
-      <td><%= transaction.fetch(:type) %></td>
-      <td title="<%= transaction.fetch(:timestamp) %>">
-        <%= transaction.fetch(:timestamp).strftime('%B %e %Y') %>
-      </td>
-      <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">
-        <%= transaction.fetch(:value) > 0 ? '£%.2f' % transaction.fetch(:value) : '-£%.2f' % transaction.fetch(:value).abs %>
-      </td>
-      <td class="numeric">
-        £<%= '%.2f' % transaction.fetch(:final_balance) %>
-      </td>
-    </tr>
+    <% transactions.each do |transaction_summary| %>
+      <% transaction_summary[:transactions].each do |transaction| %>
+      <tr>
+        <td><%= transaction.fetch(:description) %></td>
+        <td><%= transaction.fetch(:type) %></td>
+        <td title="<%= transaction.fetch(:timestamp) %>">
+          <%= transaction.fetch(:timestamp).strftime('%B %e %Y') %>
+        </td>
+        <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">
+          <%= transaction.fetch(:value) > 0 ? '£%.2f' % transaction.fetch(:value) : '-£%.2f' % transaction.fetch(:value).abs %>
+        </td>
+        <td class="numeric">
+          £<%= '%.2f' % transaction.fetch(:final_balance) %>
+        </td>
+      </tr>
+      <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/common/_tenancy_transactions_list.html.erb
+++ b/app/views/common/_tenancy_transactions_list.html.erb
@@ -13,7 +13,7 @@
       <td><%= transaction_summary.fetch(:description) %></td>
       <td></td>
       <td class="numeric <%= transaction_summary.fetch(:total_charge) > 0 ? 'negative' : 'positive' %>">
-        <%= transaction_summary.fetch(:total_charge) > 0 ? '£%.2f' % transaction_summary.fetch(:total_charge) : '-£%.2f' % transaction_summary.fetch(:total_charge).abs %>
+        <%= display_amount(transaction_summary.fetch(:total_charge)) %>
       </td>
       <td class="numeric">
         £<%= '%.2f' % transaction_summary.fetch(:final_balance) %>
@@ -27,7 +27,7 @@
         <td><%= transaction.fetch(:description) %></td>
         <td><%= transaction.fetch(:type) %></td>
         <td class="numeric <%= transaction.fetch(:value) > 0 ? 'negative' : 'positive' %>">
-          <%= transaction.fetch(:value) > 0 ? '£%.2f' % transaction.fetch(:value) : '-£%.2f' % transaction.fetch(:value).abs %>
+          <%= display_amount(transaction.fetch(:value)) %>
         </td>
         <td class="numeric">
           £<%= '%.2f' % transaction.fetch(:final_balance) %>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -186,12 +186,12 @@
 <script type="text/javascript">
   $(document).on('turbolinks:load', function () {
     var ctx = document.getElementById('balance_chart')
-    var transactions = <%= @tenancy.transactions.map do |t|
+    var transactions = <%= from_last_year(@tenancy.transactions).map do |t|
       {
-        #description: //t.fetch(:description),
-        date: t.fetch(:date).to_date.to_s,
+        description: 'Summary for -',
+        date: t.fetch(:date),
         displayValue: t.fetch(:total_charge) >= 0 ? '£%.2f' % t.fetch(:total_charge) : '-£%.2f' % t.fetch(:total_charge).abs,
-        #finalBalance: //t.fetch(:final_balance).round(2)
+        finalBalance: t.fetch(:transactions).first.fetch(:final_balance)
       }
     end.to_json.html_safe %>
 

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -25,14 +25,6 @@
         <% end %>
       </span>
     </div>
-    <h2>Rent Charges</h2>
-    <div>
-        <ul class="list">
-          <li>Rent Charge: <%= @tenancy.rent %></li>
-          <li>Service Charge: <%= @tenancy.service %></li>
-          <li>Other Charge: <%= @tenancy.other_charge %></li>
-        </ul>
-    </div>
   </div>
   <div class="column-two-thirds">
     <h2>Personal details</h2>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -190,7 +190,7 @@
       {
         description: 'Summary for -',
         date: t.fetch(:date),
-        displayValue: t.fetch(:total_charge) >= 0 ? '£%.2f' % t.fetch(:total_charge) : '-£%.2f' % t.fetch(:total_charge).abs,
+        displayValue: display_amount(t.fetch(:total_charge)),
         finalBalance: t.fetch(:transactions).first.fetch(:final_balance)
       }
     end.to_json.html_safe %>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -188,10 +188,10 @@
     var ctx = document.getElementById('balance_chart')
     var transactions = <%= @tenancy.transactions.map do |t|
       {
-        description: t.fetch(:description),
-        date: t.fetch(:timestamp).to_date.to_s,
-        displayValue: t.fetch(:value) >= 0 ? '£%.2f' % t.fetch(:value) : '-£%.2f' % t.fetch(:value).abs,
-        finalBalance: t.fetch(:final_balance).round(2)
+        #description: //t.fetch(:description),
+        date: t.fetch(:date).to_date.to_s,
+        displayValue: t.fetch(:total_charge) >= 0 ? '£%.2f' % t.fetch(:total_charge) : '-£%.2f' % t.fetch(:total_charge).abs,
+        #finalBalance: //t.fetch(:final_balance).round(2)
       }
     end.to_json.html_safe %>
 

--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -111,14 +111,38 @@ module Hackney
         outgoing = transactions.partition { |v| v[:value].positive? }.first
 
         outgoing.group_by { |d| d[:timestamp] }.each do |date, t|
-          summarised_transactions << { date: date, total_charge: t.sum { |c| c.fetch(:value) }, transactions: t }
+          summarised_transactions <<
+            {
+              description: outgoing_description(t),
+              date: date,
+              total_charge: t.sum { |c| c.fetch(:value) },
+              final_balance: t.first.fetch(:final_balance),
+              transactions: t
+            }
         end
 
         incoming.group_by { |d| d[:timestamp] }.each do |date, t|
-          summarised_transactions << { date: date, total_charge: t.sum { |c| c.fetch(:value) }, transactions: t }
+          summarised_transactions <<
+            {
+              description: incoming_description(t),
+              date: date,
+              total_charge: t.sum { |c| c.fetch(:value) },
+              final_balance: t.first.fetch(:final_balance),
+              transactions: t
+            }
         end
 
         summarised_transactions.sort_by { |summary| summary[:date] }.reverse
+      end
+
+      def incoming_description(transactions)
+        return transactions.first.fetch(:description) if transactions.size == 1
+        'Incoming payments - click for breakdown'
+      end
+
+      def outgoing_description(transactions)
+        return transactions.first.fetch(:description) if transactions.size == 1
+        'Outgoing charges - click for breakdown'
       end
     end
   end

--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -118,7 +118,7 @@ module Hackney
           summarised_transactions << { date: date, total_charge: t.sum { |c| c.fetch(:value) }, transactions: t }
         end
 
-        summarised_transactions.sort_by { |summary| summary[:date] }
+        summarised_transactions.sort_by { |summary| summary[:date] }.reverse
       end
     end
   end

--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -111,11 +111,11 @@ module Hackney
         outgoing = transactions.partition { |v| v[:value].positive? }.first
 
         outgoing.group_by { |d| d[:timestamp] }.each do |date, t|
-          summarised_transactions << { date: date, total_charge: charges(t), transactions: t }
+          summarised_transactions << { date: date.to_date.to_formatted_s(:long_ordinal), total_charge: charges(t), transactions: t }
         end
 
         incoming.group_by { |d| d[:timestamp] }.each do |date, t|
-          summarised_transactions << { date: date, total_charge: charges(t), transactions: t }
+          summarised_transactions << { date: date.to_date.to_formatted_s(:long_ordinal), total_charge: charges(t), transactions: t }
         end
 
         summarised_transactions.sort_by { |summary| summary[:date] }.reverse

--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -137,12 +137,12 @@ module Hackney
 
       def incoming_description(transactions)
         return transactions.first.fetch(:description) if transactions.size == 1
-        'Incoming payments - click for breakdown'
+        'Incoming payments'
       end
 
       def outgoing_description(transactions)
         return transactions.first.fetch(:description) if transactions.size == 1
-        'Outgoing charges - click for breakdown'
+        'Outgoing charges'
       end
     end
   end

--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -111,22 +111,14 @@ module Hackney
         outgoing = transactions.partition { |v| v[:value].positive? }.first
 
         outgoing.group_by { |d| d[:timestamp] }.each do |date, t|
-          summarised_transactions << { date: date.to_date.to_formatted_s(:long_ordinal), total_charge: charges(t), transactions: t }
+          summarised_transactions << { date: date, total_charge: t.sum { |c| c.fetch(:value) }, transactions: t }
         end
 
         incoming.group_by { |d| d[:timestamp] }.each do |date, t|
-          summarised_transactions << { date: date.to_date.to_formatted_s(:long_ordinal), total_charge: charges(t), transactions: t }
+          summarised_transactions << { date: date, total_charge: t.sum { |c| c.fetch(:value) }, transactions: t }
         end
 
-        summarised_transactions.sort_by { |summary| summary[:date] }.reverse
-      end
-
-      def charges(transactions)
-        total = 0
-        transactions.each do |t|
-          total += t[:value]
-        end
-        total
+        summarised_transactions.sort_by { |summary| summary[:date] }
       end
     end
   end

--- a/spec/helpers/transactions_helper_spec.rb
+++ b/spec/helpers/transactions_helper_spec.rb
@@ -12,10 +12,10 @@ describe TransactionsHelper do
     context 'when given a list of transactions in the last week' do
       let(:transactions) do
         [
-          { timestamp: Date.today.midnight },
-          { timestamp: Date.today.midnight - 1.day },
-          { timestamp: Date.today.midnight - 3.days },
-          { timestamp: Date.today.midnight - 7.days }
+          { date: Date.today.midnight },
+          { date: Date.today.midnight - 1.day },
+          { date: Date.today.midnight - 3.days },
+          { date: Date.today.midnight - 7.days }
         ]
       end
 
@@ -25,17 +25,17 @@ describe TransactionsHelper do
     context 'when given a list of transactions from the last few months' do
       let(:valid_transactions) do
         [
-          { timestamp: Date.today - 1.week },
-          { timestamp: Date.today - 2.weeks },
-          { timestamp: Date.today - 4.weeks },
-          { timestamp: Date.today.monday - 4.weeks },
-          { timestamp: Date.today - 3.week }
+          { date: Date.today - 1.week },
+          { date: Date.today - 2.weeks },
+          { date: Date.today - 4.weeks },
+          { date: Date.today.monday - 4.weeks },
+          { date: Date.today - 3.week }
         ]
       end
 
       let(:invalid_transactions) do
         [
-          { timestamp: Date.today - 5.week }
+          { date: Date.today - 5.week }
         ]
       end
 

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -63,7 +63,7 @@ describe Hackney::Income::ViewTenancy do
 
       it 'should contain transactions related to the tenancy' do
         expect(subject.transactions).to include(
-          date: '2018-01-01 00:00:00.000000000 +0000',
+          date: 'January 1st, 2018',
           total_charge: -50.0,
           transactions: [{
             id: '123-456-789',
@@ -80,9 +80,9 @@ describe Hackney::Income::ViewTenancy do
       it 'should order transactions by descending time' do
         timestamps = subject.transactions.map { |t| t.fetch(:date) }
         expect(timestamps).to eq([
-          Time.new(2018, 1, 1, 0, 0, 0),
-          Time.new(2017, 1, 1, 0, 0, 0),
-          Time.new(2015, 1, 1, 0, 0, 0)
+          'January 1st, 2018',
+          'January 1st, 2017',
+          'January 1st, 2015'
         ])
       end
 

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -65,6 +65,8 @@ describe Hackney::Income::ViewTenancy do
         expect(subject.transactions).to include(
           date: 'January 1st, 2018',
           total_charge: -50.0,
+          description: 'Rent Payment',
+          final_balance: 1200.99,
           transactions: [{
             id: '123-456-789',
             timestamp: Time.new(2018, 1, 1, 0, 0, 0),

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -79,11 +79,13 @@ describe Hackney::Income::ViewTenancy do
 
       it 'should order transactions by descending time' do
         timestamps = subject.transactions.map { |t| t.fetch(:date) }
-        expect(timestamps).to eq([
-          'January 1st, 2018',
-          'January 1st, 2017',
-          'January 1st, 2015'
-        ])
+        expect(timestamps).to eq(
+          [
+            '2018-01-01 00:00:00.000000000 +0000',
+            '2017-01-01 00:00:00.000000000 +0000',
+            '2015-01-01 00:00:00.000000000 +0000'
+          ]
+        )
       end
 
       it 'should include cumulative balance for each transaction' do

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -63,18 +63,22 @@ describe Hackney::Income::ViewTenancy do
 
       it 'should contain transactions related to the tenancy' do
         expect(subject.transactions).to include(
-          id: '123-456-789',
-          timestamp: Time.new(2018, 1, 1, 0, 0, 0),
-          tenancy_ref: '3456789',
-          description: 'Rent Payment',
-          value: -50.00,
-          type: 'RPY',
-          final_balance: 1200.99
+          date: '2018-01-01 00:00:00.000000000 +0000',
+          total_charge: -50.0,
+          transactions: [{
+            id: '123-456-789',
+            timestamp: Time.new(2018, 1, 1, 0, 0, 0),
+            tenancy_ref: '3456789',
+            description: 'Rent Payment',
+            value: -50.00,
+            type: 'RPY',
+            final_balance: 1200.99
+          }]
         )
       end
 
       it 'should order transactions by descending time' do
-        timestamps = subject.transactions.map { |t| t.fetch(:timestamp) }
+        timestamps = subject.transactions.map { |t| t.fetch(:date) }
         expect(timestamps).to eq([
           Time.new(2018, 1, 1, 0, 0, 0),
           Time.new(2017, 1, 1, 0, 0, 0),
@@ -83,7 +87,7 @@ describe Hackney::Income::ViewTenancy do
       end
 
       it 'should include cumulative balance for each transaction' do
-        values = subject.transactions.map { |t| t.slice(:value, :final_balance, :type) }
+        values = subject.transactions.map { |t| { value: t[:transactions][0][:value], final_balance: t[:transactions][0][:final_balance], type: t[:transactions][0][:type] } }
         expect(values).to eq([
           { value: -50.00, final_balance: 1200.99, type: 'RPY' },
           { value: 500.00, final_balance: 1250.99, type: 'RNT' },


### PR DESCRIPTION
![oct-01-2018 17-49-58](https://user-images.githubusercontent.com/7647632/46299828-84e87200-c5a2-11e8-84e2-6e11174f4a6a.gif)


![image](https://user-images.githubusercontent.com/7647632/46301954-10b0cd00-c5a8-11e8-92bd-5e9cf04e9d75.png)



*Why*
Users would like to see payments grouped by date, with a total, and the ability to click the row to see the breakdown of charges for that day, in order to condense the payment list (which can be 1000s of entries).

*What*
Currently, we get a list of transactions for an account that looks something like {type, amount debited/credited, date} and we get multiple small outgoings each day that _rent_ is debited.  Now this list is grouped by incoming/outgoing for a particular date, and the table shows a row for this summary with the total. Clicking the row expands it to show the individual transactions for that date. Clicking again will collapse back to just the summary row.