### PR TITLE
Guard against swallowing 500 errors from api

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,25 +1,25 @@
 module Exceptions
   class IncomeApiError < StandardError
-    attr_reader :responce
-    def initialize(responce)
+    attr_reader :response
+    def initialize(response)
       super
-      @responce = responce
+      @response = response
     end
 
     def to_s
-      "[Income API error: Received #{responce.code} responce] #{super}"
+      "[Income API error: Received #{response.code} response] #{super}"
     end
   end
 
   class TenancyApiError < StandardError
-    attr_reader :responce
-    def initialize(responce)
+    attr_reader :response
+    def initialize(response)
       super
-      @responce = responce
+      @response = response
     end
 
     def to_s
-      "[Tenancy API error: Received #{responce.code} responce] #{super}"
+      "[Tenancy API error: Received #{response.code} response] #{super}"
     end
   end
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,25 @@
+module Exceptions
+  class IncomeApiError < StandardError
+    attr_reader :responce
+    def initialize(responce)
+      super
+      @responce = responce
+    end
+
+    def to_s
+      "[Income API error: Received #{responce.code} responce] #{super}"
+    end
+  end
+
+  class TenancyApiError < StandardError
+    attr_reader :responce
+    def initialize(responce)
+      super
+      @responce = responce
+    end
+
+    def to_s
+      "[Tenancy API error: Received #{responce.code} responce] #{super}"
+    end
+  end
+end

--- a/lib/hackney/income/income_api_users_gateway.rb
+++ b/lib/hackney/income/income_api_users_gateway.rb
@@ -23,6 +23,11 @@ module Hackney
         req['X-Api-Key'] = @api_key
 
         res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+
+        unless res.is_a? Net::HTTPSuccess
+          raise Exceptions::IncomeApiError.new(res), "when trying to find_or_create_user with UID '#{provider_uid}'"
+        end
+
         body = JSON.parse(res.body)
 
         {

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -24,6 +24,11 @@ module Hackney
         req['X-Api-Key'] = @api_key
 
         res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+
+        unless res.is_a? Net::HTTPSuccess
+          raise Exceptions::IncomeApiError.new(res), "when trying to get_tenancies for UID '#{user_id}'"
+        end
+
         body = JSON.parse(res.body)
 
         number_of_pages = body.fetch('number_of_pages')

--- a/lib/hackney/income/search_tenancies_gateway.rb
+++ b/lib/hackney/income/search_tenancies_gateway.rb
@@ -24,6 +24,10 @@ module Hackney
 
         responce = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
 
+        unless responce.is_a? Net::HTTPSuccess
+          raise Exceptions::TenancyApiError.new(responce), "when trying to search tenancies with '#{uri}'"
+        end
+
         marshal(responce.body)
       end
 

--- a/lib/hackney/income/search_tenancies_gateway.rb
+++ b/lib/hackney/income/search_tenancies_gateway.rb
@@ -22,19 +22,19 @@ module Hackney
         request = Net::HTTP::Get.new(uri)
         request['X-Api-Key'] = @api_key
 
-        responce = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(request) }
 
-        unless responce.is_a? Net::HTTPSuccess
-          raise Exceptions::TenancyApiError.new(responce), "when trying to search tenancies with '#{uri}'"
+        unless response.is_a? Net::HTTPSuccess
+          raise Exceptions::TenancyApiError.new(response), "when trying to search tenancies with '#{uri}'"
         end
 
-        marshal(responce.body)
+        marshal(response.body)
       end
 
       private
 
-      def marshal(responce_body)
-        json = JSON.parse(responce_body)
+      def marshal(response_body)
+        json = JSON.parse(response_body)
         tenancies = []
         number_of_pages = json.dig('data', 'page_count').to_i
         number_of_results = json.dig('data', 'total_count').to_i

--- a/lib/hackney/income/transactions_gateway.rb
+++ b/lib/hackney/income/transactions_gateway.rb
@@ -18,6 +18,10 @@ module Hackney
 
         res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
 
+        unless res.is_a? Net::HTTPSuccess
+          raise Exceptions::IncomeApiError.new(res), "when trying to get transactions_for with tenancy_ref '#{tenancy_ref}'"
+        end
+
         transactions = JSON.parse(res.body).fetch('payment_transactions')
         transactions.map do |transaction|
           {

--- a/spec/lib/hackney/income/income_api_users_gateway_spec.rb
+++ b/spec/lib/hackney/income/income_api_users_gateway_spec.rb
@@ -70,7 +70,7 @@ describe Hackney::Income::IncomeApiUsersGateway do
           last_name: params.fetch(:last_name),
           provider_permissions: params.fetch(:provider_permissions)
         )
-      end.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 responce] when trying to find_or_create_user with UID '#{params.fetch(:provider_uid)}'")
+      end.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 response] when trying to find_or_create_user with UID '#{params.fetch(:provider_uid)}'")
     end
   end
 end

--- a/spec/lib/hackney/income/income_api_users_gateway_spec.rb
+++ b/spec/lib/hackney/income/income_api_users_gateway_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe Hackney::Income::IncomeApiUsersGateway do
   subject { described_class.new(api_host: 'https://example.com/api', api_key: 'skeleton') }
 
@@ -26,14 +28,14 @@ describe Hackney::Income::IncomeApiUsersGateway do
 
   let(:param_string) { URI.encode_www_form(params) }
 
-  before do
-    stub_request(:post, "https://example.com/api/users/find-or-create?#{param_string}")
+  context 'when a user has successfully logged in' do
+    before do
+      stub_request(:post, "https://example.com/api/users/find-or-create?#{param_string}")
       .to_return(
         body: response.to_json
       )
-  end
+    end
 
-  context 'when a user has successfully logged in' do
     it 'should receive details of the user and make an API request' do
       expect(
         subject.find_or_create_user(
@@ -46,6 +48,29 @@ describe Hackney::Income::IncomeApiUsersGateway do
           provider_permissions: params.fetch(:provider_permissions)
         )
       ).to eq(response)
