### PR TITLE
Ability to pause cases

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -15,6 +15,10 @@ class TenanciesController < ApplicationController
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
   end
 
+  def pause
+    @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
+  end
+
   private
 
   # FIXME: stop filtering here, improve contact details

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -18,7 +18,13 @@ class TenanciesController < ApplicationController
   end
 
   def update
-    @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
+    use_cases.update_tenancy.execute(
+      tenancy_ref: params.fetch(:id),
+      is_paused_until: params.fetch(:is_paused_until)
+    )
+
+    flash[:notice] = 'Successfully paused'
+    redirect_to tenancy_path(id: params.fetch(:id))
   end
 
   private

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -17,7 +17,7 @@ class TenanciesController < ApplicationController
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
   end
 
-  def pause
+  def update
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
   end
 

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -18,12 +18,13 @@ class TenanciesController < ApplicationController
   end
 
   def update
-    use_cases.update_tenancy.execute(
+    response = use_cases.update_tenancy.execute(
       tenancy_ref: params.fetch(:id),
       is_paused_until: params.fetch(:is_paused_until)
     )
 
-    flash[:notice] = 'Successfully paused'
+    flash[:notice] = response.code == 204 ? 'Successfully paused' : "Unable to pause: #{response.message}"
+
     redirect_to tenancy_path(id: params.fetch(:id))
   end
 

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -11,7 +11,7 @@
     <%= render('common/tenancy_header') %>
   </div>
   <div class="column-full">
-    <%= form_tag(update_path, method: :patch) do -%>
+    <%= form_tag(tenancy_path, method: :patch) do -%>
       <%= label_tag(:is_paused_until, 'Pause this case until:') %>
       <%= date_field_tag :is_paused_until, Date.today, class: 'form-control' %>
       <%= submit_tag 'Save', class: 'button' %>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -10,6 +10,13 @@
   <div class="column-two-thirds">
     <%= render('common/tenancy_header') %>
   </div>
+  <div class="column-full">
+    <%= form_tag(update_path, method: :patch) do -%>
+      <%= label_tag(:is_paused_until, 'Pause this case until:') %>
+      <%= date_field_tag :is_paused_until, Date.today, class: 'form-control' %>
+      <%= submit_tag 'Save', class: 'button' %>
+    <% end -%>
+  </div>
 </div>
 
 <div class="grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get '/search', to: 'search_tenancies#show'
 
   get '/tenancies/:id', to: 'tenancies#show', as: :tenancy
-  post '/tenancies/:id', to: 'tenancies#pause', as: :pause
+  patch '/tenancies/:id', to: 'tenancies#update', as: :update
   get '/tenancies/:id/sms', to: 'tenancies_sms#show', as: :tenancy_sms
   post '/tenancies/:id/sms', to: 'tenancies_sms#create', as: :create_tenancy_sms
   get '/tenancies/:id/email', to: 'tenancies_email#show', as: :tenancy_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get '/search', to: 'search_tenancies#show'
 
   get '/tenancies/:id', to: 'tenancies#show', as: :tenancy
+  post '/tenancies/:id', to: 'tenancies#pause', as: :pause
   get '/tenancies/:id/sms', to: 'tenancies_sms#show', as: :tenancy_sms
   post '/tenancies/:id/sms', to: 'tenancies_sms#create', as: :create_tenancy_sms
   get '/tenancies/:id/email', to: 'tenancies_email#show', as: :tenancy_email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get '/search', to: 'search_tenancies#show'
 
   get '/tenancies/:id', to: 'tenancies#show', as: :tenancy
-  patch '/tenancies/:id', to: 'tenancies#update', as: :update
+  patch '/tenancies/:id', to: 'tenancies#update'
   get '/tenancies/:id/sms', to: 'tenancies_sms#show', as: :tenancy_sms
   post '/tenancies/:id/sms', to: 'tenancies_sms#create', as: :create_tenancy_sms
   get '/tenancies/:id/email', to: 'tenancies_email#show', as: :tenancy_email

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -113,7 +113,8 @@ module Hackney
         req = Net::HTTP::Patch.new(uri)
         req['X-Api-Key'] = @api_key
 
-        Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+        res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+        res
       end
 
       def get_contacts_for(tenancy_ref:)

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -104,6 +104,18 @@ module Hackney
         tenancy_item
       end
 
+      def update_tenancy(tenancy_ref:, is_paused_until:)
+        uri = URI("#{@api_host}/tenancies/#{ERB::Util.url_encode(tenancy_ref)}")
+        uri.query = URI.encode_www_form(
+          is_paused_until: is_paused_until
+        )
+
+        req = Net::HTTP::Patch.new(uri)
+        req['X-Api-Key'] = @api_key
+
+        Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) { |http| http.request(req) }
+      end
+
       def get_contacts_for(tenancy_ref:)
         uri = URI("#{@api_host}/tenancies/#{ERB::Util.url_encode(tenancy_ref)}/contacts")
 

