### PR TITLE
Fix for single payment_ref not found

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -9,7 +9,6 @@ $( document ).on('turbolinks:load', function() {
 function get_previews(pay_refs, template_id) {
   if (pay_refs.length != 0) {
     showLoader()
-    pay_refs = pay_refs.split(",");
     max = pay_refs.length
     for (i in pay_refs) {
       ajax_preview(pay_refs[i], template_id, max);

--- a/app/views/letters/preview.erb
+++ b/app/views/letters/preview.erb
@@ -6,8 +6,7 @@
 
 <div class="grid-row">
   <div class="column-full">
-
-    <div class="letters" data-uuids="<%=@payment_refs.join(',')%>" data-template_id="<%=@preview.dig(:template, :id) %>" %>
+    <div class="letters" data-uuids="<%=@payment_refs.to_json%>" data-template_id="<%=@preview.dig(:template, :id) %>" %>
       <div class="grid-row">
         <div class="column-full">
           <h1>Letter preview</h1>

--- a/spec/controllers/letters_controller_spec.rb
+++ b/spec/controllers/letters_controller_spec.rb
@@ -37,7 +37,8 @@ describe LettersController do
           template_id: template_id,
           user_id: user_id
         ).once.and_return(
-          preview: Faker::StarTrek.villain
+          preview: Faker::StarTrek.villain,
+          case: { payment_ref: payment_refs.first }
         )
 
         post :preview, params: {
@@ -49,7 +50,7 @@ describe LettersController do
       it { expect(assigns(:preview)).to be_present }
       it { expect(assigns(:payment_refs)).to be_present }
 
-      it { expect(assigns(:payment_refs)).to eq(payment_refs.reject { |r| r == payment_refs.first }) }
+      it { expect(assigns(:payment_refs)).to eq(payment_refs.drop(1)) }
     end
 
     context 'shows preview with errors' do


### PR DESCRIPTION
This fixex  the bug about unique `payment_ref`

The issue was about the behaviour of `pay_refs = pay_refs.split(",");` with unique `one pay_ref`
There was also another bug in the controller preview, I fixed it and I refactored a bit.

NOTE: it still need improvement, the code in the controller is growing (the code should not be there) and there are missing tests.
