### PR TITLE
Manually send a text message via gov notify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 gem 'faker'
+gem 'phonelib'
 
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
+    phonelib (0.6.27)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -327,6 +328,7 @@ DEPENDENCIES
   notifications-ruby-client
   omniauth
   omniauth-azure-activedirectory
+  phonelib
   puma (~> 3.11)
   rails (~> 5.2.0)
   rails-controller-testing (~> 1.0)
@@ -349,4 +351,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/app/controllers/tenancies_sms_controller.rb
+++ b/app/controllers/tenancies_sms_controller.rb
@@ -6,6 +6,7 @@ class TenanciesSmsController < ApplicationController
 
   def create
     use_cases.send_sms.execute(
+      phone_numbers: params.fetch(:phone_numbers),
       tenancy_ref: params.fetch(:id),
       template_id: params.fetch(:template_id)
     )

--- a/app/helpers/contact_helper.rb
+++ b/app/helpers/contact_helper.rb
@@ -6,4 +6,8 @@ module ContactHelper
       contact.fetch(:last_name)
     ].join(' ')
   end
+
+  def sanitize_number(number)
+    Phonelib.parse(number).sanitized
+  end
 end

--- a/app/jobs/send_sms_job.rb
+++ b/app/jobs/send_sms_job.rb
@@ -1,6 +1,6 @@
 class SendSmsJob < ApplicationJob
-  def perform(description:, tenancy_ref:, template_id:)
-    send_sms.execute(tenancy_ref: tenancy_ref, template_id: template_id)
+  def perform(phone_numbers:, description:, tenancy_ref:, template_id:)
+    send_sms.execute(phone_numbers: phone_numbers, tenancy_ref: tenancy_ref, template_id: template_id)
   end
 
   private

--- a/app/views/tenancies_sms/_contact.html.erb
+++ b/app/views/tenancies_sms/_contact.html.erb
@@ -1,0 +1,17 @@
+<ul class="column-one-third">
+  <% if contact[:responsible] %>
+    <li><span class="contact-details-list__responsible">Responsible Tenant</span></li>
+  <% end %>
+  <% if contact[:full_name] %>
+    <li><% if contact[:title] %><%= contact[:title] %><% end %> <%= contact[:full_name] %></li>
+  <% end %>
+
+  <% [:telephone_1, :telephone_2, :telephone_3].each_with_index do | t, i | %>
+    <% if contact[t] %>
+      <li>
+        <%= check_box_tag(:phone_numbers, sanitize_number(contact[t]), (i == 0 ? true : false ), name: 'phone_numbers[]', id: "t-#{sanitize_number(contact[t])}") %>
+        <%= label_tag "t-#{sanitize_number(contact[t])}", contact[t] %>
+      </li>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/tenancies_sms/show.html.erb
+++ b/app/views/tenancies_sms/show.html.erb
@@ -23,20 +23,20 @@
               <% end %>
               <% if contact[:telephone_1] %>
                 <li>
-                  <%= check_box_tag(:phone_numbers, contact[:telephone_1], true, name: 'phone_numbers[]', id: "t-#{contact[:telephone_1]}") %>
-                  <%= label_tag "t-#{contact[:telephone_1]}", contact[:telephone_1] %>
+                  <%= check_box_tag(:phone_numbers, Phonelib.parse(contact[:telephone_1]).sanitized, true, name: 'phone_numbers[]', id: "t-#{Phonelib.parse(contact[:telephone_1]).sanitized}") %>
+                  <%= label_tag "t-#{Phonelib.parse(contact[:telephone_1]).sanitized}", contact[:telephone_1] %>
                 </li>
               <% end %>
               <% if contact[:telephone_2] %>
                 <li>
