### PR TITLE
Add priority band to show page

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -9,7 +9,11 @@ $white: #fff;
 $black: #000;
 $red: red;
 
+$priority-band-red: #be3a34;
+$priority-band-amber: #ffc845;
+$priority-band-green: #00b140;
+
 $positive-green: $hackney-mid-green;
 $negative-red: $red;
 
-$toolkit-font-stack: 'Droid Sans', arial, helvetica, sans-serif;
+$toolkit-font-stack: "Droid Sans", arial, helvetica, sans-serif;

--- a/app/assets/stylesheets/components/tenancy_list.scss
+++ b/app/assets/stylesheets/components/tenancy_list.scss
@@ -50,15 +50,15 @@
     line-height: 75px;
 
     &--red {
-      background-color: #be3a34;
+      background-color: $priority-band-red;
     }
 
     &--amber {
-      background-color: #ffc845;
+      background-color: $priority-band-amber;
     }
 
     &--green {
-      background-color: #00b140;
+      background-color: $priority-band-green;
     }
 
     @media (min-width: 641px) {

--- a/app/assets/stylesheets/components/tenancy_list.scss
+++ b/app/assets/stylesheets/components/tenancy_list.scss
@@ -1,3 +1,11 @@
+.priority_band {
+  height: 23px;
+  width: 100px;
+  color: white;
+  text-align: center;
+  margin-top: 10px;
+}
+
 .tenancy_list {
   margin-top: 30px;
 
@@ -42,15 +50,15 @@
     line-height: 75px;
 
     &--red {
-      background-color: #BE3A34;
+      background-color: #be3a34;
     }
 
     &--amber {
-      background-color: #FFC845;
+      background-color: #ffc845;
     }
 
     &--green {
-      background-color: #00B140;
+      background-color: #00b140;
     }
 
     @media (min-width: 641px) {
@@ -75,7 +83,8 @@
     top: -50px;
     width: 500px;
 
-    &:after, &:before {
+    &:after,
+    &:before {
       left: 100%;
       top: 80px;
       border: solid transparent;

--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -7,6 +7,8 @@
       <li><strong>Payment reference:</strong> <%= @tenancy.payment_ref %></li>
       <li><strong>Tenure:</strong> <%= tenancy_type_name(@tenancy.tenure) %></li>
       <li><strong>Assigned to:</strong> <%= @tenancy.display_assigned_to %></li>
+
+      <li><strong>BAND:</strong> <%= @tenancy.display_band %></li>
     </ul>
   </div>
 </div>

--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -7,8 +7,6 @@
       <li><strong>Payment reference:</strong> <%= @tenancy.payment_ref %></li>
       <li><strong>Tenure:</strong> <%= tenancy_type_name(@tenancy.tenure) %></li>
       <li><strong>Assigned to:</strong> <%= @tenancy.display_assigned_to %></li>
-
-      <li><strong>BAND:</strong> <%= @tenancy.display_band %></li>
     </ul>
   </div>
 </div>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -12,6 +12,7 @@
   </div>
   <div class="column-one-third">
     <%= link_to 'Pause case', tenancy_pause_path(@tenancy.ref), class:'button' %>
+    <div style="height:30px; width:100px; background-color:<%= @tenancy.display_priority_band %>;"><strong>PRIORITY</strong></div>
   </div>
 </div>
 

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -12,7 +12,9 @@
   </div>
   <div class="column-one-third">
     <%= link_to 'Pause case', tenancy_pause_path(@tenancy.ref), class:'button' %>
-    <div class="tenancy_list__item--<%= @tenancy.display_priority_band %> priority_band"><strong>PRIORITY</strong></div>
+   <% if @tenancy.display_priority_band.present? %>
+      <div class="tenancy_list__item--<%= @tenancy.display_priority_band %> priority_band"><strong>PRIORITY</strong></div>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="column-one-third">
     <%= link_to 'Pause case', tenancy_pause_path(@tenancy.ref), class:'button' %>
-    <div style="height:30px; width:100px; background-color:<%= @tenancy.display_priority_band %>;"><strong>PRIORITY</strong></div>
+    <div class="tenancy_list__item--<%= @tenancy.display_priority_band %> priority_band"><strong>PRIORITY</strong></div>
   </div>
 </div>
 

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -28,7 +28,7 @@ module Hackney
           end
         end
 
-        def display_band
+        def display_priority_band
           case_priority[:priority_band]
         end
       end

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -29,7 +29,7 @@ module Hackney
         end
 
         def display_band
-          "#{case_priority[:priority_band]}"
+          case_priority[:priority_band]
         end
       end
     end

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -27,6 +27,10 @@ module Hackney
             'Not assigned'
           end
         end
+
+        def display_band
+          "#{case_priority[:priority_band]}"
+        end
       end
     end
   end

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -21,7 +21,7 @@ module Hackney
         end
 
         def display_assigned_to
-          if case_priority
+          if case_priority.present?
             "#{case_priority.dig(:assigned_user, :name)} (#{case_priority.dig(:assigned_user, :role)})".titleize
           else
             'Not assigned'

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -39,6 +39,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_css('li', text: 'Payment reference: 1010101010', count: 1)
     expect(page.body).to have_css('li', text: 'Start date: August 30th, 2014', count: 1)
     expect(page.body).to have_css('li', text: 'Assigned to: Billy Bob (Credit Controller)', count: 1)
+    expect(page.body).to have_css('li', text: 'BAND: red', count: 1)
   end
 
   def then_i_should_see_case_account_balance

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -39,7 +39,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_css('li', text: 'Payment reference: 1010101010', count: 1)
     expect(page.body).to have_css('li', text: 'Start date: August 30th, 2014', count: 1)
     expect(page.body).to have_css('li', text: 'Assigned to: Billy Bob (Credit Controller)', count: 1)
-    expect(page.body).to have_css('div', text: 'PRIORITY')
+    expect(page.body).to have_css('div.tenancy_list__item--red', text: 'PRIORITY')
   end
 
   def then_i_should_see_case_account_balance

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -39,7 +39,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_css('li', text: 'Payment reference: 1010101010', count: 1)
     expect(page.body).to have_css('li', text: 'Start date: August 30th, 2014', count: 1)
     expect(page.body).to have_css('li', text: 'Assigned to: Billy Bob (Credit Controller)', count: 1)
-    expect(page.body).to have_css('li', text: 'BAND: red', count: 1)
+    expect(page.body).to have_css('div', text: 'PRIORITY')
   end
 
   def then_i_should_see_case_account_balance

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -37,6 +37,10 @@ describe Hackney::Income::ViewTenancy do
         )
       end
 
+      it 'should contain the priority_band result' do
+        expect(subject.case_priority.fetch('priority_band')).to eq('red')
+      end
+
       it 'should include contact details' do
         expect(subject.primary_contact_name).to eq('Ms Diana Prince')
         expect(subject.primary_contact_long_address).to eq('1 Themyscira')


### PR DESCRIPTION
WHAT: We added the priority band to the show view.

WHY: To show users the severity of a specific case.

![Screenshot 2019-09-19 at 10 29 14](https://user-images.githubusercontent.com/40758489/65232015-5b349d80-dac8-11e9-99c0-64b50107d239.png)