+    end
+  end
+
+  context 'when the backend throws an error' do
+    before do
+      stub_request(:post, "https://example.com/api/users/find-or-create?#{param_string}")
+      .to_return(status: [500, 'Internal Server Error'])
+    end
+
+    let(:provider_uid) { params.fetch(:provider_uid) }
+
+    it 'should not login' do
+      expect do
+        subject.find_or_create_user(
+          provider_uid: params.fetch(:provider_uid),
+          provider: params.fetch(:provider),
+          name: params.fetch(:name),
+          email: params.fetch(:email),
+          first_name: params.fetch(:first_name),
+          last_name: params.fetch(:last_name),
+          provider_permissions: params.fetch(:provider_permissions)
+        )
+      end.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 responce] when trying to find_or_create_user with UID '#{params.fetch(:provider_uid)}'")
     end
   end
 end

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -26,7 +26,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       end
 
       it 'should raise a IncomeApiError' do
-        expect { subject }.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 responce] when trying to get_tenancies for UID '#{user_id}'")
+        expect { subject }.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 response] when trying to get_tenancies for UID '#{user_id}'")
       end
     end
 

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -18,345 +18,359 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       )
     end
 
-    before do
-      stub_request(:get, 'https://example.com/api/my-cases')
-        .with(query: hash_including({}))
-        .to_return(body: stub_response.to_json)
-    end
-
-    let(:stub_response) { { cases: stub_tenancies, number_of_pages: number_of_pages } }
-    let(:number_of_pages) { Faker::Number.number(3).to_i }
-    let(:stub_tenancies) do
-      Array.new(Faker::Number.number(2).to_i).map { example_tenancy_list_response_item }
-    end
-
-    it 'should look up tenancies for the user id and page params passed in' do
-      subject
-
-      request = a_request(:get, 'https://example.com/api/my-cases').with(
-        headers: { 'X-Api-Key' => 'skeleton' },
-        query: {
-          'user_id' => user_id,
-          'page_number' => page_number,
-          'number_per_page' => number_per_page,
-          'is_paused' => is_paused
-        }
-      )
-
-      expect(request).to have_been_made
-    end
-
-    it 'should include all tenancies' do
-      expect(subject.tenancies.count).to eq(stub_tenancies.count)
-      expect(subject.tenancies.map(&:ref)).to eq(stub_tenancies.map { |t| t[:ref] })
-    end
-
-    it 'should include the number of pages' do
-      expect(subject.number_of_pages).to eq(number_of_pages)
-    end
-
-    context 'for each tenancy' do
-      let(:stub_tenancies) do
-        [example_tenancy_list_response_item(current_balance: '¤5,675.89')]
-      end
-
-      let(:expected_tenancy) { stub_tenancies.first }
-
-      it 'should include a score' do
-        expect(subject.tenancies.first.score).to eq(expected_tenancy[:priority_score])
-      end
-
-      it 'should include a band' do
-        expect(subject.tenancies.first.band).to eq(expected_tenancy[:priority_band])
-      end
-
-      it 'should include the contributions made to the score' do
-        expect(subject.tenancies.first.balance_contribution).to eq(expected_tenancy[:balance_contribution])
-        expect(subject.tenancies.first.days_in_arrears_contribution).to eq(expected_tenancy[:days_in_arrears_contribution])
-        expect(subject.tenancies.first.days_since_last_payment_contribution).to eq(expected_tenancy[:days_since_last_payment_contribution])
-        expect(subject.tenancies.first.payment_amount_delta_contribution).to eq(expected_tenancy[:payment_amount_delta_contribution])
-        expect(subject.tenancies.first.payment_date_delta_contribution).to eq(expected_tenancy[:payment_date_delta_contribution])
-        expect(subject.tenancies.first.number_of_broken_agreements_contribution).to eq(expected_tenancy[:number_of_broken_agreements_contribution])
-        expect(subject.tenancies.first.active_agreement_contribution).to eq(expected_tenancy[:active_agreement_contribution])
-        expect(subject.tenancies.first.broken_court_order_contribution).to eq(expected_tenancy[:broken_court_order_contribution])
-        expect(subject.tenancies.first.nosp_served_contribution).to eq(expected_tenancy[:nosp_served_contribution])
-        expect(subject.tenancies.first.active_nosp_contribution).to eq(expected_tenancy[:active_nosp_contribution])
-      end
-
-      it 'should include some useful info for displaying the priority contributions in a readable way' do
-        expect(subject.tenancies.first.days_in_arrears).to eq(expected_tenancy[:days_in_arrears])
-        expect(subject.tenancies.first.days_since_last_payment).to eq(expected_tenancy[:days_since_last_payment])
-        expect(subject.tenancies.first.payment_amount_delta).to eq(expected_tenancy[:payment_amount_delta])
-        expect(subject.tenancies.first.payment_date_delta).to eq(expected_tenancy[:payment_date_delta])
-        expect(subject.tenancies.first.number_of_broken_agreements).to eq(expected_tenancy[:number_of_broken_agreements])
-        expect(subject.tenancies.first.broken_court_order).to eq(expected_tenancy[:broken_court_order])
-        expect(subject.tenancies.first.nosp_served).to eq(expected_tenancy[:nosp_served])
-        expect(subject.tenancies.first.active_nosp).to eq(expected_tenancy[:active_nosp])
-      end
-
-      it 'should include balances, converting those given as currencies' do
-        expect(subject.tenancies.first.current_balance).to eq(5_675.89)
-      end
-
-      it 'should include current agreement status' do
-        expect(subject.tenancies.first.current_arrears_agreement_status).to eq(expected_tenancy[:current_arrears_agreement_status])
-      end
-
-      it 'should include latest action code' do
-        expect(subject.tenancies.first.latest_action_code).to eq(expected_tenancy[:latest_action][:code])
-      end
-
-      it 'should include latest action date' do
-        expect(subject.tenancies.first.latest_action_date).to eq(expected_tenancy[:latest_action][:date].strftime('%Y-%m-%d'))
-      end
-
-      it 'should include basic contact details - name' do
-        expect(subject.tenancies.first.primary_contact_name).to eq(expected_tenancy[:primary_contact][:name])
-      end
-
-      it 'should include basic contact details - short address' do
-        expect(subject.tenancies.first.primary_contact_short_address).to eq(expected_tenancy[:primary_contact][:short_address])
-      end
-
-      it 'should include basic contact details - postcode' do
-        expect(subject.tenancies.first.primary_contact_postcode).to eq(expected_tenancy[:primary_contact][:postcode])
-      end
-    end
-
-    context 'in a staging environment' do
-      let(:stub_tenancies) do
-        [example_tenancy_list_response_item(ref: '000015/03')]
-      end
-
+    context 'when the api is returning errors' do
       before do
