### PR TITLE
Remove worker

### DIFF
--- a/config/initializers/schedule_jobs.rb
+++ b/config/initializers/schedule_jobs.rb
@@ -1,5 +1,6 @@
 if defined?(Rails::Server)
   # This sets up these scheduled tasks for the first time if they haven't already been queued, when booting the application server.
 
+  # FIXME: This file will also need to be moved to the IC API
   Delayed::Worker.logger = ActiveSupport::Logger.new(STDOUT)
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,6 @@ services:
       - 3000:3000
     links:
       - db
-      - worker
-  worker:
-    build: .
-    command: 'rake jobs:work'
-    volumes:
-      - .:/app
-    environment:
-      - DATABASE_USERNAME=root
-      - DATABASE_PASSWORD=root
-      - DATABASE_HOST=db
-      - DATABASE_PORT=3306
-    links:
-      - db
   db:
     image: mysql:8.0.11
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/lib/hackney/income/scheduler_gateway.rb
+++ b/lib/hackney/income/scheduler_gateway.rb
@@ -1,3 +1,6 @@
+# FIXME: this is no longer used, but will need to be migrated to the IC API. It schedules jobs to
+# resolve events, like scheduling an SMS to be sent.
+
 module Hackney
   module Income
     class SchedulerGateway

--- a/lib/hackney/income/sql_events_gateway.rb
+++ b/lib/hackney/income/sql_events_gateway.rb
@@ -1,3 +1,4 @@
+# FIXME: this file is used to schedule events using the local db, to be moved to IC API
 module Hackney
   module Income
     class SqlEventsGateway


### PR DESCRIPTION
Remove the docker image as it can spawn logs that are totally unnecessary.
Document some files that I don't want to remove yet, but will be moved to the IC API in time when events are scheduled on the API.