### PR TITLE
hotfixing notifications on the client side

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -23,7 +23,7 @@ class TenanciesController < ApplicationController
       is_paused_until: params.fetch(:is_paused_until)
     )
 
-    flash[:notice] = response.code == 204 ? 'Successfully paused' : "Unable to pause: #{response.message}"
+    flash[:notice] = response.code.to_i == 204 ? 'Successfully paused' : "Unable to pause: #{response.message}"
 
     redirect_to tenancy_path(id: params.fetch(:id))
   end


### PR DESCRIPTION
<img width="1016" alt="screenshot 2018-10-31 at 11 58 29" src="https://user-images.githubusercontent.com/8051117/47786673-69d56300-dd04-11e8-9ac6-10a1124dad44.png">

Making sure that a successful message is shown when a no content response is received 