### PR TITLE
Initial removal of permission check - handling now done in azure AD

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,7 +39,8 @@ class SessionsController < ApplicationController
   private
 
   def user_has_ic_staff_permissions?
-    whitelist.include?(auth_hash.info.email)
+    # access permission is now handled by assignment to the Manage Arrears-Azure group on Azure AD
+    true
   end
 
   def whitelist

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -48,7 +48,8 @@ describe SessionsController do
       ENV.delete('IC_STAFF_GROUP')
     end
 
-    it 'should not allow login if the requested group token is not permitted' do
+    # FIXME: we need a test around azureAD refusing the callback
+    xit 'should not allow login if the requested group token is not permitted' do
       ENV['IC_STAFF_GROUP'] = ''
 
       get :create, params: { provider: 'azureactivedirectory' }


### PR DESCRIPTION
This is a very very basic removal - I still think there's more to do in terms of managing user permissions which is why I've gone for a tech debt approach. Please discuss!