-                  <%= check_box_tag(:phone_numbers, contact[:telephone_2], false, name: 'phone_numbers[]', id: "t-#{contact[:telephone_2]}") %>
-                  <%= label_tag "t-#{contact[:telephone_2]}", contact[:telephone_2] %>
+                  <%= check_box_tag(:phone_numbers, Phonelib.parse(contact[:telephone_2]).sanitized, false, name: 'phone_numbers[]', id: "t-#{Phonelib.parse(contact[:telephone_2]).sanitized}") %>
+                  <%= label_tag "t-#{Phonelib.parse(contact[:telephone_2]).sanitized}", contact[:telephone_2] %>
                 </li>
               <% end %>
               <% if contact[:telephone_3] %>
                 <li>
-                  <%= check_box_tag(:phone_numbers, contact[:telephone_3], false, name: 'phone_numbers[]', id: "t-#{contact[:telephone_3]}") %>
-                  <%= label_tag "t-#{contact[:telephone_3]}", contact[:telephone_3] %>
+                  <%= check_box_tag(:phone_numbers, Phonelib.parse(contact[:telephone_3]).sanitized, false, name: 'phone_numbers[]', id: "t-#{Phonelib.parse(contact[:telephone_3]).sanitized}") %>
+                  <%= label_tag "t-#{Phonelib.parse(contact[:telephone_3]).sanitized}", contact[:telephone_3] %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/tenancies_sms/show.html.erb
+++ b/app/views/tenancies_sms/show.html.erb
@@ -14,32 +14,7 @@
         <span class="form-hint">Choose the number you'd like to send the message to</span>
         <div class="grid-row">
           <% @tenancy.contacts.each do |contact| %>
-            <ul class="column-one-third">
-              <% if contact[:responsible] %>
-                <li><span class="contact-details-list__responsible">Responsible Tenant</span></li>
-              <% end %>
-              <% if contact[:full_name] %>
-                <li><% if contact[:title] %><%= contact[:title] %><% end %> <%= contact[:full_name] %></li>
-              <% end %>
-              <% if contact[:telephone_1] %>
-                <li>
-                  <%= check_box_tag(:phone_numbers, Phonelib.parse(contact[:telephone_1]).sanitized, true, name: 'phone_numbers[]', id: "t-#{Phonelib.parse(contact[:telephone_1]).sanitized}") %>
-                  <%= label_tag "t-#{Phonelib.parse(contact[:telephone_1]).sanitized}", contact[:telephone_1] %>
-                </li>
-              <% end %>
-              <% if contact[:telephone_2] %>
-                <li>
-                  <%= check_box_tag(:phone_numbers, Phonelib.parse(contact[:telephone_2]).sanitized, false, name: 'phone_numbers[]', id: "t-#{Phonelib.parse(contact[:telephone_2]).sanitized}") %>
-                  <%= label_tag "t-#{Phonelib.parse(contact[:telephone_2]).sanitized}", contact[:telephone_2] %>
-                </li>
-              <% end %>
-              <% if contact[:telephone_3] %>
-                <li>
-                  <%= check_box_tag(:phone_numbers, Phonelib.parse(contact[:telephone_3]).sanitized, false, name: 'phone_numbers[]', id: "t-#{Phonelib.parse(contact[:telephone_3]).sanitized}") %>
-                  <%= label_tag "t-#{Phonelib.parse(contact[:telephone_3]).sanitized}", contact[:telephone_3] %>
-                </li>
-              <% end %>
-            </ul>
+            <%= render('contact', contact: contact) %>
           <% end %>
         </div>
       </div>

--- a/app/views/tenancies_sms/show.html.erb
+++ b/app/views/tenancies_sms/show.html.erb
@@ -10,9 +10,37 @@
       <%= render('common/tenancy_header') %>
 
       <div class="form-group">
