### PR TITLE
Rescue omniauth errors, keep failure route

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,7 @@
 OmniAuth.config.logger = Rails.logger
-
+OmniAuth.config.on_failure = proc { |env|
+  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
+}
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :azure_activedirectory, ENV['AAD_CLIENT_ID'], ENV['AAD_TENANT']
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,15 @@
 OmniAuth.config.logger = Rails.logger
-OmniAuth.config.on_failure = proc { |env|
-  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
-}
+
+module OmniAuthWithExceptionHandling
+  def callback_phase
+    super
+  rescue OmniAuth::Strategies::AzureActiveDirectory::OAuthError
+    redirect '/auth/failure'
+  end
+end
+
+OmniAuth::Strategies::AzureActiveDirectory.prepend OmniAuthWithExceptionHandling
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :azure_activedirectory, ENV['AAD_CLIENT_ID'], ENV['AAD_TENANT']
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,5 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new', as: :login
   get '/logout', to: 'sessions#destroy', as: :logout
   match '/auth/:provider/callback', to: 'sessions#create', via: %i[get post]
-  match '/auth/:provider/failure', to: 'sessions#failure', via: %i[get post]
+  match '/auth/failure', to: 'sessions#failure', via: %i[get post]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,5 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy', as: :logout
   match '/auth/:provider/callback', to: 'sessions#create', via: %i[get post]
   match '/auth/failure', to: 'sessions#failure', via: %i[get post]
+  match '/auth/:provider/failure', to: 'sessions#failure', via: %i[get post]
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -86,15 +86,17 @@ describe SessionsController do
       stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
       OmniAuth.config.test_mode = true
       OmniAuth.config.mock_auth[:azureactivedirectory] = :invalid_credentials
+      request.env['omniauth.auth'] = OmniAuth.config.mock_auth[:azureactivedirectory]
     end
 
     after do
       OmniAuth.config.test_mode = false
       OmniAuth.config.mock_auth.delete(:azureactivedirectory)
+      request.env['omiauth.auth'] = nil
     end
 
     it 'should not allow login' do
-      get :failure, params: { provider: 'azureactivedirectory' }
+      get :create, params: { provider: 'azureactivedirectory' }
       expect(response).to redirect_to(login_path)
       expect(flash[:notice]).to be_present
     end


### PR DESCRIPTION
Testing this issue seems to be a problem - forcing omniauth to redirect to the failure route doesn't seem to work, nor does test_mode actually raise any exceptions. I can use `get :failure` instead of :create, but this feels again like the actual integration is untested.

Rescue on `OmniAuth::Strategies::AzureActiveDirectory::OAuthError` covers what I'm seeing in the logs for access denied errors, but I feel like the test is at this point redundant unless it is properly testing the actual behaviour. Right now, this test is meaningless? 

Suggest just removing it and ad-hoc testing this as the docs for omniauth seem to differ from the actual behaviour. Open to discussion.

EDIT: Now monkeypatched the gem to rescue and redirect to 'auth/failure' as expected. In future, if the gem updates to behave as documented, simply removing the patch should still work.