-        allow(Rails.env).to receive(:staging?).and_return(true)
+        stub_request(:get, 'https://example.com/api/my-cases')
+        .with(query: hash_including({}))
+        .to_return(status: [500, 'oh no!'])
       end
 
-      let(:seeded_prioritised_tenancy) do
-        {
-          primary_contact_name: 'Mr. Reanna Mann',
-          primary_contact_short_address: '796 Jacobs Burg',
-          primary_contact_postcode: '23109-5863'
-        }
-      end
-
-      it 'should obfuscate the name, address and postcode for each prioritised list item' do
-        expect(subject.tenancies.first.primary_contact_short_address).to eq(seeded_prioritised_tenancy[:primary_contact_short_address])
-        expect(subject.tenancies.first.primary_contact_name).to eq(seeded_prioritised_tenancy[:primary_contact_name])
-        expect(subject.tenancies.first.primary_contact_postcode).to eq(seeded_prioritised_tenancy[:primary_contact_postcode])
-      end
-    end
-  end
-
-  context 'when receiving details of a single tenancy' do
-    let(:triangulated_stub_tenancy_response) { example_single_tenancy_response }
-    let(:stub_response) do
-      example_single_tenancy_response(
-        tenancy_details: {
-          rent: '¤1,234.56',
-          service: '¤2,234.56',
-          other_charge: '¤3,234.56',
-          current_balance: '¤4,234.56'
-        }
-      )
-    end
-
-    before do
-      stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01')
-        .to_return(body: stub_response.to_json)
-
-      stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F02')
-        .to_return(body: triangulated_stub_tenancy_response.to_json)
-    end
-
-    subject { tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/01') }
-    let(:expected_details) { stub_response.fetch(:tenancy_details) }
-
-    it 'should return a single tenancy matching the reference given with converted currencies' do
-      expect(subject).to be_instance_of(Hackney::Income::Domain::Tenancy)
-      expect(subject.ref).to eq(expected_details.fetch(:ref))
-      expect(subject.tenure).to eq(expected_details.fetch(:tenure))
-      expect(subject.rent).to eq(1234.56)
-      expect(subject.service).to eq(2234.56)
-      expect(subject.other_charge).to eq(3234.56)
-      expect(subject.current_balance).to eq(4234.56)
-    end
-
-    it 'should return a single tenancy matching the reference given' do
-      tenancy = tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/02')
-      expected_details = triangulated_stub_tenancy_response.fetch(:tenancy_details)
-
-      expect(tenancy).to be_instance_of(Hackney::Income::Domain::Tenancy)
-      expect(tenancy.ref).to eq(expected_details.fetch(:ref))
-      expect(tenancy.tenure).to eq(expected_details.fetch(:tenure))
-      expect(tenancy.rent).to eq(expected_details.fetch(:rent).to_f)
-      expect(tenancy.service).to eq(expected_details.fetch(:service).to_f)
-      expect(tenancy.other_charge).to eq(expected_details.fetch(:other_charge).to_f)
-      expect(tenancy.current_balance).to eq(expected_details.fetch(:current_balance).to_f)
-    end
-
-    it 'should include the contact details and current state of the account' do
-      expect(subject.current_arrears_agreement_status).to eq(expected_details.fetch(:current_arrears_agreement_status))
-      expect(subject.primary_contact_name).to eq(expected_details.fetch(:primary_contact_name))
-      expect(subject.primary_contact_long_address).to eq(expected_details.fetch(:primary_contact_long_address))
-      expect(subject.primary_contact_postcode).to eq(expected_details.fetch(:primary_contact_postcode))
-    end
-
-    let(:expected_actions) { stub_response.fetch(:latest_action_diary_events) }
-    let(:expected_agreements) { stub_response.fetch(:latest_arrears_agreements) }
-
-    it 'should include the latest 5 action diary events' do
-      expect(subject.arrears_actions.length).to eq(5)
-
-      subject.arrears_actions.each_with_index do |action, i|
-        assert_action_diary_event(expected_actions[i], action)
+      it 'should raise a IncomeApiError' do
+        expect { subject }.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 responce] when trying to get_tenancies for UID '#{user_id}'")
       end
     end
 
-    it 'should include the latest 5 arrears actions' do
-      expect(subject.agreements.length).to eq(5)
-
-      subject.agreements.each_with_index do |agreement, i|
-        assert_agreement(expected_agreements[i], agreement)
+    context 'when the api is running' do
+      before do
+        stub_request(:get, 'https://example.com/api/my-cases')
+          .with(query: hash_including({}))
+          .to_return(body: stub_response.to_json)
       end
-    end
 
