### PR TITLE
Paused cases view

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -4,13 +4,13 @@ class TenanciesController < ApplicationController
       user_id: current_user_id,
       page_number: page_number,
       count_per_page: cases_per_page,
-      is_paused: is_paused
+      paused: paused?
     )
 
     @page_number = response.page_number
     @number_of_pages = response.number_of_pages
     @user_assigned_tenancies = valid_tenancies(response.tenancies)
-    @showing_paused_tenancies = response.is_paused
+    @showing_paused_tenancies = response.paused
   end
 
   def show
@@ -32,8 +32,8 @@ class TenanciesController < ApplicationController
     params.fetch(:page, 1).to_i
   end
 
-  def is_paused
-    ActiveModel::Type::Boolean.new.cast(params.fetch(:is_paused, false))
+  def paused?
+    ActiveModel::Type::Boolean.new.cast(params.fetch(:paused, false))
   end
 
   def cases_per_page

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -3,12 +3,14 @@ class TenanciesController < ApplicationController
     response = use_cases.list_user_assigned_cases.execute(
       user_id: current_user_id,
       page_number: page_number,
-      count_per_page: cases_per_page
+      count_per_page: cases_per_page,
+      is_paused: is_paused
     )
 
     @page_number = response.page_number
     @number_of_pages = response.number_of_pages
     @user_assigned_tenancies = valid_tenancies(response.tenancies)
+    @showing_paused_tenancies = response.is_paused
   end
 
   def show
@@ -28,6 +30,10 @@ class TenanciesController < ApplicationController
 
   def page_number
     params.fetch(:page, 1).to_i
+  end
+
+  def is_paused
+    ActiveModel::Type::Boolean.new.cast(params.fetch(:is_paused, false))
   end
 
   def cases_per_page

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Hackney Income Collection</title>
+    <% if content_for?(:title) %>
+      <title><%= yield(:title) %> - Income Collection</title>
+    <% else %>
+      <title>Hackney Income Collection</title>
+    <% end %>
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/tenancies/_worktray_table.html.erb
+++ b/app/views/tenancies/_worktray_table.html.erb
@@ -1,0 +1,120 @@
+<table class="tenancy_list">
+  <thead>
+  <tr>
+    <th>Ref No.</th>
+    <th>Tenant</th>
+    <th class="numeric">Balance</th>
+    <th>Last Action</th>
+    <th>Agreement</th>
+    <th>Priority</th>
+  </tr>
+  </thead>
+  <tbody>
+  <% tenancies_list.each do |tenancy| %>
+    <tr>
+      <td>
+        <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
+          <span class="tenancy_list__ref"><%= tenancy.ref %></span>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
+          <span class="tenancy_list__name"><strong><%= tenancy.primary_contact_name %></strong></span>
+          <span class="tenancy_list__address"><%= tenancy.primary_contact_short_address %></span>
+          <span class="tenancy_list__post_code"><%= tenancy.primary_contact_postcode %></span>
+        <% end %>
+      </td>
+      <td class="numeric">
+        <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
+          <span>£<%= number_with_precision(tenancy.current_balance, precision: 2) %></span>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
+          <span class="tenancy_list__latest_action_date"><%= tenancy.last_action_display_date %></span><br />
+          <span class="tenancy_list__latest_action_code"><strong><%= Hackney::Income::ActionDiaryEntryCodes.human_readable_action_code(tenancy.latest_action_code) %></strong></span>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
+          <span class="tenancy_list__ref"><%= human_agreement_status(tenancy.current_arrears_agreement_status) %></span>
+        <% end %>
+      </td>
+      <td>
+        <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
+            <span class="tenancy_list__item tenancy_list__item--<%= tenancy.band %>"><%= tenancy.score.to_i < 0 ? 0 : tenancy.score %>
+              <div class="tenancy_list__priority_tooltip">
+                <table class="tenancy_list__priority_table">
+                  <thead>
+                    <th>Criteria</th>
+                    <th>Amount</th>
+                    <th>Adjustment</th>
+                  </thead>
+                  <tbody>
+                    <%
+                      criteria = [
+                          {
+                              name: 'Balance',
+                              display_value: "£#{display_priority_value(number_with_precision(tenancy.current_balance, precision: 2))}",
+                              adjustment: tenancy.balance_contribution
+                          },
+                          {
+                              name: 'Days in arrears',
+                              display_value: "#{display_priority_value(tenancy.days_in_arrears)}",
+                              adjustment: tenancy.days_in_arrears_contribution
+                          },
+                          {
+                              name: 'Days since last payment',
+                              display_value: "#{display_priority_value(tenancy.days_since_last_payment)}",
+                              adjustment: tenancy.days_since_last_payment_contribution
+                          },
+                          {
+                              name: 'Difference in payment amounts for the last three payments',
+                              display_value: "£#{display_priority_value(tenancy.payment_amount_delta&.to_f&.abs)}",
+                              adjustment: tenancy.payment_amount_delta_contribution
+                          },
+                          {
+                              name: 'Time difference between last three payments',
+                              display_value: "#{display_priority_value(tenancy.payment_date_delta&.abs)} days",
+                              adjustment: tenancy.payment_date_delta_contribution
+                          },
+                          {
+                              name: 'Number of historic broken agreements',
+                              display_value: "#{display_priority_value(tenancy.number_of_broken_agreements)}",
+                              adjustment: tenancy.number_of_broken_agreements_contribution
+                          },
+                          {
+                              name: 'Broken court order status',
+                              display_value: "#{display_priority_value(tenancy.broken_court_order)}",
+                              adjustment: tenancy.broken_court_order_contribution
+                          },
+                          {
+                              name: 'NOSP (within the last year) status',
+                              display_value: "#{display_priority_value(tenancy.nosp_served)}",
+                              adjustment: tenancy.nosp_served_contribution
+                          },
+                          {
+                              name: 'NOSP (within the last month) status',
+                              display_value: "#{display_priority_value(tenancy.active_nosp)}",
+                              adjustment: tenancy.active_nosp_contribution
+                          }
+                      ]
+                    %>
+
+                    <% sorted_priority_criteria(criteria).each do |criteria| %>
+                      <tr>
+                        <td><%= criteria.fetch(:name) %></td>
+                        <td><%= criteria.fetch(:display_value) %></td>
+                        <td><%= display_priority_adjustment(criteria.fetch(:adjustment)) %></td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </span>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/tenancies/index.html.erb
+++ b/app/views/tenancies/index.html.erb
@@ -7,7 +7,7 @@
   <% content_for :title do %>Active - Worktray<% end %>
   <h2>Your Worktray</h2>
   <a id="active">Active</a>