-        <div class="panel panel-border-narrow">
-          <label class="form-label"><strong>Phone Number</strong></label>
-          <%= @tenancy.primary_contact_phone %>
+        <label class="form-label" for="sms-template-select"><strong>Select a person to contact</strong></label>
+        <span class="form-hint">Choose the number you'd like to send the message to</span>
+        <div class="grid-row">
+          <% @tenancy.contacts.each do |contact| %>
+            <ul class="column-one-third">
+              <% if contact[:responsible] %>
+                <li><span class="contact-details-list__responsible">Responsible Tenant</span></li>
+              <% end %>
+              <% if contact[:full_name] %>
+                <li><% if contact[:title] %><%= contact[:title] %><% end %> <%= contact[:full_name] %></li>
+              <% end %>
+              <% if contact[:telephone_1] %>
+                <li>
+                  <%= check_box_tag(:phone_numbers, contact[:telephone_1], true, name: 'phone_numbers[]', id: "t-#{contact[:telephone_1]}") %>
+                  <%= label_tag "t-#{contact[:telephone_1]}", contact[:telephone_1] %>
+                </li>
+              <% end %>
+              <% if contact[:telephone_2] %>
+                <li>
+                  <%= check_box_tag(:phone_numbers, contact[:telephone_2], false, name: 'phone_numbers[]', id: "t-#{contact[:telephone_2]}") %>
+                  <%= label_tag "t-#{contact[:telephone_2]}", contact[:telephone_2] %>
+                </li>
+              <% end %>
+              <% if contact[:telephone_3] %>
+                <li>
+                  <%= check_box_tag(:phone_numbers, contact[:telephone_3], false, name: 'phone_numbers[]', id: "t-#{contact[:telephone_3]}") %>
+                  <%= label_tag "t-#{contact[:telephone_3]}", contact[:telephone_3] %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
         </div>
       </div>
 

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = "GB"

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,1 +1,1 @@
-Phonelib.default_country = "GB"
+Phonelib.default_country = 'GB'

--- a/lib/hackney/income/send_sms.rb
+++ b/lib/hackney/income/send_sms.rb
@@ -7,16 +7,18 @@ module Hackney
         @events_gateway = events_gateway
       end
 
-      def execute(tenancy_ref:, template_id:)
+      def execute(phone_numbers:, tenancy_ref:, template_id:)
         tenancy = @tenancy_gateway.get_tenancy(tenancy_ref: tenancy_ref)
 
