### PR TITLE
Add num_bedrooms to get_tenancy method

### DIFF
--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -8,7 +8,8 @@ module Hackney
                       :primary_contact_name, :primary_contact_long_address, :case_priority,
                       :primary_contact_postcode, :transactions, :arrears_actions, :agreements,
                       :scheduled_actions, :primary_contact_phone, :primary_contact_email,
-                      :tenure, :rent, :service, :other_charge, :start_date, :contacts, :payment_ref
+                      :num_bedrooms, :tenure, :rent, :service, :other_charge, :start_date,
+                      :contacts, :payment_ref
 
         validates :ref, :current_balance, :current_arrears_agreement_status,
                   :primary_contact_name, :primary_contact_long_address,
@@ -40,8 +41,7 @@ module Hackney
         end
 
         def display_number_of_bedrooms
-          return 'Unknown' if case_priority[:num_bedrooms].nil?
-          case_priority[:num_bedrooms]
+          num_bedrooms
         end
 
         private

--- a/lib/hackney/income/tenancy_gateway.rb
+++ b/lib/hackney/income/tenancy_gateway.rb
@@ -101,6 +101,7 @@ module Hackney
           t.primary_contact_long_address = tenancy.dig('tenancy_details', 'primary_contact_long_address')
           t.primary_contact_postcode = tenancy.dig('tenancy_details', 'primary_contact_postcode')
           t.payment_ref = tenancy.dig('tenancy_details', 'payment_ref')
+          t.num_bedrooms = tenancy.dig('tenancy_details', 'num_bedrooms')
           t.arrears_actions = extract_action_diary(events: tenancy.dig('latest_action_diary_events'))
           t.agreements = extract_agreements(agreements: tenancy.dig('latest_arrears_agreements'))
           t.start_date = tenancy.dig('tenancy_details', 'start_date')

--- a/spec/examples/single_case_priority_response.json
+++ b/spec/examples/single_case_priority_response.json
@@ -1,7 +1,6 @@
 {
   "id": 1,
   "tenancy_ref": "055593/01",
-  "num_bedrooms": null,
   "priority_band": "red",
   "priority_score": 21563,
   "created_at": "2019-04-02T03:26:35.000Z",

--- a/spec/examples/single_case_response.json
+++ b/spec/examples/single_case_response.json
@@ -3,6 +3,7 @@
     "ref": "1234567/01",
     "prop_ref": null,
     "tenure": "SEC",
+    "num_bedrooms": 1,
     "rent": "¤0.00",
     "service": "¤0.00",
     "other_charge": "¤0.00",
@@ -91,7 +92,8 @@
         "hackney_homes_id": "290195",
         "age": 51,
         "responsible": true
-      }, {
+      },
+      {
         "first_name": "Ann",
         "last_name": "Sugar",
         "full_name": "Ann Sugar",

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -46,7 +46,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_css('li', text: 'Start date: August 30th, 2014', count: 1)
     expect(page.body).to have_css('li', text: 'Assigned to: Billy Bob (Credit Controller)', count: 1)
     expect(page.body).to have_css('div.tenancy_list__item--red', text: 'PRIORITY')
-    expect(page.body).to have_css('li', text: 'Number of bedrooms: Unknown')
+    expect(page.body).to have_css('li', text: 'Number of bedrooms: 1')
     expect(page.body).to have_css('li', text: 'NoSP served: August 17th, 2016')
     expect(page.body).to have_css('li', text: 'NoSP expires: September 18th, 2017')
   end


### PR DESCRIPTION
Fixes issue #211

Where we call `case_priority[:num_bedrooms]` instead we should just be calling `num_bedrooms`