### PR TITLE
Improve stubbing in "view a case" spec

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
 INCOME_COLLECTION_API_HOST=http://example.com/api
-INCOME_COLLECTION_LIST_API_HOST=http://example.com/other/api
+INCOME_COLLECTION_LIST_API_HOST=http://example.com/income/api
 INCOME_COLLECTION_API_KEY='TEST_API_KEY'

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
-INCOME_COLLECTION_API_HOST=http://example.com/api
-INCOME_COLLECTION_LIST_API_HOST=http://example.com/income/api
+INCOME_COLLECTION_API_HOST=https://example.com/api
+INCOME_COLLECTION_LIST_API_HOST=https://example.com/income/api
 INCOME_COLLECTION_API_KEY='TEST_API_KEY'

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
-INCOME_COLLECTION_API_HOST=https://example.com/api
+INCOME_COLLECTION_API_HOST=https://example.com/tenancy/api
 INCOME_COLLECTION_LIST_API_HOST=https://example.com/income/api
 INCOME_COLLECTION_API_KEY='TEST_API_KEY'

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -83,16 +83,6 @@ describe TenanciesController do
     end
   end
 
-  context '#show' do
-    it 'should assign a valid tenancy' do
-      get :show, params: { id: '1234567' }
-
-      expect(assigns(:tenancy)).to be_present
-      expect(assigns(:tenancy)).to be_instance_of(Hackney::Income::Domain::Tenancy)
-      expect(assigns(:tenancy)).to be_valid
-    end
-  end
-
   context '#pause' do
     it 'should assign a valid tenancy' do
       get :pause, params: { id: '1234567' }

--- a/spec/examples/actions_response.json
+++ b/spec/examples/actions_response.json
@@ -1,0 +1,22 @@
+{
+  "arrears_action_diary_events": [
+    {
+      "balance": "100.00",
+      "code": "",
+      "type": "",
+      "date": "01-01-2010",
+      "comment": "",
+      "universal_housing_username": ""
+    },
+    {
+      "balance": "",
+      "code": "",
+      "type": "",
+      "date": "01-02-2010",
+      "comment": "",
+      "universal_housing_username": ""
+    }
+  ],
+  "statusCode": 200,
+  "error": null
+}

--- a/spec/features/creating_action_diary_entry_spec.rb
+++ b/spec/features/creating_action_diary_entry_spec.rb
@@ -44,7 +44,7 @@ describe 'creating action diary entry' do
   def stub_income_api_actions
     body = File.read(Rails.root.join('spec', 'examples', 'actions_response.json'))
 
-    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567/actions")
+    stub_request(:get, 'https://example.com:80/api/v1/tenancies/1234567/actions')
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: body)
   end

--- a/spec/features/creating_action_diary_entry_spec.rb
+++ b/spec/features/creating_action_diary_entry_spec.rb
@@ -12,6 +12,7 @@ describe 'creating action diary entry' do
     allow(create_action_diary_entry_class).to receive(:new).and_return(create_action_diary_entry_double)
     stub_const('Hackney::Income::CreateActionDiaryEntry', create_action_diary_entry_class)
     stub_use_cases
+    stub_income_api_actions
   end
 
   around do |example|
@@ -38,6 +39,14 @@ describe 'creating action diary entry' do
       fill_in 'comment', with: 'Test comment.'
       click_button 'Add action'
     end
+  end
+
+  def stub_income_api_actions
+    body = File.read(Rails.root.join('spec', 'examples', 'actions_response.json'))
+
+    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567/actions")
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .to_return(status: 200, body: body)
   end
 
   def stub_use_cases

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -144,7 +144,7 @@ describe 'Viewing A Single Case' do
 
   def stub_income_api_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567%2F01")
+    stub_request(:get, "https://example.com/api/v1/tenancies/1234567%2F01")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -152,7 +152,7 @@ describe 'Viewing A Single Case' do
   def stub_income_api_payments
     response_json = {"payment_transactions": []}.to_json
 
-    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567%2F01/payments")
+    stub_request(:get, "https://example.com/api/v1/tenancies/1234567%2F01/payments")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -172,7 +172,7 @@ describe 'Viewing A Single Case' do
       }
     }.to_json
 
-    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567%2F01/contacts")
+    stub_request(:get, "https://example.com/api/v1/tenancies/1234567%2F01/contacts")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -180,7 +180,7 @@ describe 'Viewing A Single Case' do
   def stub_tenancy_api_my_cases
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
 