-  <%= link_to 'Paused', worktray_path(is_paused: true), id: 'paused' %>
+  <%= link_to 'Paused', worktray_path(paused: true), id: 'paused' %>
 <% end %>
 
 <% if @user_assigned_tenancies.none? %>

--- a/app/views/tenancies/index.html.erb
+++ b/app/views/tenancies/index.html.erb
@@ -1,134 +1,26 @@
-<h2>Your Worktray</h2>
+<% if @showing_paused_tenancies %>
+  <% content_for :title do %>Paused - Worktray<% end %>
+  <h2>Your paused cases</h2>
+  <%= link_to 'Active', worktray_path, id: 'active' %>
+  <a id="paused">Paused</a>
+<% else %>
+  <% content_for :title do %>Active - Worktray<% end %>
+  <h2>Your Worktray</h2>
+  <a id="active">Active</a>
+  <%= link_to 'Paused', worktray_path(is_paused: true), id: 'paused' %>
+<% end %>
 
 <% if @user_assigned_tenancies.none? %>
 <h3>You currently have no assigned cases</h3>
 <% else %>
-<table class="tenancy_list">
-  <thead>
-    <tr>
-      <th>Ref No.</th>
-      <th>Tenant</th>
-      <th class="numeric">Balance</th>
-      <th>Last Action</th>
-      <th>Agreement</th>
-      <th>Priority</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @user_assigned_tenancies.each do |tenancy| %>
-      <tr>
-        <td>
-          <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
-            <span class="tenancy_list__ref"><%= tenancy.ref %></span>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
-            <span class="tenancy_list__name"><strong><%= tenancy.primary_contact_name %></strong></span>
-            <span class="tenancy_list__address"><%= tenancy.primary_contact_short_address %></span>
-            <span class="tenancy_list__post_code"><%= tenancy.primary_contact_postcode %></span>
-          <% end %>
-        </td>
-        <td class="numeric">
-          <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
-            <span>£<%= number_with_precision(tenancy.current_balance, precision: 2) %></span>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
-            <span class="tenancy_list__latest_action_date"><%= tenancy.last_action_display_date %></span><br />
-            <span class="tenancy_list__latest_action_code"><strong><%= Hackney::Income::ActionDiaryEntryCodes.human_readable_action_code(tenancy.latest_action_code) %></strong></span>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
-            <span class="tenancy_list__ref"><%= human_agreement_status(tenancy.current_arrears_agreement_status) %></span>
-          <% end %>
-        </td>
-        <td>
-          <%= link_to(tenancy_path(id: tenancy.ref), class: 'tenancy_list__link') do %>
-            <span class="tenancy_list__item tenancy_list__item--<%= tenancy.band %>"><%= tenancy.score.to_i < 0 ? 0 : tenancy.score %>
-              <div class="tenancy_list__priority_tooltip">
-                <table class="tenancy_list__priority_table">
-                  <thead>
-                    <th>Criteria</th>
-                    <th>Amount</th>
-                    <th>Adjustment</th>
-                  </thead>
-                  <tbody>
-                    <%
-                      criteria = [
-                        {
-                          name: 'Balance',
-                          display_value: "£#{display_priority_value(number_with_precision(tenancy.current_balance, precision: 2))}",
-                          adjustment: tenancy.balance_contribution
-                        },
-                        {
-                          name: 'Days in arrears',
-                          display_value: "#{display_priority_value(tenancy.days_in_arrears)}",
-                          adjustment: tenancy.days_in_arrears_contribution
-                        },
-                        {
-                          name: 'Days since last payment',
-                          display_value: "#{display_priority_value(tenancy.days_since_last_payment)}",
-                          adjustment: tenancy.days_since_last_payment_contribution
-                        },
-                        {
-                          name: 'Difference in payment amounts for the last three payments',
-                          display_value: "£#{display_priority_value(tenancy.payment_amount_delta&.to_f&.abs)}",
-                          adjustment: tenancy.payment_amount_delta_contribution
-                        },
-                        {
-                          name: 'Time difference between last three payments',
-                          display_value: "#{display_priority_value(tenancy.payment_date_delta&.abs)} days",
-                          adjustment: tenancy.payment_date_delta_contribution
-                        },
-                        {
-                          name: 'Number of historic broken agreements',
-                          display_value: "#{display_priority_value(tenancy.number_of_broken_agreements)}",
-                          adjustment: tenancy.number_of_broken_agreements_contribution
-                        },
-                        {
-                          name: 'Broken court order status',
-                          display_value: "#{display_priority_value(tenancy.broken_court_order)}",
-                          adjustment: tenancy.broken_court_order_contribution
-                        },
-                        {
-                          name: 'NOSP (within the last year) status',
-                          display_value: "#{display_priority_value(tenancy.nosp_served)}",
-                          adjustment: tenancy.nosp_served_contribution
-                        },
-                        {
-                          name: 'NOSP (within the last month) status',
-                          display_value: "#{display_priority_value(tenancy.active_nosp)}",
-                          adjustment: tenancy.active_nosp_contribution
-                        }
-                      ]
-                    %>
 