-        @notification_gateway.send_text_message(
-          tenancy_ref: tenancy_ref,
-          phone_number: contact_number_for(tenancy),
-          template_id: template_id,
-          reference: reference_for(tenancy),
-          variables: Hackney::TemplateVariables.variables_for(tenancy)
-        )
+        phone_numbers.each do |phone_number|
+          @notification_gateway.send_text_message(
+            tenancy_ref: tenancy_ref,
+            phone_number: phone_number,
+            template_id: template_id,
+            reference: reference_for(tenancy),
+            variables: Hackney::TemplateVariables.variables_for(tenancy)
+          )
+        end
 
         @events_gateway.create_event(
           tenancy_ref: tenancy_ref,

--- a/lib/hackney/income/send_sms.rb
+++ b/lib/hackney/income/send_sms.rb
@@ -10,7 +10,7 @@ module Hackney
       def execute(phone_numbers:, tenancy_ref:, template_id:)
         tenancy = @tenancy_gateway.get_tenancy(tenancy_ref: tenancy_ref)
 
-        phone_numbers.each do |phone_number|
+        phone_numbers.uniq.each do |phone_number|
           @notification_gateway.send_text_message(
             tenancy_ref: tenancy_ref,
             phone_number: phone_number,

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -156,7 +156,7 @@ module Hackney
                 t.primary_contact_name = [attributes.fetch(:title), attributes.fetch(:first_name), attributes.fetch(:last_name)].join(' ')
                 t.primary_contact_long_address = attributes.fetch(:address_1)
                 t.primary_contact_postcode = 'E1 123'
-                t.primary_contact_phone = '0208 123 1234'
+                t.primary_contact_phone = Faker::PhoneNumber.phone_number
                 t.primary_contact_email = 'test@example.com'
                 t.arrears_actions = [action]
                 t.agreements = [agreement]

--- a/lib/hackney/income/tenancy_gateway.rb
+++ b/lib/hackney/income/tenancy_gateway.rb
@@ -136,7 +136,7 @@ module Hackney
 
         return [] if contacts.blank? || Rails.env.staging?
 
-        contacts.map do |c|
+        contacts = contacts.map do |c|
           Hackney::Income::Domain::Contact.new.tap do |t|
             t.contact_id = c['contact_id']
             t.email_address = c['email_address']
@@ -163,6 +163,7 @@ module Hackney
             t.responsible = c['responsible']
           end
         end
+        contacts
       end
 
       private

--- a/lib/hackney/income/view_tenancy.rb
+++ b/lib/hackney/income/view_tenancy.rb
@@ -33,6 +33,7 @@ module Hackney
             telephone_1: contact.telephone_1,
             telephone_2: contact.telephone_2,
             telephone_3: contact.telephone_3,
+            phone_numbers: [contact.telephone_1, contact.telephone_2, contact.telephone_3],
             cautionary_alert: contact.cautionary_alert,
             property_cautionary_alert: contact.property_cautionary_alert,
             house_ref: contact.house_ref,

--- a/spec/controllers/tenancies_sms_controller_spec.rb
+++ b/spec/controllers/tenancies_sms_controller_spec.rb
@@ -32,19 +32,20 @@ describe TenanciesSmsController do
     it 'should call the send sms use case correctly' do
       expect_any_instance_of(Hackney::Income::SendSms).to receive(:execute).with(
         tenancy_ref: '3456789',
-        template_id: '00001'
+        template_id: '00001',
+        phone_numbers: ['0208 123 1234']
       )
 
-      post :create, params: { id: '3456789', template_id: '00001' }
+      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: ['0208 123 1234'] }
     end
 
     it 'should call redirect me to the tenancy page' do
-      post :create, params: { id: '3456789', template_id: '00001' }
+      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: ['0208 123 1234'] }
       expect(response).to redirect_to(tenancy_path(id: '3456789'))
     end
 
     it 'should show me a success message' do
-      post :create, params: { id: '3456789', template_id: '00001' }
+      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: ['0208 123 1234'] }
       expect(flash[:notice]).to eq('Successfully sent the tenant an SMS message')
     end
   end

--- a/spec/controllers/tenancies_sms_controller_spec.rb
+++ b/spec/controllers/tenancies_sms_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe TenanciesSmsController do
+  let(:phone_number) { Faker::PhoneNumber.phone_number }
+
   before do
     stub_authentication
     stub_const('Hackney::Income::TenancyGateway', Hackney::Income::StubTenancyGatewayBuilder.build_stub)
@@ -33,19 +35,19 @@ describe TenanciesSmsController do
       expect_any_instance_of(Hackney::Income::SendSms).to receive(:execute).with(
         tenancy_ref: '3456789',
         template_id: '00001',
-        phone_numbers: ['0208 123 1234']
+        phone_numbers: [phone_number]
       )
 
-      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: ['0208 123 1234'] }
+      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: [phone_number] }
     end
 
     it 'should call redirect me to the tenancy page' do
-      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: ['0208 123 1234'] }
+      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: [phone_number] }
       expect(response).to redirect_to(tenancy_path(id: '3456789'))
     end
 
     it 'should show me a success message' do
-      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: ['0208 123 1234'] }
+      post :create, params: { id: '3456789', template_id: '00001', phone_numbers: [phone_number] }
       expect(flash[:notice]).to eq('Successfully sent the tenant an SMS message')
     end
   end

--- a/spec/jobs/send_sms_job_spec.rb
+++ b/spec/jobs/send_sms_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe SendSmsJob do
   let(:tenancy_ref) { Faker::Lorem.word }
   let(:template_id) { Faker::Lorem.word }
