### PR TITLE
Show filter only on immediate action tab

### DIFF
--- a/app/helpers/recommended_actions_select_helper.rb
+++ b/app/helpers/recommended_actions_select_helper.rb
@@ -12,7 +12,6 @@ module RecommendedActionsSelectHelper
 
   def recommended_actions_dropdown_options(selected: nil)
     options = recommended_actions_map.map { |db_name, human_name| [human_name, db_name] }
-    options.unshift(['All', nil])
 
     options_for_select(options, selected)
   end

--- a/app/helpers/worktray_helper.rb
+++ b/app/helpers/worktray_helper.rb
@@ -1,0 +1,7 @@
+module WorktrayHelper
+  def show_immediate_actions_filter?
+    tabs_to_hide_filter = %w[paused full_patch upcoming_court_dates upcoming_evictions]
+
+    tabs_to_hide_filter.select { |filter| filter.in?(params.keys) }.empty?
+  end
+end

--- a/app/views/tenancies/index.html.erb
+++ b/app/views/tenancies/index.html.erb
@@ -7,9 +7,7 @@
   <%# <%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates) %>
   <%# <%= worktray_tab_link_to("Upcoming Evictions", worktray_path(upcoming_evictions: true), :upcoming_evictions) %>
 
-  <% unless %w[paused full_patch upcoming_court_dates upcoming_evictions].any? { |tab| params.include? tab } %>
-    <%= render 'tenancies/worktray/recommended_action_filter'%>
-  <% end %>
+  <%= render 'tenancies/worktray/recommended_action_filter' if show_immediate_actions_filter? %>
 
   <% if @user_assigned_tenancies.none? %>
     <h3 class="tenancy_list tenancy_list__no_tenancies">No results found</h3>

--- a/app/views/tenancies/index.html.erb
+++ b/app/views/tenancies/index.html.erb
@@ -7,19 +7,9 @@
   <%# <%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates) %>
   <%# <%= worktray_tab_link_to("Upcoming Evictions", worktray_path(upcoming_evictions: true), :upcoming_evictions) %>
 
-  <table>
-    <tr>
-      <%= form_tag(worktray_path, :method => "get") do %>
-        <td>
-          <label class="govuk-label form-label-bold" for="code">Next Recommended Action<br/></label>
-          <%= select_tag(:recommended_actions, recommended_actions_dropdown_options(selected: params[:recommended_actions]), { :class => 'form-control' }) %>
-        </td>
-        <td>
-          <%= submit_tag('Filter by next action', class: 'button') %>
-        </td>
-      <% end %>
-    </tr>
-  </table>
+  <% unless %w[paused full_patch upcoming_court_dates upcoming_evictions].any? { |tab| params.include? tab } %>
+    <%= render 'tenancies/worktray/recommended_action_filter'%>
+  <% end %>
 
   <% if @user_assigned_tenancies.none? %>
     <h3 class="tenancy_list tenancy_list__no_tenancies">No results found</h3>

--- a/app/views/tenancies/worktray/_recommended_action_filter.html.erb
+++ b/app/views/tenancies/worktray/_recommended_action_filter.html.erb
@@ -1,0 +1,13 @@
+<%= form_tag(worktray_path, :method => "get") do %>
+  <table>
+    <tr>
+      <td>
+        <label class="govuk-label form-label-bold" for="code">Next Recommended Action<br/></label>
+        <%= select_tag(:recommended_actions, recommended_actions_dropdown_options(selected: params[:recommended_actions]), { :class => 'form-control', prompt: 'Select an action' }) %>
+      </td>
+      <td>
+        <%= submit_tag('Filter by next action', class: 'button') %>
+      </td>
+    </tr>
+  </table>
+<% end %>


### PR DESCRIPTION
### WHAT: 
Only show immediate action filter on immediate actions tab


### WHY: 
As users will only need to use this action on this tab only