-                    <% sorted_priority_criteria(criteria).each do |criteria| %>
-                      <tr>
-                        <td><%= criteria.fetch(:name) %></td>
-                        <td><%= criteria.fetch(:display_value) %></td>
-                        <td><%= display_priority_adjustment(criteria.fetch(:adjustment)) %></td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
-            </span>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render :partial => 'worktray_table', locals: { tenancies_list: @user_assigned_tenancies } %>
 
 <%=
   render 'common/pagination',
     page_number: @page_number,
     number_of_pages: @number_of_pages,
-    previous_page_path: root_path(page: @page_number - 1),
-    next_page_path: root_path(page: @page_number + 1)
+    previous_page_path: worktray_path(page: @page_number - 1),
+    next_page_path: worktray_path(page: @page_number + 1)
 %>
 <% end %>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title do %><%= @tenancy.ref%> - Tenancy<% end %>
+
 <div class="grid-row">
   <div class="column-full">
     <%= link_to('Return back to your worktray', root_path, class: 'link--back') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root to: 'tenancies#index'
+  root to: redirect('/worktray')
+
+  get '/worktray', to: 'tenancies#index'
+
   get '/search', to: 'search_tenancies#show'
 
   get '/tenancies/:id', to: 'tenancies#show', as: :tenancy

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -11,13 +11,13 @@ module Hackney
         @api_key = api_key
       end
 
-      def get_tenancies(user_id:, page_number:, number_per_page:, is_paused: nil)
+      def get_tenancies(user_id:, page_number:, number_per_page:, paused: nil)
         uri = URI("#{@api_host}/my-cases")
         uri.query = URI.encode_www_form(
           'user_id' => user_id,
           'page_number' => page_number,
           'number_per_page' => number_per_page,
-          'is_paused' => is_paused
+          'is_paused' => paused
         )
 
         req = Net::HTTP::Get.new(uri)

