### PR TITLE
Remove basic auth for production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,5 @@
 class ApplicationController < ActionController::Base
-  if Rails.env.staging? || Rails.env.production?
-    http_basic_authenticate_with name: ENV['BASIC_AUTH_USERNAME'], password: ENV['BASIC_AUTH_PASSWORD']
-  end
+  http_basic_authenticate_with name: ENV['BASIC_AUTH_USERNAME'], password: ENV['BASIC_AUTH_PASSWORD'] if Rails.application.config.private_environment
 
   helper_method :logged_in?
   helper_method :current_user
@@ -20,6 +18,7 @@ class ApplicationController < ActionController::Base
 
   def check_authentication
     return if logged_in? || auth_request? || logout_request?
+
     redirect_to login_path
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module App
   class Application < Rails::Application
+    config.private_environment = true
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.private_environment = false
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-
+  config.private_environment = false
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.private_environment = false
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's


### PR DESCRIPTION
Now that we have OAuth in front of the app the time has come to remove the now redundant basic auth layer for the production environment. 

**As this is an auth change I have added many devs as a heads up approve/reject this PR. Can we all approve this PR to acknowledge this change?**

notes:
 - add 'private_environment' bool config setting
 - set it to false on production app config