-    stub_request(:get, "https://example.com:80/income/api/v1/my-cases")
+    stub_request(:get, "https://example.com/income/api/v1/my-cases")
       .with(query: hash_including({
         is_paused: "false",
         number_per_page: "20",
@@ -203,7 +203,7 @@ describe 'Viewing A Single Case' do
       priority_band: "red"
     }.to_json
 
-    stub_request(:get, "https://example.com:80/income/api/v1/tenancies/1234567%2F01")
+    stub_request(:get, "https://example.com/income/api/v1/tenancies/1234567%2F01")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -144,7 +144,7 @@ describe 'Viewing A Single Case' do
 
   def stub_income_api_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-    stub_request(:get, "https://example.com/api/v1/tenancies/1234567%2F01")
+    stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/1234567%2F01")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -152,7 +152,7 @@ describe 'Viewing A Single Case' do
   def stub_income_api_payments
     response_json = {"payment_transactions": []}.to_json
 
-    stub_request(:get, "https://example.com/api/v1/tenancies/1234567%2F01/payments")
+    stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -172,7 +172,7 @@ describe 'Viewing A Single Case' do
       }
     }.to_json
 
-    stub_request(:get, "https://example.com/api/v1/tenancies/1234567%2F01/contacts")
+    stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -144,6 +144,7 @@ describe 'Viewing A Single Case' do
 
   def stub_income_api_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
+
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
@@ -167,7 +168,7 @@ describe 'Viewing A Single Case' do
           title: 'Mr',
           first_name: 'Alan',
           last_name: 'Sugar',
-          email_address: 'alan.sugar@domain.com'
+          email_address: 'alan.sugar@example.com'
         }]
       }
     }.to_json

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -144,15 +144,15 @@ describe 'Viewing A Single Case' do
 
   def stub_income_api_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-    stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/1234567%2F01")
+    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_income_api_payments
-    response_json = {"payment_transactions": []}.to_json
+    response_json = { 'payment_transactions': [] }.to_json
 
-    stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments")
+    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments')
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -161,18 +161,18 @@ describe 'Viewing A Single Case' do
     response_json = {
       data: {
         contacts: [{
-          post_code: "E8 1DY",
+          post_code: 'E8 1DY',
           responsible: true,
-          address_line1: "Primary Street",
-          title: "Mr",
-          first_name: "Alan",
-          last_name: "Sugar",
-          email_address: "alan.sugar@domain.com"
+          address_line1: 'Primary Street',
+          title: 'Mr',
+          first_name: 'Alan',
+          last_name: 'Sugar',
+          email_address: 'alan.sugar@domain.com'
         }]
       }
     }.to_json
 
-    stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts")
+    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts')
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -180,12 +180,12 @@ describe 'Viewing A Single Case' do
   def stub_tenancy_api_my_cases
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
 
-    stub_request(:get, "https://example.com/income/api/v1/my-cases")
-      .with(query: hash_including({
-        is_paused: "false",
-        number_per_page: "20",
-        page_number: "1"
-      }))
+    stub_request(:get, 'https://example.com/income/api/v1/my-cases')
+      .with(query: hash_including(
+        is_paused: 'false',
+        number_per_page: '20',
+        page_number: '1'
+      ))
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
@@ -193,17 +193,17 @@ describe 'Viewing A Single Case' do
   def stub_tenancy_api_show_tenancy
     response_json = {
       assigned_user: {
-        id: "1",
-        name: "Billy Bob",
-        email: "Billy.Bob@hackney.gov.uk",
-        first_name: "Billy",
-        last_name: "Bob",
-        role: "credit_controller"
+        id: '1',
+        name: 'Billy Bob',
+        email: 'Billy.Bob@hackney.gov.uk',
+        first_name: 'Billy',
+        last_name: 'Bob',
+        role: 'credit_controller'
       },
-      priority_band: "red"
+      priority_band: 'red'
     }.to_json
 
-    stub_request(:get, "https://example.com/income/api/v1/tenancies/1234567%2F01")
+    stub_request(:get, 'https://example.com/income/api/v1/tenancies/1234567%2F01')
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -4,8 +4,14 @@ describe 'Viewing A Single Case' do
   around { |example| with_mock_authentication { example.run } }
 
   before do
-    stub_my_cases_response
-    stub_view_case_response
+    stub_income_api_tenancy
+    stub_income_api_payments
+    stub_income_api_contacts
+
+    stub_tenancy_api_my_cases
+    stub_tenancy_api_show_tenancy
+
+    stub_users_gateway
   end
 
   scenario do
@@ -60,8 +66,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_css('li', text: '1 Hillman street', count: 1)
     expect(page.body).to have_css('li', text: 'E8 1DY', count: 2)
     expect(page.body).to have_css('h3', text: 'Primary Tenant', count: 1)