--- a/lib/hackney/income/list_user_assigned_cases.rb
+++ b/lib/hackney/income/list_user_assigned_cases.rb
@@ -1,21 +1,21 @@
 module Hackney
   module Income
     class ListUserAssignedCases
-      Response = Struct.new(:tenancies, :page_number, :number_of_pages)
+      Response = Struct.new(:tenancies, :is_paused, :page_number, :number_of_pages)
 
       def initialize(tenancy_gateway:)
         @tenancy_gateway = tenancy_gateway
       end
 
-      def execute(user_id:, page_number: nil, count_per_page: nil)
+      def execute(user_id:, page_number: nil, count_per_page: nil, is_paused: nil)
         get_tenancies_response = @tenancy_gateway.get_tenancies(
           user_id: user_id,
           page_number: page_number,
           number_per_page: count_per_page,
-          is_paused: false
+          is_paused: is_paused
         )
 
-        Response.new(get_tenancies_response.tenancies, page_number, get_tenancies_response.number_of_pages)
+        Response.new(get_tenancies_response.tenancies, is_paused, page_number, get_tenancies_response.number_of_pages)
       end
     end
   end

--- a/lib/hackney/income/list_user_assigned_cases.rb
+++ b/lib/hackney/income/list_user_assigned_cases.rb
@@ -1,21 +1,21 @@
 module Hackney
   module Income
     class ListUserAssignedCases
-      Response = Struct.new(:tenancies, :is_paused, :page_number, :number_of_pages)
+      Response = Struct.new(:tenancies, :paused, :page_number, :number_of_pages)
 
       def initialize(tenancy_gateway:)
         @tenancy_gateway = tenancy_gateway
       end
 
-      def execute(user_id:, page_number: nil, count_per_page: nil, is_paused: nil)
+      def execute(user_id:, page_number: nil, count_per_page: nil, paused: nil)
         get_tenancies_response = @tenancy_gateway.get_tenancies(
           user_id: user_id,
           page_number: page_number,
           number_per_page: count_per_page,
-          is_paused: is_paused
+          paused: paused
         )
 
-        Response.new(get_tenancies_response.tenancies, is_paused, page_number, get_tenancies_response.number_of_pages)
+        Response.new(get_tenancies_response.tenancies, paused, page_number, get_tenancies_response.number_of_pages)
       end
     end
   end

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -1,7 +1,7 @@
 module Hackney
   module Income
     class StubTenancyGatewayBuilder
-      GetTenanciesResponse = Struct.new(:tenancies, :is_paused, :page_number, :number_of_pages)
+      GetTenanciesResponse = Struct.new(:tenancies, :paused, :page_number, :number_of_pages)
 
       class << self
         def build_stub(with_tenancies: DEFAULT_TENANCIES)
@@ -20,13 +20,13 @@ module Hackney
               @tenancies = default_tenancies
             end
 
-            def get_tenancies(user_id:, page_number:, number_per_page:, is_paused: nil)
+            def get_tenancies(user_id:, page_number:, number_per_page:, paused: nil)
               cases = @tenancies
                 .select { |t| t.fetch(:assigned_user_id) == user_id }
                 .map(&method(:create_tenancy_list_item))
 
               number_of_pages = (cases.count.to_f / number_per_page).ceil
-              GetTenanciesResponse.new(cases, is_paused, page_number, number_of_pages)
+              GetTenanciesResponse.new(cases, paused, page_number, number_of_pages)
             end
 
             def get_tenancy(tenancy_ref:)

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -1,7 +1,7 @@
 module Hackney
   module Income
     class StubTenancyGatewayBuilder
-      GetTenanciesResponse = Struct.new(:tenancies, :number_of_pages)
+      GetTenanciesResponse = Struct.new(:tenancies, :is_paused, :page_number, :number_of_pages)
 
       class << self
         def build_stub(with_tenancies: DEFAULT_TENANCIES)
@@ -25,7 +25,8 @@ module Hackney
                 .select { |t| t.fetch(:assigned_user_id) == user_id }
                 .map(&method(:create_tenancy_list_item))
 