-    context 'in a staging environment' do
-      let(:stub_response) do
-        {
-          tenancy_details:
+      let(:stub_response) { { cases: stub_tenancies, number_of_pages: number_of_pages } }
+      let(:number_of_pages) { Faker::Number.number(3).to_i }
+      let(:stub_tenancies) do
+        Array.new(Faker::Number.number(2).to_i).map { example_tenancy_list_response_item }
+      end
+
+      it 'should look up tenancies for the user id and page params passed in' do
+        subject
+
+        request = a_request(:get, 'https://example.com/api/my-cases').with(
+          headers: { 'X-Api-Key' => 'skeleton' },
+          query: {
+            'user_id' => user_id,
+            'page_number' => page_number,
+            'number_per_page' => number_per_page,
+            'is_paused' => is_paused
+          }
+        )
+
+        expect(request).to have_been_made
+      end
+
+      it 'should include all tenancies' do
+        expect(subject.tenancies.count).to eq(stub_tenancies.count)
+        expect(subject.tenancies.map(&:ref)).to eq(stub_tenancies.map { |t| t[:ref] })
+      end
+
+      it 'should include the number of pages' do
+        expect(subject.number_of_pages).to eq(number_of_pages)
+      end
+
+      context 'for each tenancy' do
+        let(:stub_tenancies) do
+          [example_tenancy_list_response_item(current_balance: '¤5,675.89')]
+        end
+
+        let(:expected_tenancy) { stub_tenancies.first }
+
+        it 'should include a score' do
+          expect(subject.tenancies.first.score).to eq(expected_tenancy[:priority_score])
+        end
+
+        it 'should include a band' do
+          expect(subject.tenancies.first.band).to eq(expected_tenancy[:priority_band])
+        end
+
+        it 'should include the contributions made to the score' do
+          expect(subject.tenancies.first.balance_contribution).to eq(expected_tenancy[:balance_contribution])
+          expect(subject.tenancies.first.days_in_arrears_contribution).to eq(expected_tenancy[:days_in_arrears_contribution])
+          expect(subject.tenancies.first.days_since_last_payment_contribution).to eq(expected_tenancy[:days_since_last_payment_contribution])
+          expect(subject.tenancies.first.payment_amount_delta_contribution).to eq(expected_tenancy[:payment_amount_delta_contribution])
+          expect(subject.tenancies.first.payment_date_delta_contribution).to eq(expected_tenancy[:payment_date_delta_contribution])
+          expect(subject.tenancies.first.number_of_broken_agreements_contribution).to eq(expected_tenancy[:number_of_broken_agreements_contribution])
+          expect(subject.tenancies.first.active_agreement_contribution).to eq(expected_tenancy[:active_agreement_contribution])
+          expect(subject.tenancies.first.broken_court_order_contribution).to eq(expected_tenancy[:broken_court_order_contribution])
+          expect(subject.tenancies.first.nosp_served_contribution).to eq(expected_tenancy[:nosp_served_contribution])
+          expect(subject.tenancies.first.active_nosp_contribution).to eq(expected_tenancy[:active_nosp_contribution])
+        end
+
+        it 'should include some useful info for displaying the priority contributions in a readable way' do
+          expect(subject.tenancies.first.days_in_arrears).to eq(expected_tenancy[:days_in_arrears])
+          expect(subject.tenancies.first.days_since_last_payment).to eq(expected_tenancy[:days_since_last_payment])
+          expect(subject.tenancies.first.payment_amount_delta).to eq(expected_tenancy[:payment_amount_delta])
+          expect(subject.tenancies.first.payment_date_delta).to eq(expected_tenancy[:payment_date_delta])
+          expect(subject.tenancies.first.number_of_broken_agreements).to eq(expected_tenancy[:number_of_broken_agreements])
+          expect(subject.tenancies.first.broken_court_order).to eq(expected_tenancy[:broken_court_order])
+          expect(subject.tenancies.first.nosp_served).to eq(expected_tenancy[:nosp_served])
+          expect(subject.tenancies.first.active_nosp).to eq(expected_tenancy[:active_nosp])
+        end
+
+        it 'should include balances, converting those given as currencies' do
+          expect(subject.tenancies.first.current_balance).to eq(5_675.89)
+        end
+
+        it 'should include current agreement status' do
+          expect(subject.tenancies.first.current_arrears_agreement_status).to eq(expected_tenancy[:current_arrears_agreement_status])
+        end
+
+        it 'should include latest action code' do
+          expect(subject.tenancies.first.latest_action_code).to eq(expected_tenancy[:latest_action][:code])
+        end
+
+        it 'should include latest action date' do
+          expect(subject.tenancies.first.latest_action_date).to eq(expected_tenancy[:latest_action][:date].strftime('%Y-%m-%d'))
+        end
+
+        it 'should include basic contact details - name' do
+          expect(subject.tenancies.first.primary_contact_name).to eq(expected_tenancy[:primary_contact][:name])
+        end
+
+        it 'should include basic contact details - short address' do
+          expect(subject.tenancies.first.primary_contact_short_address).to eq(expected_tenancy[:primary_contact][:short_address])
+        end
+
+        it 'should include basic contact details - postcode' do
+          expect(subject.tenancies.first.primary_contact_postcode).to eq(expected_tenancy[:primary_contact][:postcode])
+        end
+      end
+
+      context 'in a staging environment' do
+        let(:stub_tenancies) do
+          [example_tenancy_list_response_item(ref: '000015/03')]
+        end
+
+        before do
+          allow(Rails.env).to receive(:staging?).and_return(true)
+        end
+
+        let(:seeded_prioritised_tenancy) do
           {
-            ref: '12345',
-            tenure: Faker::Lorem.characters(3),
-            rent: "¤#{Faker::Number.decimal(2)}",
-            service: "¤#{Faker::Number.decimal(2)}",
-            other_charge: "¤#{Faker::Number.decimal(2)}",
-            current_arrears_agreement_status: Faker::Lorem.characters(3),
-            current_balance: "¤#{Faker::Number.decimal(2)}",
-            primary_contact_name: Faker::Name.first_name,
-            primary_contact_long_address: Faker::Address.street_address,
-            primary_contact_postcode: Faker::Lorem.word
-          },
-          latest_action_diary_events: Array.new(5) { action_diary_event },
-          latest_arrears_agreements: Array.new(5) { arrears_agreement }
-        }
+            primary_contact_name: 'Mr. Reanna Mann',
+            primary_contact_short_address: '796 Jacobs Burg',
+            primary_contact_postcode: '23109-5863'
+          }
+        end
+
+        it 'should obfuscate the name, address and postcode for each prioritised list item' do
+          expect(subject.tenancies.first.primary_contact_short_address).to eq(seeded_prioritised_tenancy[:primary_contact_short_address])
+          expect(subject.tenancies.first.primary_contact_name).to eq(seeded_prioritised_tenancy[:primary_contact_name])
+          expect(subject.tenancies.first.primary_contact_postcode).to eq(seeded_prioritised_tenancy[:primary_contact_postcode])
+        end
+      end
+    end
+
+    context 'when receiving details of a single tenancy' do
+      let(:triangulated_stub_tenancy_response) { example_single_tenancy_response }
+      let(:stub_response) do
+        example_single_tenancy_response(
+          tenancy_details: {
+            rent: '¤1,234.56',
+            service: '¤2,234.56',
+            other_charge: '¤3,234.56',
+            current_balance: '¤4,234.56'
+          }
+        )
       end
 
       before do
         stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01')
           .to_return(body: stub_response.to_json)
 