--- a/lib/hackney/income/less_dangerous_tenancy_gateway.rb
+++ b/lib/hackney/income/less_dangerous_tenancy_gateway.rb
@@ -105,7 +105,7 @@ module Hackney
       end
 
       def update_tenancy(tenancy_ref:, is_paused_until:)
-        uri = URI("#{@api_host}/tenancies/#{ERB::Util.url_encode(tenancy_ref)}")
+        uri = URI.parse(File.join(@api_host, "/tenancies/#{ERB::Util.url_encode(tenancy_ref)}"))
         uri.query = URI.encode_www_form(
           is_paused_until: is_paused_until
         )

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -10,7 +10,22 @@ module Hackney
           end
         end
 
+        def build_failing_stub(with_tenancies: DEFAULT_TENANCIES)
+          build_failing_class.tap {}
+        end
+
         private
+
+        def build_failing_class
+          Class.new do
+
+            def initialize(api_host: nil, api_key: nil, include_developer_data: nil); end
+
+            def update_tenancy(tenancy_ref:, is_paused_until:)
+              Net::HTTPClientError.new(1.1, 500, 'Internal server error')
+            end
+          end
+        end
 
         def build_gateway_class
           Class.new do
@@ -37,6 +52,7 @@ module Hackney
             def update_tenancy(tenancy_ref:, is_paused_until:)
               tenancy = @tenancies.select { |t| t[:tenancy_ref] == tenancy_ref }.first
               create_tenancy(tenancy)
+              Net::HTTPNoContent.new(1.1, 204, nil)
             end
 
             def get_contacts_for(tenancy_ref:)

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -18,7 +18,6 @@ module Hackney
 
         def build_failing_class
           Class.new do
-
             def initialize(api_host: nil, api_key: nil, include_developer_data: nil); end
 
             def update_tenancy(tenancy_ref:, is_paused_until:)

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -34,6 +34,11 @@ module Hackney
               create_tenancy(tenancy)
             end
 
+            def update_tenancy(tenancy_ref:, is_paused_until:)
+              tenancy = @tenancies.select { |t| t[:tenancy_ref] == tenancy_ref }.first
+              create_tenancy(tenancy)
+            end
+
             def get_contacts_for(tenancy_ref:)
               [
                 generate_contact

--- a/lib/hackney/income/update_tenancy.rb
+++ b/lib/hackney/income/update_tenancy.rb
@@ -1,6 +1,3 @@
-require 'date'
-require 'ostruct'
-
 module Hackney
   module Income
     class UpdateTenancy

--- a/lib/hackney/income/update_tenancy.rb
+++ b/lib/hackney/income/update_tenancy.rb
@@ -1,0 +1,16 @@
+require 'date'
+require 'ostruct'
+
+module Hackney
+  module Income
+    class UpdateTenancy
+      def initialize(tenancy_gateway:)
+        @tenancy_gateway = tenancy_gateway
+      end
+
+      def execute(tenancy_ref:, is_paused_until:)
+        @tenancy_gateway.update_tenancy(tenancy_ref: tenancy_ref, is_paused_until: is_paused_until)
+      end
+    end
+  end
+end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -22,6 +22,12 @@ module Hackney
         )
       end
 