-              GetTenanciesResponse.new(cases, (cases.count.to_f / number_per_page).ceil)
+              number_of_pages = (cases.count.to_f / number_per_page).ceil
+              GetTenanciesResponse.new(cases, is_paused, page_number, number_of_pages)
             end
 
             def get_tenancy(tenancy_ref:)

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -23,7 +23,7 @@ describe TenanciesController do
     end
 
     it 'should pass filter params to the ListUserAssignedCases use case' do
-      expected_filter_args = { user_id: 123, page_number: 1, count_per_page: 20, is_paused: false }
+      expected_filter_args = { user_id: 123, page_number: 1, count_per_page: 20, paused: false }
 
       expect_any_instance_of(Hackney::Income::ListUserAssignedCases)
         .to receive(:execute)
@@ -42,7 +42,7 @@ describe TenanciesController do
     it 'should inform the template not showing paused cases' do
       allow_any_instance_of(Hackney::Income::ListUserAssignedCases)
         .to receive(:execute)
-            .with({ user_id: 123, page_number: 1, count_per_page: 20, is_paused: false })
+            .with(user_id: 123, page_number: 1, count_per_page: 20, paused: false)
             .and_call_original
 
       get :index
@@ -52,7 +52,7 @@ describe TenanciesController do
 
     context 'when visiting page two' do
       it 'should pass filter params for page two to the ListUserAssignedCases use case' do
-        expected_filter_args = { user_id: 123, page_number: 2, count_per_page: 20, is_paused: false }
+        expected_filter_args = { user_id: 123, page_number: 2, count_per_page: 20, paused: false }
 
         expect_any_instance_of(Hackney::Income::ListUserAssignedCases)
           .to receive(:execute)
@@ -72,10 +72,10 @@ describe TenanciesController do
       it 'should show a list of only paused tenancies when requested' do
         expect_any_instance_of(Hackney::Income::ListUserAssignedCases)
         .to receive(:execute)
-            .with(user_id: 123, page_number: 1, count_per_page: 20, is_paused: true)
+            .with(user_id: 123, page_number: 1, count_per_page: 20, paused: true)
             .and_call_original
 
-        get :index, params: { is_paused: true }
+        get :index, params: { paused: true }
 
         expect(assigns(:showing_paused_tenancies)).to eq(true)
         expect(assigns(:user_assigned_tenancies)).to all(be_instance_of(Hackney::Income::Domain::TenancyListItem))

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -80,7 +80,7 @@ describe 'Authentication' do
   end
 
   def then_they_should_be_taken_to_the_homepage_and_acknowledged
-    expect(page.current_path).to eq('/')
+    expect(page.current_path).to eq('/worktray')
     expect(page).to have_content(info_hash.fetch('name'))
   end
 

--- a/spec/features/view_my_cases_spec.rb
+++ b/spec/features/view_my_cases_spec.rb
@@ -11,6 +11,13 @@ describe 'Viewing My Cases' do
     then_i_should_see_cases_assigned_to_me
   end
 
+  scenario do
+    given_i_am_logged_in
+    when_i_visit_the_homepage
+    when_i_click_on_the_paused_tab
+    then_i_should_see_paused_cases
+  end
+
   def given_i_am_logged_in
     visit '/auth/azureactivedirectory'
   end
@@ -19,7 +26,16 @@ describe 'Viewing My Cases' do
     visit '/'
   end
 
+  def when_i_click_on_the_paused_tab
+    click_link 'paused'
+  end
+
+  def then_i_should_see_paused_cases
+    expect(page.body).to have_css('h2', text: 'Your paused cases', count: 1)
+  end
+
   def then_i_should_see_cases_assigned_to_me
+    expect(page.body).to have_css('h2', text: 'Your Worktray', count: 1)
     expect(page.body).to have_content('TEST/01')
     expect(page.body).to have_content('TEST/02')
   end

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -7,14 +7,14 @@ describe Hackney::Income::LessDangerousTenancyGateway do
     let(:user_id) { Faker::Number.number(2).to_i }
     let(:page_number) { Faker::Number.number(2).to_i }
     let(:number_per_page) { Faker::Number.number(2).to_i }
-    let(:is_paused) { false }
+    let(:paused) { false }
 
     subject do
       tenancy_gateway.get_tenancies(
         user_id: user_id,
         page_number: page_number,
         number_per_page: number_per_page,
-        is_paused: is_paused
+        paused: paused
       )
     end
 
@@ -52,7 +52,7 @@ describe Hackney::Income::LessDangerousTenancyGateway do
             'user_id' => user_id,
             'page_number' => page_number,
             'number_per_page' => number_per_page,