-  let(:phone_numbers) { [Faker::PhoneNumber.phone_number]}
+  let(:phone_numbers) { [Faker::PhoneNumber.phone_number] }
 
   subject do
     described_class.perform_now(

--- a/spec/jobs/send_sms_job_spec.rb
+++ b/spec/jobs/send_sms_job_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 describe SendSmsJob do
   let(:tenancy_ref) { Faker::Lorem.word }
   let(:template_id) { Faker::Lorem.word }
+  let(:phone_numbers) { [Faker::PhoneNumber.phone_number]}
 
   subject do
     described_class.perform_now(
+      phone_numbers: phone_numbers,
       description: 'test',
       tenancy_ref: tenancy_ref,
       template_id: template_id
@@ -21,7 +23,7 @@ describe SendSmsJob do
   context 'when running the job' do
     it 'should call the SendSms use case correctly' do
       expect_any_instance_of(Hackney::Income::SendSms).to receive(:execute)
-        .with(tenancy_ref: tenancy_ref, template_id: template_id)
+        .with(phone_numbers: phone_numbers, tenancy_ref: tenancy_ref, template_id: template_id)
 
       subject
     end

--- a/spec/lib/hackney/income/send_sms_spec.rb
+++ b/spec/lib/hackney/income/send_sms_spec.rb
@@ -4,6 +4,7 @@ describe Hackney::Income::SendSms do
   let(:tenancy_gateway) { Hackney::Income::StubTenancyGatewayBuilder.build_stub.new }
   let(:notification_gateway) { Hackney::Income::StubNotificationsGateway.new }
   let(:events_gateway) { Hackney::Income::StubEventsGateway.new }
+  let!(:phone_number) { Faker::PhoneNumber.phone_number }
   let(:events) { events_gateway.events_for(tenancy_ref: '2345678') }
 
   let(:send_sms) do
@@ -16,7 +17,7 @@ describe Hackney::Income::SendSms do
 
   context 'when sending an SMS manually' do
     subject do
-      send_sms.execute(tenancy_ref: '2345678', template_id: 'this-is-a-template-id', phone_numbers: ['0208 123 1234'])
+      send_sms.execute(tenancy_ref: '2345678', template_id: 'this-is-a-template-id', phone_numbers: [phone_number])
       notification_gateway.last_text_message
     end
 
@@ -32,7 +33,7 @@ describe Hackney::Income::SendSms do
 
     it 'should pass through the phone number' do
       expect(subject).to include(
-        phone_number: '0208 123 1234'
+        phone_number: phone_number
       )
     end
 
@@ -54,7 +55,7 @@ describe Hackney::Income::SendSms do
         expect(events).to include(
           tenancy_ref: '2345678',
           type: 'sms_message_sent',
-          description: 'Sent SMS message to 0208 123 1234',
+          description: /Sent SMS message to /,
           timestamp: Time.local(2018),
           automated: false
         )

--- a/spec/lib/hackney/income/send_sms_spec.rb
+++ b/spec/lib/hackney/income/send_sms_spec.rb
@@ -16,7 +16,7 @@ describe Hackney::Income::SendSms do
 
   context 'when sending an SMS manually' do
     subject do
-      send_sms.execute(tenancy_ref: '2345678', template_id: 'this-is-a-template-id')
+      send_sms.execute(tenancy_ref: '2345678', template_id: 'this-is-a-template-id', phone_numbers: ['0208 123 1234'])
       notification_gateway.last_text_message
     end
 

--- a/spec/tenancy_helper.rb
+++ b/spec/tenancy_helper.rb
@@ -17,7 +17,7 @@ def example_tenancy(attributes = {})
       first_name: 'Waffles',
       last_name: 'The Dog',
       title: 'Ms',
-      contact_number: '0208 123 1234',
+      contact_number: Faker::PhoneNumber.phone_number,
       email_address: 'test@example.com'
     },
     address: {


### PR DESCRIPTION
<img width="982" alt="screenshot 2018-11-19 at 18 03 53" src="https://user-images.githubusercontent.com/8051117/48725902-85f26300-ec25-11e8-979f-afd4332ab962.png">
Fixed a bug relating to contact details not being correctly parsed through and introduced the ability to send sms to multiple responsible tenants 