+      def update_tenancy
+        Hackney::Income::UpdateTenancy.new(
+          tenancy_gateway: tenancy_gateway
+        )
+      end
+
       def view_actions
         Hackney::Income::ViewActions.new(
           actions_gateway: action_diary_gateway

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -24,7 +24,7 @@ module Hackney
 
       def update_tenancy
         Hackney::Income::UpdateTenancy.new(
-          tenancy_gateway: tenancy_gateway
+          tenancy_gateway: income_tenancy_gateway
         )
       end
 

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -94,9 +94,9 @@ describe TenanciesController do
     end
   end
 
-  context '#pause' do
-    it 'should pause a tenancy case' do
-      post :pause, params: { id: 1234567, until_date: Faker::Date.forward(23)}
+  context '#update' do
+    it 'should update tenancy is_paused_until field' do
+      patch :update, params: { id: 1234567, until_date: Faker::Date.forward(23)}
 
       expect(assigns(:tenancy)).to be_present
       expect(assigns(:tenancy)).to be_instance_of(Hackney::Income::Domain::Tenancy)

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -95,12 +95,37 @@ describe TenanciesController do
   end
 
   context '#update' do
-    it 'should update tenancy is_paused_until field' do
-      patch :update, params: { id: 1234567, until_date: Faker::Date.forward(23)}
+    let(:future_date_param) { Faker::Date.forward(23).to_s }
+    let(:tenancy_ref) { '1234567' }
 
-      expect(assigns(:tenancy)).to be_present
-      expect(assigns(:tenancy)).to be_instance_of(Hackney::Income::Domain::Tenancy)
-      expect(assigns(:tenancy)).to be_valid
+    it 'should call the update tenancy use case correctly' do
+      expect_any_instance_of(Hackney::Income::UpdateTenancy).to receive(:execute).with(
+        tenancy_ref: tenancy_ref,
+        is_paused_until: future_date_param
+      )
+
+      patch :update, params: {
+          id: tenancy_ref,
+          is_paused_until: future_date_param
+      }
+    end
+
+    it 'should call redirect me to the tenancy page' do
+      patch :update, params: {
+          id: tenancy_ref,
+          is_paused_until: future_date_param
+      }
+
+      expect(response).to redirect_to(tenancy_path(id: tenancy_ref))
+    end
+
+    it 'should show me a success message' do
+      patch :update, params: {
+          id: tenancy_ref,
+          is_paused_until: future_date_param
+      }
+
+      expect(flash[:notice]).to eq('Successfully paused')
     end
   end
 end

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -129,7 +129,6 @@ describe TenanciesController do
     end
 
     context 'when an update is unsuccessful' do
-
       before do
         stub_const('Hackney::Income::LessDangerousTenancyGateway', Hackney::Income::StubTenancyGatewayBuilder.build_failing_stub)
       end

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -73,4 +73,14 @@ describe TenanciesController do
       expect(assigns(:tenancy)).to be_valid
     end
   end
+
+  context '#pause' do
+    it 'should pause a tenancy case' do
+      post :pause, params: { id: 1234567, until_date: Faker::Date.forward(23)}
+
+      expect(assigns(:tenancy)).to be_present
+      expect(assigns(:tenancy)).to be_instance_of(Hackney::Income::Domain::Tenancy)
+      expect(assigns(:tenancy)).to be_valid
+    end
+  end
 end

--- a/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
+++ b/spec/lib/hackney/income/less_dangerous_tenancy_gateway_spec.rb
@@ -374,6 +374,23 @@ describe Hackney::Income::LessDangerousTenancyGateway do
       end
     end
   end
+
+  context 'when updating a tenancy' do
+    context 'successfully updates a tenancy' do
+      let(:future_date_param) { Faker::Date.forward(23).to_s }
+      let(:tenancy_ref) { Faker::Lorem.characters(6) }
+
+      before do
+        stub_request(:patch, "https://example.com/api/tenancies/#{tenancy_ref}?is_paused_until=#{future_date_param}")
+            .to_return(status: [204, :no_content])
+      end
+
+      it 'should return HTTPNoContent' do
+        expect(tenancy_gateway.update_tenancy(tenancy_ref: tenancy_ref, is_paused_until: future_date_param))
+            .to be_instance_of(Net::HTTPNoContent)
+      end
+    end
+  end
 end
 
 def action_diary_event

--- a/spec/lib/hackney/income/update_tenancy_spec.rb
+++ b/spec/lib/hackney/income/update_tenancy_spec.rb
@@ -1,0 +1,24 @@
+describe Hackney::Income::UpdateTenancy do
+  let(:tenancy_gateway) { Hackney::Income::StubTenancyGatewayBuilder.build_stub.new }
+
+  let(:params) do
+    {
+        tenancy_ref: Faker::Lorem.characters(6),
+        is_paused_until: Faker::Date.forward(23)
+    }
+  end
+
+  subject { described_class.new(tenancy_gateway: tenancy_gateway) }
+
+  it 'should pass the required data through to the gateway' do
+    expect(tenancy_gateway).to receive(:update_tenancy).with(
+      tenancy_ref: params.fetch(:tenancy_ref),
+      is_paused_until: params.fetch(:is_paused_until)
+    )
+
+    subject.execute(
+      tenancy_ref: params.fetch(:tenancy_ref),
+      is_paused_until: params.fetch(:is_paused_until)
+    )
+  end
+end


### PR DESCRIPTION

<img width="1050" alt="screenshot 2018-10-30 at 11 11 31" src="https://user-images.githubusercontent.com/8051117/47714373-9752db80-dc34-11e8-81dc-502ff1f33b4b.png">


The ability to pause can be accessed via the `/tenancies/[id]` page:
- Setting the date to a future date pauses the case, meaning that it can only be accessed via the `paused` tab. 
- Setting the date to a past date unpauses the case, meaning that it can be accessed via the worktray