-        allow(Rails.env).to receive(:staging?).and_return(true)
+        stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F02')
+          .to_return(body: triangulated_stub_tenancy_response.to_json)
       end
 
-      let(:single_tenancy) { tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/01') }
-      let(:expected_tenancy) do
-        {
-          primary_contact_name: 'Ms. Mittie Torphy',
-          primary_contact_long_address: '6216 O\'Reilly Point',
-          primary_contact_postcode: '86029-1267'
-        }
+      subject { tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/01') }
+      let(:expected_details) { stub_response.fetch(:tenancy_details) }
+
+      it 'should return a single tenancy matching the reference given with converted currencies' do
+        expect(subject).to be_instance_of(Hackney::Income::Domain::Tenancy)
+        expect(subject.ref).to eq(expected_details.fetch(:ref))
+        expect(subject.tenure).to eq(expected_details.fetch(:tenure))
+        expect(subject.rent).to eq(1234.56)
+        expect(subject.service).to eq(2234.56)
+        expect(subject.other_charge).to eq(3234.56)
+        expect(subject.current_balance).to eq(4234.56)
       end
 
-      it 'should obfuscate the name, address and postcode for each single tenancy item' do
-        expect(single_tenancy.primary_contact_long_address).to eq(expected_tenancy[:primary_contact_long_address])
-        expect(single_tenancy.primary_contact_name).to eq(expected_tenancy[:primary_contact_name])
-        expect(single_tenancy.primary_contact_postcode).to eq(expected_tenancy[:primary_contact_postcode])
+      it 'should return a single tenancy matching the reference given' do
+        tenancy = tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/02')
+        expected_details = triangulated_stub_tenancy_response.fetch(:tenancy_details)
+
+        expect(tenancy).to be_instance_of(Hackney::Income::Domain::Tenancy)
+        expect(tenancy.ref).to eq(expected_details.fetch(:ref))
+        expect(tenancy.tenure).to eq(expected_details.fetch(:tenure))
+        expect(tenancy.rent).to eq(expected_details.fetch(:rent).to_f)
+        expect(tenancy.service).to eq(expected_details.fetch(:service).to_f)
+        expect(tenancy.other_charge).to eq(expected_details.fetch(:other_charge).to_f)
+        expect(tenancy.current_balance).to eq(expected_details.fetch(:current_balance).to_f)
+      end
+
+      it 'should include the contact details and current state of the account' do
+        expect(subject.current_arrears_agreement_status).to eq(expected_details.fetch(:current_arrears_agreement_status))
+        expect(subject.primary_contact_name).to eq(expected_details.fetch(:primary_contact_name))
+        expect(subject.primary_contact_long_address).to eq(expected_details.fetch(:primary_contact_long_address))
+        expect(subject.primary_contact_postcode).to eq(expected_details.fetch(:primary_contact_postcode))
+      end
+
+      let(:expected_actions) { stub_response.fetch(:latest_action_diary_events) }
+      let(:expected_agreements) { stub_response.fetch(:latest_arrears_agreements) }
+
+      it 'should include the latest 5 action diary events' do
+        expect(subject.arrears_actions.length).to eq(5)
+
+        subject.arrears_actions.each_with_index do |action, i|
+          assert_action_diary_event(expected_actions[i], action)
+        end
+      end
+
+      it 'should include the latest 5 arrears actions' do
+        expect(subject.agreements.length).to eq(5)
+
+        subject.agreements.each_with_index do |agreement, i|
+          assert_agreement(expected_agreements[i], agreement)
+        end
+      end
+
+      context 'in a staging environment' do
+        let(:stub_response) do
+          {
+            tenancy_details:
+            {
+              ref: '12345',
+              tenure: Faker::Lorem.characters(3),
+              rent: "¤#{Faker::Number.decimal(2)}",
+              service: "¤#{Faker::Number.decimal(2)}",
+              other_charge: "¤#{Faker::Number.decimal(2)}",
+              current_arrears_agreement_status: Faker::Lorem.characters(3),
+              current_balance: "¤#{Faker::Number.decimal(2)}",
+              primary_contact_name: Faker::Name.first_name,
+              primary_contact_long_address: Faker::Address.street_address,
+              primary_contact_postcode: Faker::Lorem.word
+            },
+            latest_action_diary_events: Array.new(5) { action_diary_event },
+            latest_arrears_agreements: Array.new(5) { arrears_agreement }
+          }
+        end
+
+        before do
+          stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01')
+            .to_return(body: stub_response.to_json)
+
+          allow(Rails.env).to receive(:staging?).and_return(true)
+        end
+
+        let(:single_tenancy) { tenancy_gateway.get_tenancy(tenancy_ref: 'FAKE/01') }
+        let(:expected_tenancy) do
+          {
+            primary_contact_name: 'Ms. Mittie Torphy',
+            primary_contact_long_address: '6216 O\'Reilly Point',
+            primary_contact_postcode: '86029-1267'
+          }
+        end
+
+        it 'should obfuscate the name, address and postcode for each single tenancy item' do
+          expect(single_tenancy.primary_contact_long_address).to eq(expected_tenancy[:primary_contact_long_address])
+          expect(single_tenancy.primary_contact_name).to eq(expected_tenancy[:primary_contact_name])
+          expect(single_tenancy.primary_contact_postcode).to eq(expected_tenancy[:primary_contact_postcode])
+        end
       end
     end
-  end
 
-  context 'getting contact details for a tenancy ref' do
-    let(:stub_single_response) { generate_contacts_response([generate_contact]) }
+    context 'getting contact details for a tenancy ref' do
+      let(:stub_single_response) { generate_contacts_response([generate_contact]) }
 
-    context 'a single tenant' do
-      before do
-        stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01/contacts')
-          .to_return(body: stub_single_response.to_json)
+      context 'a single tenant' do
+        before do
+          stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01/contacts')
+            .to_return(body: stub_single_response.to_json)
+        end
+
+        it 'should have at least one contact' do
+          contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/01')
+          expected_contact = stub_single_response[:data][:contacts].first
+
+          expect(contacts.size).to eq(1)
+
+          expect(contacts[0]).to be_instance_of(Hackney::Income::Domain::Contact)
+
+          expect(contacts[0].contact_id).to eq(expected_contact.fetch(:contact_id))
+          expect(contacts[0].email_address).to eq(expected_contact.fetch(:email_address))
+          expect(contacts[0].uprn).to eq(expected_contact.fetch(:uprn))
+          expect(contacts[0].address_line_1).to eq(expected_contact.fetch(:address_line1))
+          expect(contacts[0].address_line_2).to eq(expected_contact.fetch(:address_line2))
+          expect(contacts[0].address_line_3).to eq(expected_contact.fetch(:address_line3))
+          expect(contacts[0].first_name).to eq(expected_contact.fetch(:first_name))
+          expect(contacts[0].last_name).to eq(expected_contact.fetch(:last_name))
+          expect(contacts[0].full_name).to eq(expected_contact.fetch(:full_name))
+          expect(contacts[0].larn).to eq(expected_contact.fetch(:larn))
+          expect(contacts[0].telephone_1).to eq(expected_contact.fetch(:telephone1))
+          expect(contacts[0].telephone_2).to eq(expected_contact.fetch(:telephone2))
+          expect(contacts[0].telephone_3).to eq(expected_contact.fetch(:telephone3))
+          expect(contacts[0].cautionary_alert).to eq(expected_contact.fetch(:cautionary_alert))
+          expect(contacts[0].property_cautionary_alert).to eq(expected_contact.fetch(:property_cautionary_alert))
+          expect(contacts[0].house_ref).to eq(expected_contact.fetch(:house_ref))
+          expect(contacts[0].title).to eq(expected_contact.fetch(:title))
+          expect(contacts[0].full_address_display).to eq(expected_contact.fetch(:full_address_display))
+          expect(contacts[0].full_address_search).to eq(expected_contact.fetch(:full_address_search))
+          expect(contacts[0].post_code).to eq(expected_contact.fetch(:post_code))
+          expect(contacts[0].date_of_birth).to eq(expected_contact.fetch(:date_of_birth).strftime('%Y-%m-%d'))
+          expect(contacts[0].hackney_homes_id).to eq(expected_contact.fetch(:hackney_homes_id))
+          expect(contacts[0].responsible).to eq(expected_contact.fetch(:responsible))
+        end
       end
 
-      it 'should have at least one contact' do
-        contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/01')
-        expected_contact = stub_single_response[:data][:contacts].first
+      context 'a joint tenancy' do
+        let(:stub_joint_response) { generate_contacts_response(2.times.to_a.map { generate_contact }) }
 
-        expect(contacts.size).to eq(1)
+        before do
+          stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F02/contacts')
+            .to_return(body: stub_joint_response.to_json)
+        end
 
-        expect(contacts[0]).to be_instance_of(Hackney::Income::Domain::Contact)
-
-        expect(contacts[0].contact_id).to eq(expected_contact.fetch(:contact_id))
-        expect(contacts[0].email_address).to eq(expected_contact.fetch(:email_address))
-        expect(contacts[0].uprn).to eq(expected_contact.fetch(:uprn))
-        expect(contacts[0].address_line_1).to eq(expected_contact.fetch(:address_line1))
-        expect(contacts[0].address_line_2).to eq(expected_contact.fetch(:address_line2))
-        expect(contacts[0].address_line_3).to eq(expected_contact.fetch(:address_line3))
-        expect(contacts[0].first_name).to eq(expected_contact.fetch(:first_name))
-        expect(contacts[0].last_name).to eq(expected_contact.fetch(:last_name))
-        expect(contacts[0].full_name).to eq(expected_contact.fetch(:full_name))
-        expect(contacts[0].larn).to eq(expected_contact.fetch(:larn))
-        expect(contacts[0].telephone_1).to eq(expected_contact.fetch(:telephone1))
-        expect(contacts[0].telephone_2).to eq(expected_contact.fetch(:telephone2))
-        expect(contacts[0].telephone_3).to eq(expected_contact.fetch(:telephone3))
-        expect(contacts[0].cautionary_alert).to eq(expected_contact.fetch(:cautionary_alert))
-        expect(contacts[0].property_cautionary_alert).to eq(expected_contact.fetch(:property_cautionary_alert))
-        expect(contacts[0].house_ref).to eq(expected_contact.fetch(:house_ref))
-        expect(contacts[0].title).to eq(expected_contact.fetch(:title))
-        expect(contacts[0].full_address_display).to eq(expected_contact.fetch(:full_address_display))
-        expect(contacts[0].full_address_search).to eq(expected_contact.fetch(:full_address_search))
-        expect(contacts[0].post_code).to eq(expected_contact.fetch(:post_code))
-        expect(contacts[0].date_of_birth).to eq(expected_contact.fetch(:date_of_birth).strftime('%Y-%m-%d'))
-        expect(contacts[0].hackney_homes_id).to eq(expected_contact.fetch(:hackney_homes_id))
-        expect(contacts[0].responsible).to eq(expected_contact.fetch(:responsible))
-      end
-    end
-
-    context 'a joint tenancy' do
-      let(:stub_joint_response) { generate_contacts_response(2.times.to_a.map { generate_contact }) }
-
-      before do
-        stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F02/contacts')
-          .to_return(body: stub_joint_response.to_json)
+        it 'should have more than one contact' do
+          contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/02')
+          expect(contacts.size).to eq(2)
+          contacts.each { |c| expect(c).to be_instance_of(Hackney::Income::Domain::Contact) }
+        end
       end
 
-      it 'should have more than one contact' do
-        contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/02')
-        expect(contacts.size).to eq(2)
-        contacts.each { |c| expect(c).to be_instance_of(Hackney::Income::Domain::Contact) }
-      end
-    end
+      context 'in a staging environment' do
+        before do
+          stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01/contacts')
+            .to_return(body: stub_single_response.to_json)
 
-    context 'in a staging environment' do
-      before do
-        stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F01/contacts')
-          .to_return(body: stub_single_response.to_json)
+          allow(Rails.env).to receive(:staging?).and_return(true)
+        end
 
-        allow(Rails.env).to receive(:staging?).and_return(true)
-      end
-
-      it 'should not return any contact data at all' do
-        contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/01')
-        expect(contacts).to eq([])
-      end
-    end
-
-    context 'contact data is missing or fragmented' do
-      let(:stub_empty_response_1) { generate_contacts_response([]) }
-      let(:stub_empty_response_2) { generate_contacts_response(nil) }
-
-      before do
-        stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F03/contacts')
-          .to_return(body: stub_empty_response_1.to_json)
-        stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F04/contacts')
-          .to_return(body: stub_empty_response_2.to_json)
+        it 'should not return any contact data at all' do
+          contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/01')
+          expect(contacts).to eq([])
+        end
       end
 
-      it 'should return nothing if no contact was available' do
-        contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/03')
-        expect(contacts).to eq([])
-      end
+      context 'contact data is missing or fragmented' do
+        let(:stub_empty_response_1) { generate_contacts_response([]) }
+        let(:stub_empty_response_2) { generate_contacts_response(nil) }
 
-      it 'should return nothing if nil was received' do
-        contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/04')
-        expect(contacts).to eq([])
+        before do
+          stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F03/contacts')
+            .to_return(body: stub_empty_response_1.to_json)
+          stub_request(:get, 'https://example.com/api/tenancies/FAKE%2F04/contacts')
+            .to_return(body: stub_empty_response_2.to_json)
+        end
+
+        it 'should return nothing if no contact was available' do
+          contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/03')
+          expect(contacts).to eq([])
+        end
+
+        it 'should return nothing if nil was received' do
+          contacts = tenancy_gateway.get_contacts_for(tenancy_ref: 'FAKE/04')
+          expect(contacts).to eq([])
+        end
       end
     end
   end

--- a/spec/lib/hackney/income/search_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/search_tenancies_gateway_spec.rb
@@ -160,7 +160,7 @@ describe Hackney::Income::SearchTenanciesGateway do
     it 'should throw an error' do
       expect { subject }.to raise_error(
         Exceptions::TenancyApiError,
-        "[Tenancy API error: Received 500 responce] when trying to search tenancies with 'https://example.com/api/v1/tenancies/search?#{URI.encode_www_form(url_params)}'"
+        "[Tenancy API error: Received 500 response] when trying to search tenancies with 'https://example.com/api/v1/tenancies/search?#{URI.encode_www_form(url_params)}'"
       )
     end
   end

--- a/spec/lib/hackney/income/search_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/search_tenancies_gateway_spec.rb
@@ -136,7 +136,7 @@ describe Hackney::Income::SearchTenanciesGateway do
       end
     end
 
-    context 'when there is some strange json' do
+    context 'when request returns empty json object' do
       let(:tenancies_results_body) { '{}' }
 
       it 'should return an empty array' do

--- a/spec/lib/hackney/income/search_tenancies_gateway_spec.rb
+++ b/spec/lib/hackney/income/search_tenancies_gateway_spec.rb
@@ -51,101 +51,117 @@ describe Hackney::Income::SearchTenanciesGateway do
     search_tenancies_gateway.search(params)
   end
 
-  before do
-    stub_request(:get, "https://example.com/api/v1/tenancies/search?#{URI.encode_www_form(url_params)}")
-    .to_return(body: tenancies_results_body)
-  end
-
-  context 'when searching for Mrs S Smith' do
-    let(:search_term) { 'Mrs S Smith' }
-    let(:tenancies_results) do
-      results = generate_fake_tennancy_results(3)
-      results.insert(0,
-                     "ref": '112345/35',
-                     "prop_ref": '00015378',
-                     "current_balance": {
-                       "value": -15.89,
-                       "currency_code": 'GBP'
-                     },
-                     "tenure": 'SEC',
-                     "primary_contact": {
-                        "name": 'Mrs S Smith                                                              ',
-                        "postcode": 'G9 0RX',
-                        "short_address": '6 Fake Road 99 Wot Street'
-                     })
-      results
+  context 'when requesting from the tenancies api' do
+    before do
+      stub_request(:get, "https://example.com/api/v1/tenancies/search?#{URI.encode_www_form(url_params)}")
+      .to_return(body: tenancies_results_body)
     end
 
-    it 'the returned result should be a TenancySearchResult' do
-      expect(subject[:tenancies].size).to eq(4)
+    context 'when searching for Mrs S Smith' do
+      let(:search_term) { 'Mrs S Smith' }
+      let(:tenancies_results) do
+        results = generate_fake_tennancy_results(3)
+        results.insert(0,
+                       "ref": '112345/35',
+                       "prop_ref": '00015378',
+                       "current_balance": {
+                         "value": -15.89,
+                         "currency_code": 'GBP'
+                       },
+                       "tenure": 'SEC',
+                       "primary_contact": {
+                          "name": 'Mrs S Smith                                                              ',
+                          "postcode": 'G9 0RX',
+                          "short_address": '6 Fake Road 99 Wot Street'
+                       })
+        results
+      end
 
-      expect(subject[:tenancies]).to all(be_instance_of(Hackney::Income::Domain::TenancySearchResult))
+      it 'the returned result should be a TenancySearchResult' do
+        expect(subject[:tenancies].size).to eq(4)
 
-      expect(subject[:tenancies].first).to have_attributes(ref: '112345/35')
-      expect(subject[:tenancies].first).to have_attributes(property_ref: '00015378')
-      expect(subject[:tenancies].first).to have_attributes(tenure: 'SEC')
-      expect(subject[:tenancies].first).to have_attributes(current_balance: -15.89)
-      expect(subject[:tenancies].first).to have_attributes(primary_contact_name: 'Mrs S Smith                                                              ')
-      expect(subject[:tenancies].first).to have_attributes(primary_contact_short_address: '6 Fake Road 99 Wot Street')
-      expect(subject[:tenancies].first).to have_attributes(primary_contact_postcode: 'G9 0RX')
+        expect(subject[:tenancies]).to all(be_instance_of(Hackney::Income::Domain::TenancySearchResult))
 
-      expect(subject[:number_of_pages]).to eq(number_of_pages)
+        expect(subject[:tenancies].first).to have_attributes(ref: '112345/35')
+        expect(subject[:tenancies].first).to have_attributes(property_ref: '00015378')
+        expect(subject[:tenancies].first).to have_attributes(tenure: 'SEC')
+        expect(subject[:tenancies].first).to have_attributes(current_balance: -15.89)
+        expect(subject[:tenancies].first).to have_attributes(primary_contact_name: 'Mrs S Smith                                                              ')
+        expect(subject[:tenancies].first).to have_attributes(primary_contact_short_address: '6 Fake Road 99 Wot Street')
+        expect(subject[:tenancies].first).to have_attributes(primary_contact_postcode: 'G9 0RX')
 
-      request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
-        headers: { 'X-Api-Key' => 'skeleton' },
-        query: url_params
-      )
+        expect(subject[:number_of_pages]).to eq(number_of_pages)
 
-      expect(request).to have_been_made
+        request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
+          headers: { 'X-Api-Key' => 'skeleton' },
+          query: url_params
+        )
+
+        expect(request).to have_been_made
+      end
+    end
+
+    context 'when searching with different params' do
+      let(:page) { 10 }
+      let(:page_size) { 1000 }
+      let(:search_term) { 'the house by the main road' }
+
+      it 'forwards all these params' do
+        expect(subject[:tenancies].size).to eq(10)
+        expect(subject[:tenancies]).to all(be_instance_of(Hackney::Income::Domain::TenancySearchResult))
+        expect(subject[:number_of_pages]).to eq(number_of_pages)
+        expect(subject[:number_of_results]).to eq(number_of_results)
+
+        request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
+          headers: { 'X-Api-Key' => 'skeleton' },
+          query: url_params
+        )
+        expect(request).to have_been_made
+      end
+    end
+
+    context 'when searching for something with no results' do
+      let(:tenancies_results) { [] }
+
+      it 'should return an empty array of items' do
+        expect(subject[:tenancies]).to eq([])
+        expect(subject[:number_of_pages]).to eq(number_of_pages)
+        expect(subject[:number_of_results]).to eq(number_of_results)
+
+        request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
+          headers: { 'X-Api-Key' => 'skeleton' },
+          query: url_params
+        )
+        expect(request).to have_been_made
+      end
+    end
+
+    context 'when there is some strange json' do
+      let(:tenancies_results_body) { '{}' }
+
+      it 'should return an empty array' do
+        expect(subject[:tenancies]).to eq([])
+
+        request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
+          headers: { 'X-Api-Key' => 'skeleton' },
+          query: url_params
+        )
+        expect(request).to have_been_made
+      end
     end
   end
 
