### PR TITLE
Hide and show graph MA-110

### DIFF
--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -85,8 +85,6 @@
   </div>
 </div>
 
-
-
 <div class="grid-row">
   <div class="column-full">
     <h2>Arrears Agreements</h2>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -75,7 +75,7 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <h2>Balance over time</h2>
+    <h2>Balance over time - <a><u id= "hide_graph">click to hide graph</u></a></h2>
     <canvas id="balance_chart" height="300"></canvas>
   </div>
 </div>
@@ -188,6 +188,7 @@
 
 <script type="text/javascript">
   $(document).on('turbolinks:load', draw_graph);
+  $("#hide_graph").on('click', hide_graph);
 
   function draw_graph() {
     {
@@ -196,5 +197,12 @@
         window.arrearsGraph && window.arrearsGraph.destroy();
       window.arrearsGraph = BalanceGraph(ctx, transactions)
     }
+  }
+
+  function hide_graph(){
+  $("#balance_chart").toggle()
+  var ctx = document.getElementById('balance_chart');
+  var text = document.getElementById('hide_graph')
+  ctx.style.display == "none" ? text.innerHTML = "click to show graph": text.innerHTML = "click to hide graph"
   }
 </script>

--- a/app/views/tenancies/show.html.erb
+++ b/app/views/tenancies/show.html.erb
@@ -73,12 +73,19 @@
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-full">
-    <h2>Balance over time - <a><u id= "hide_graph">click to hide graph</u></a></h2>
-    <canvas id="balance_chart" height="300"></canvas>
+<h2>Balance over time</h2> 
+  <div class="grid-row">
+    <div class="column-full">
+      <details class="govuk-details" data-module="govuk-details">
+      <summary style="color:#1d70b8; cursor:pointer" class="govuk-details__summary">
+    <span class="govuk-details__summary-text"><u>Graph</u></span>
+  </summary>
+    <canvas id="balance_chart"></canvas> 
+    </details>
   </div>
 </div>
+
+
 
 <div class="grid-row">
   <div class="column-full">
@@ -188,7 +195,6 @@
 
 <script type="text/javascript">
   $(document).on('turbolinks:load', draw_graph);
-  $("#hide_graph").on('click', hide_graph);
 
   function draw_graph() {
     {
@@ -196,13 +202,7 @@
       var transactions = <%= from_last_year_as_json(@tenancy.transactions) %>
         window.arrearsGraph && window.arrearsGraph.destroy();
       window.arrearsGraph = BalanceGraph(ctx, transactions)
+      ctx.style.height = "300px"
     }
-  }
-
-  function hide_graph(){
-  $("#balance_chart").toggle()
-  var ctx = document.getElementById('balance_chart');
-  var text = document.getElementById('hide_graph')
-  ctx.style.display == "none" ? text.innerHTML = "click to show graph": text.innerHTML = "click to hide graph"
   }
 </script>

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -50,9 +50,8 @@ describe 'Viewing A Single Case' do
 
   def then_i_should_see_balance_graph
     expect(page.body).to have_css('h2', text: 'Balance over time', count: 1)
+    expect(page.body).to have_css('span', text: 'Graph', count: 1)
     expect(page.body).to have_css('canvas#balance_chart', count: 1)
-    # page.execute_script('draw_graph()')
-    # expect(page.body).to have_script('var transactions = []', count: 1)
   end
 
   def then_i_should_see_tenant_details

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -51,7 +51,7 @@ describe 'Viewing A Single Case' do
   def then_i_should_see_balance_graph
     expect(page.body).to have_css('h2', text: 'Balance over time', count: 1)
     expect(page.body).to have_css('span', text: 'Graph', count: 1)
-    expect(page.body).to have_css('canvas#balance_chart', count: 1)
+    expect(page.find('#balance_chart').visible?).to eq(true)
   end
 
   def then_i_should_see_tenant_details


### PR DESCRIPTION
WHAT: Added hide and show graph on case details page.

WHY: So that the user can tailor the case detail page to suit their preference.

![Screenshot 2019-09-23 at 15 07 21](https://user-images.githubusercontent.com/43789512/65436172-a1b43000-de19-11e9-9c74-ff81c9f40805.png)