-            'is_paused' => is_paused
+            'is_paused' => paused
           }
         )
 

--- a/spec/lib/hackney/income/list_user_assigned_cases_spec.rb
+++ b/spec/lib/hackney/income/list_user_assigned_cases_spec.rb
@@ -4,15 +4,17 @@ describe Hackney::Income::ListUserAssignedCases do
   let(:tenancy_gateway) { Hackney::Income::StubTenancyGatewayBuilder.build_stub(with_tenancies: tenancies).new }
   let(:tenancies) { [] }
   let(:user_id) { Faker::Number.number(2).to_i }
+  let(:is_paused) { Faker::Boolean.boolean }
   let(:page_number) { Faker::Number.number(2).to_i }
   let(:number_per_page) { Faker::Number.number(2).to_i }
+  let(:number_of_pages) { (tenancies.count.to_f / number_per_page).ceil }
 
   let(:list_cases) { described_class.new(tenancy_gateway: tenancy_gateway) }
 
-  subject { list_cases.execute(user_id: user_id, page_number: page_number, count_per_page: number_per_page) }
+  subject { list_cases.execute(user_id: user_id, page_number: page_number, count_per_page: number_per_page, is_paused: is_paused) }
 
   it 'should query the tenancy gateway for cases for the given user, on that page' do
-    expected_args = { user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: false }
+    expected_args = { user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: is_paused }
     expect(tenancy_gateway).to receive(:get_tenancies).with(expected_args).and_call_original
 
     subject
@@ -30,6 +32,15 @@ describe Hackney::Income::ListUserAssignedCases do
     let(:case_attributes) { generate_tenancy }
     let(:tenancy_ref) { case_attributes.fetch(:tenancy_ref) }
     let(:tenancies) { [case_attributes] }
+
+    it 'should return expected params' do
+      expect(subject.tenancies.count).to eq(tenancies.count)
+      expect(subject).to have_attributes(
+        is_paused: is_paused,
+        page_number: page_number,
+        number_of_pages: number_of_pages
+      )
+    end
 
     it 'should return Hackney::Income::Domain::TenancyListItem objects' do
       expect(subject.tenancies).to all(be_kind_of(Hackney::Income::Domain::TenancyListItem))

--- a/spec/lib/hackney/income/list_user_assigned_cases_spec.rb
+++ b/spec/lib/hackney/income/list_user_assigned_cases_spec.rb
@@ -4,17 +4,17 @@ describe Hackney::Income::ListUserAssignedCases do
   let(:tenancy_gateway) { Hackney::Income::StubTenancyGatewayBuilder.build_stub(with_tenancies: tenancies).new }
   let(:tenancies) { [] }
   let(:user_id) { Faker::Number.number(2).to_i }
-  let(:is_paused) { Faker::Boolean.boolean }
+  let(:paused) { Faker::Boolean.boolean }
   let(:page_number) { Faker::Number.number(2).to_i }
   let(:number_per_page) { Faker::Number.number(2).to_i }
   let(:number_of_pages) { (tenancies.count.to_f / number_per_page).ceil }
 
   let(:list_cases) { described_class.new(tenancy_gateway: tenancy_gateway) }
 
-  subject { list_cases.execute(user_id: user_id, page_number: page_number, count_per_page: number_per_page, is_paused: is_paused) }
+  subject { list_cases.execute(user_id: user_id, page_number: page_number, count_per_page: number_per_page, paused: paused) }
 
   it 'should query the tenancy gateway for cases for the given user, on that page' do
-    expected_args = { user_id: user_id, page_number: page_number, number_per_page: number_per_page, is_paused: is_paused }
+    expected_args = { user_id: user_id, page_number: page_number, number_per_page: number_per_page, paused: paused }
     expect(tenancy_gateway).to receive(:get_tenancies).with(expected_args).and_call_original
 
     subject
@@ -36,7 +36,7 @@ describe Hackney::Income::ListUserAssignedCases do
     it 'should return expected params' do
       expect(subject.tenancies.count).to eq(tenancies.count)
       expect(subject).to have_attributes(
-        is_paused: is_paused,
+        paused: paused,
         page_number: page_number,
         number_of_pages: number_of_pages
       )


### PR DESCRIPTION
- Worktray lives now at '/worktray' and root redirects there
- There are a set of buttons (soon to be tabs) that switch between showing paused and active cases
<img width="562" alt="image" src="https://user-images.githubusercontent.com/8915854/47425291-d0e19d80-d781-11e8-81b6-3e10cf869922.png">