-  context 'when searching with different params' do
-    let(:page) { 10 }
-    let(:page_size) { 1000 }
-    let(:search_term) { 'the house by the main road' }
-
-    it 'forwards all these params' do
-      expect(subject[:tenancies].size).to eq(10)
-      expect(subject[:tenancies]).to all(be_instance_of(Hackney::Income::Domain::TenancySearchResult))
-      expect(subject[:number_of_pages]).to eq(number_of_pages)
-      expect(subject[:number_of_results]).to eq(number_of_results)
-
-      request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
-        headers: { 'X-Api-Key' => 'skeleton' },
-        query: url_params
-      )
-      expect(request).to have_been_made
+  context 'when the tenancies api returns an error' do
+    before do
+      stub_request(:get, "https://example.com/api/v1/tenancies/search?#{URI.encode_www_form(url_params)}")
+      .to_return(status: 500)
     end
-  end
 
-  context 'when searching for something with no results' do
-    let(:tenancies_results) { [] }
-
-    it 'should return an empty array of items' do
-      expect(subject[:tenancies]).to eq([])
-      expect(subject[:number_of_pages]).to eq(number_of_pages)
-      expect(subject[:number_of_results]).to eq(number_of_results)
-
-      request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
-        headers: { 'X-Api-Key' => 'skeleton' },
-        query: url_params
+    it 'should throw an error' do
+      expect { subject }.to raise_error(
+        Exceptions::TenancyApiError,
+        "[Tenancy API error: Received 500 responce] when trying to search tenancies with 'https://example.com/api/v1/tenancies/search?#{URI.encode_www_form(url_params)}'"
       )
