### PR TITLE
Display the number of bedrooms

### DIFF
--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -7,6 +7,7 @@
       <li><strong>Payment reference:</strong> <%= @tenancy.payment_ref %></li>
       <li><strong>Tenure:</strong> <%= tenancy_type_name(@tenancy.tenure) %></li>
       <li><strong>Assigned to:</strong> <%= @tenancy.display_assigned_to %></li>
+      <li><strong>Number of bedrooms:</strong> <%= @tenancy.display_number_of_bedrooms %></li>
       <br>
       <li><strong>NoSP served:</strong> <%= @tenancy.display_nosp_served %></li>
       <li><strong>NoSP expires:</strong> <%= @tenancy.display_nosp_expiry %></li>

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -40,7 +40,7 @@ module Hackney
         end
 
         def display_number_of_bedrooms
-          return "Unknown" if case_priority[:num_bedrooms].nil?
+          return 'Unknown' if case_priority[:num_bedrooms].nil?
           case_priority[:num_bedrooms]
         end
 

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -39,6 +39,11 @@ module Hackney
           format_date(case_priority[:nosp_expiry_date])
         end
 
+        def display_number_of_bedrooms
+          return "Unknown" if case_priority[:num_bedrooms].nil?
+          case_priority[:num_bedrooms]
+        end
+
         private
 
         def format_date(date)

--- a/lib/hackney/income/stub_tenancy_gateway_builder.rb
+++ b/lib/hackney/income/stub_tenancy_gateway_builder.rb
@@ -53,6 +53,7 @@ module Hackney
               {
                 'id' => 1,
                 'tenancy_ref' => tenancy[:tenancy_ref],
+                'num_bedrooms' => 3,
                 'priority_band' => 'red',
                 'priority_score' => 21_563,
                 'created_at' => '2019-04-02T03=>26=>35.000Z',

--- a/spec/examples/single_case_priority_response.json
+++ b/spec/examples/single_case_priority_response.json
@@ -1,6 +1,7 @@
 {
   "id": 1,
   "tenancy_ref": "055593/01",
+  "num_bedrooms": null,
   "priority_band": "red",
   "priority_score": 21563,
   "created_at": "2019-04-02T03:26:35.000Z",

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -46,6 +46,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_css('li', text: 'Start date: August 30th, 2014', count: 1)
     expect(page.body).to have_css('li', text: 'Assigned to: Billy Bob (Credit Controller)', count: 1)
     expect(page.body).to have_css('div.tenancy_list__item--red', text: 'PRIORITY')
+    expect(page.body).to have_css('li', text: 'Number of bedrooms: Unknown')
     expect(page.body).to have_css('li', text: 'NoSP served: August 17th, 2016')
     expect(page.body).to have_css('li', text: 'NoSP expires: September 18th, 2017')
   end

--- a/spec/lib/hackney/income/view_tenancy_spec.rb
+++ b/spec/lib/hackney/income/view_tenancy_spec.rb
@@ -46,6 +46,10 @@ describe Hackney::Income::ViewTenancy do
         expect(subject.case_priority.fetch('nosp_expiry_date')).to eq('2017-09-18T00:00:00.000Z')
       end
 
+      it 'should contain the number of bedrooms of a property' do
+        expect(subject.case_priority.fetch('num_bedrooms')).to eq(3)
+      end
+
       it 'should include contact details' do
         expect(subject.primary_contact_name).to eq('Ms Diana Prince')
         expect(subject.primary_contact_long_address).to eq('1 Themyscira')


### PR DESCRIPTION
WHAT: Display the number of bedrooms for a given property

WHY: So an Income Collection Officer, can see the number of bedrooms in a property


<img width="968" alt="Screenshot 2019-10-07 at 15 29 19" src="https://user-images.githubusercontent.com/40758489/66320702-3f7a2580-e917-11e9-9d18-2867c5a944b0.png">