-    expect(page.body).to have_css('li', text: 'HILLMAN STREET', count: 1)
-    expect(page.body).to have_css('li', text: 'HACKNEY', count: 1)
+    expect(page.body).to have_css('li', text: 'Primary Street', count: 1)
   end
 
   def then_i_should_see_agreements_table
@@ -112,15 +117,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_css('.contact-details-list__responsible', text: 'Responsible Tenant', count: 1)
     expect(page.body).to have_css('.contact-details-list li', text: 'Title: Mr', count: 1)
     expect(page.body).to have_css('.contact-details-list li', text: 'First Name: Alan', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Last Name: Sugar', count: 2)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Phone One: 07123456789', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Phone Two: 07070707070', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Phone Three: 07987654321', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'E-Mail: sugar_ring@dougnut.com', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Title: Ms', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Phone One: 01010101010', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Phone Two: 02020202020', count: 1)
-    expect(page.body).to have_css('.contact-details-list li', text: 'Phone Three: 03030303030', count: 1)
+    expect(page.body).to have_css('.contact-details-list li', text: 'Last Name: Sugar', count: 1)
   end
 
   def then_i_should_see_contact_buttons
@@ -145,24 +142,73 @@ describe 'Viewing A Single Case' do
     expect(page).to have_link(href: '/tenancies/1234567%2F01/pause')
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /my-cases\?is_paused=false&number_per_page=20&page_number=1&user_id=/)
+  def stub_income_api_tenancy
+    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
+    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567%2F01")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_view_case_response
-    response_json = JSON.parse(File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json')))
-    allow_any_instance_of(Hackney::Income::TenancyGateway).to receive(:get_case_priority).and_return(response_json.deep_symbolize_keys)
+  def stub_income_api_payments
+    response_json = {"payment_transactions": []}.to_json
 
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-    stub_request(:get, %r{/api\/v1\/tenancies\/1234567/})
+    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567%2F01/payments")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
+  end
+
+  def stub_income_api_contacts
+    response_json = {
+      data: {
+        contacts: [{
+          post_code: "E8 1DY",
+          responsible: true,
+          address_line1: "Primary Street",
+          title: "Mr",
+          first_name: "Alan",
+          last_name: "Sugar",
+          email_address: "alan.sugar@domain.com"
+        }]
+      }
+    }.to_json
+
+    stub_request(:get, "https://example.com:80/api/v1/tenancies/1234567%2F01/contacts")
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .to_return(status: 200, body: response_json)
+  end
+
+  def stub_tenancy_api_my_cases
+    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
+
+    stub_request(:get, "https://example.com:80/other/api/v1/my-cases")
+      .with(query: hash_including({
+        is_paused: "false",
+        number_per_page: "20",
+        page_number: "1"
+      }))
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .to_return(status: 200, body: response_json)
+  end
+
+  def stub_tenancy_api_show_tenancy
+    response_json = {
+      assigned_user: {
+        id: "1",
+        name: "Billy Bob",
+        email: "Billy.Bob@hackney.gov.uk",
+        first_name: "Billy",
+        last_name: "Bob",
+        role: "credit_controller"
+      },
+      priority_band: "red"
+    }.to_json
+
+    stub_request(:get, "https://example.com:80/other/api/v1/tenancies/1234567%2F01")
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .to_return(status: 200, body: response_json)
+  end
+
+  def stub_users_gateway
+    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
   end
 end

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -180,7 +180,7 @@ describe 'Viewing A Single Case' do
   def stub_tenancy_api_my_cases
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
 
-    stub_request(:get, "https://example.com:80/other/api/v1/my-cases")
+    stub_request(:get, "https://example.com:80/income/api/v1/my-cases")
       .with(query: hash_including({
         is_paused: "false",
         number_per_page: "20",
@@ -203,7 +203,7 @@ describe 'Viewing A Single Case' do
       priority_band: "red"
     }.to_json
 
-    stub_request(:get, "https://example.com:80/other/api/v1/tenancies/1234567%2F01")
+    stub_request(:get, "https://example.com:80/income/api/v1/tenancies/1234567%2F01")
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end


### PR DESCRIPTION
Noticed some funky webmock/stubbing constants in these specs as I was working on MA-35 ("Link period summary/transactions to arrears diary").

This PR: 
- explictly webmocks each of the APIs for viewing a single case
- removes any stubbing of constants from this spec
- fixes a few other specs that I believe were "accidentally" passing because of this spec's heavy use of wide-matching regexes in webmock