-      expect(request).to have_been_made
-    end
-  end
-
-  context 'when there is some strange json' do
-    let(:tenancies_results_body) { '{}' }
-
-    it 'should return an empty array' do
-      expect(subject[:tenancies]).to eq([])
-
-      request = a_request(:get, 'https://example.com/api/v1/tenancies/search').with(
-        headers: { 'X-Api-Key' => 'skeleton' },
-        query: url_params
-      )
-      expect(request).to have_been_made
     end
   end
 

--- a/spec/lib/hackney/income/transactions_gateway_spec.rb
+++ b/spec/lib/hackney/income/transactions_gateway_spec.rb
@@ -15,7 +15,7 @@ describe Hackney::Income::TransactionsGateway do
     end
 
     it 'should raise a IncomeApiError' do
-      expect { subject }.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 responce] when trying to get transactions_for with tenancy_ref '#{tenancy_ref}'")
+      expect { subject }.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 response] when trying to get transactions_for with tenancy_ref '#{tenancy_ref}'")
     end
   end
 

--- a/spec/lib/hackney/income/transactions_gateway_spec.rb
+++ b/spec/lib/hackney/income/transactions_gateway_spec.rb
@@ -1,9 +1,23 @@
+require 'rails_helper'
+
 describe Hackney::Income::TransactionsGateway do
   let(:transaction_gateway) { described_class.new(api_host: 'https://example.com/api', api_key: 'skeleton') }
   let(:transaction_endpoint) { 'https://example.com/api/tenancies/000123%2F01/payments' }
 
-  subject { transaction_gateway.transactions_for(tenancy_ref: '000123/01') }
+  let(:tenancy_ref) { '000123/01' }
+  subject { transaction_gateway.transactions_for(tenancy_ref: tenancy_ref) }
   alias_method :get_transactions, :subject
+
+  context 'when the api returns an error' do
+    before do
+      stub_request(:get, transaction_endpoint)
+      .to_return(status: 500)
+    end
+
+    it 'should raise a IncomeApiError' do
+      expect { subject }.to raise_error(Exceptions::IncomeApiError, "[Income API error: Received 500 responce] when trying to get transactions_for with tenancy_ref '#{tenancy_ref}'")
+    end
+  end
 
   context 'when retrieving all transactions for a tenancy with some' do
     before do


### PR DESCRIPTION
- Throw the corresponding IncomeApiError or TenancyApiError when receiving non 200 results for all API gateways
- Create a custom exception so that it's easy to tell what API is throwing errors
