### PR TITLE
Add route for failed azure AD authentication, with a redirect and notice

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
 
   def failure
     flash[:notice] = 'Failed to authenticate your Azure Active Directory account'
-    return redirect_to login_path
+    redirect_to login_path
   end
 
   def create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,6 +4,11 @@ class SessionsController < ApplicationController
 
   def new; end
 
+  def failure
+    flash[:notice] = 'Failed to authenticate your Azure Active Directory account'
+    return redirect_to login_path
+  end
+
   def create
     if auth_hash.extra.raw_info.nil? || !user_has_ic_staff_permissions?
       flash[:notice] = 'You do not have the required access permission'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,5 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new', as: :login
   get '/logout', to: 'sessions#destroy', as: :logout
   match '/auth/:provider/callback', to: 'sessions#create', via: %i[get post]
+  match '/auth/:provider/failure', to: 'sessions#failure', via: %i[get post]
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -86,10 +86,6 @@ describe SessionsController do
       stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:azureactivedirectory] = :invalid_credentials
-
-      OmniAuth.config.on_failure = Proc.new { |env|
-        OmniAuth::FailureEndpoint.new(env).redirect_to_failure
-      } 
     end
 
     after do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -48,16 +48,6 @@ describe SessionsController do
       ENV.delete('IC_STAFF_GROUP')
     end
 
-    # FIXME: we need a test around azureAD refusing the callback
-    xit 'should not allow login if the requested group token is not permitted' do
-      ENV['IC_STAFF_GROUP'] = ''
-
-      get :create, params: { provider: 'azureactivedirectory' }
-
-      expect(response).to redirect_to(login_path)
-      expect(flash[:notice]).to be_present
-    end
-
     it 'should pass the correct data from the provider to the use case' do
       expect_any_instance_of(Hackney::Income::FindOrCreateUser).to receive(:execute).with(
         provider_uid: provider_uid,
@@ -88,6 +78,29 @@ describe SessionsController do
         'email' => info_hash.fetch(:email),
         'groups_token' => true
       )
+    end
+  end
+
+  context 'when the user fails to authenticate' do
+    before do
+      stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.mock_auth[:azureactivedirectory] = :invalid_credentials
+
+      OmniAuth.config.on_failure = Proc.new { |env|
+        OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+      } 
+    end
+
+    after do
+      OmniAuth.config.test_mode = false
+      OmniAuth.config.mock_auth.delete(:azureactivedirectory)
+    end
+
+    it 'should not allow login' do
+      get :failure, params: { provider: 'azureactivedirectory' }
+      expect(response).to redirect_to(login_path)
+      expect(flash[:notice]).to be_present
     end
   end
 end


### PR DESCRIPTION
This should now redirect the user and show a message rather than failing.