### PR TITLE
Show only unpaused tenancies in worktray

### DIFF
--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -11,12 +11,13 @@ module Hackney
         @api_key = api_key
       end
 
-      def get_tenancies(user_id:, page_number:, number_per_page:)
+      def get_tenancies(user_id:, page_number:, number_per_page:, is_paused: nil)
         uri = URI("#{@api_host}/my-cases")
         uri.query = URI.encode_www_form(
           'user_id' => user_id,
           'page_number' => page_number,
-          'number_per_page' => number_per_page
+          'number_per_page' => number_per_page,
+          'is_paused' => is_paused
         )
 
         req = Net::HTTP::Get.new(uri)

--- a/lib/hackney/income/list_user_assigned_cases.rb
+++ b/lib/hackney/income/list_user_assigned_cases.rb
@@ -11,7 +11,8 @@ module Hackney
         get_tenancies_response = @tenancy_gateway.get_tenancies(
           user_id: user_id,
           page_number: page_number,
-          number_per_page: count_per_page
+          number_per_page: count_per_page,
+          is_paused: false
         )
 
         Response.new(get_tenancies_response.tenancies, page_number, get_tenancies_response.number_of_pages)

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -20,7 +20,7 @@ module Hackney
               @tenancies = default_tenancies
             end
 
-            def get_tenancies(user_id:, page_number:, number_per_page:)
+            def get_tenancies(user_id:, page_number:, number_per_page:, is_paused: nil)
               cases = @tenancies
                 .select { |t| t.fetch(:assigned_user_id) == user_id }
                 .map(&method(:create_tenancy_list_item))

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -7,12 +7,14 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     let(:user_id) { Faker::Number.number(2).to_i }
     let(:page_number) { Faker::Number.number(2).to_i }
     let(:number_per_page) { Faker::Number.number(2).to_i }
+    let(:is_paused) { false }
 
     subject do
       tenancy_gateway.get_tenancies(
         user_id: user_id,
         page_number: page_number,
-        number_per_page: number_per_page
+        number_per_page: number_per_page,
+        is_paused: is_paused
       )
     end
 
@@ -36,7 +38,8 @@ describe Hackney::Income::LessDangerousTenancyGateway do
         query: {
           'user_id' => user_id,
           'page_number' => page_number,
-          'number_per_page' => number_per_page
+          'number_per_page' => number_per_page,
+          'is_paused' => is_paused
         }
       )
 

--- a/spec/lib/hackney/income/list_user_assigned_cases_spec.rb
+++ b/spec/lib/hackney/income/list_user_assigned_cases_spec.rb
@@ -12,7 +12,7 @@ describe Hackney::Income::ListUserAssignedCases do
   subject { list_cases.execute(user_id: user_id, page_number: page_number, count_per_page: number_per_page) }
 
   it 'should query the tenancy gateway for cases for the given user, on that page' do
-    expected_args = { user_id: user_id, page_number: page_number, number_per_page: number_per_page }
+    expected_args = { user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: false }
     expect(tenancy_gateway).to receive(:get_tenancies).with(expected_args).and_call_original
 
     subject


### PR DESCRIPTION
This just adds a new param on the request for the work tray. The backend is doing all the work here. 