### PR TITLE
Return to last page used after viewing a case

### DIFF
--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <%= link_to('Return back to your worktray', root_path, class: 'link--back') %>
+    <%= link_to('Return back to your worktray', :back, class: 'link--back') %>
   </div>
 </div>
 


### PR DESCRIPTION
WHAT: Add a back method to the `Return back to your worktray` link.

WHY: To allow a user to go back to the page they came from and not back to page 1.