### PR TITLE
Fix sent letter with 2 payrefs

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -9,7 +9,6 @@ $( document ).on('turbolinks:load', function() {
 function get_previews(pay_refs, template_id) {
   if (pay_refs.length != 0) {
     showLoader()
-    pay_refs = pay_refs.split(",");
     max = pay_refs.length
     for (i in pay_refs) {
       ajax_preview(pay_refs[i], template_id, max);

--- a/app/views/letters/preview.erb
+++ b/app/views/letters/preview.erb
@@ -7,7 +7,7 @@
 <div class="grid-row">
   <div class="column-full">
 
-    <div class="letters" data-uuids="<%=@payment_refs.join(',')%>" data-template_id="<%=@preview.dig(:template, :id) %>" %>
+    <div class="letters" data-uuids="<%=@payment_refs.to_json%>" data-template_id="<%=@preview.dig(:template, :id) %>" %>
       <div class="grid-row">
         <div class="column-full">
           <h1>Letter preview</h1>


### PR DESCRIPTION
The issue is:
with just one element `pay_refs` is considered `Numeric` and pay_refs.split(",") return `pay_refs.split is not a function`

