### PR TITLE
Show court date and outcome on case details page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,4 +15,10 @@ module ApplicationHelper
       safe_join(html)
     end
   end
+
+  def format_date(date)
+    return '' if date.nil?
+
+    Date.parse(date).to_formatted_s(:long_ordinal)
+  end
 end

--- a/app/helpers/court_outcomes_helper.rb
+++ b/app/helpers/court_outcomes_helper.rb
@@ -1,0 +1,19 @@
+module CourtOutcomesHelper
+  def court_outcomes_map
+    {
+      'AAH' => 'Adjourned to another hearing date',
+      'AGE' => 'Adjourned generally',
+      'AOT' => 'Adjourned on Terms',
+      'OPD' => 'Outright Possession (with Date)',
+      'OPF' => 'Outright Possession (Forthwith)',
+      'PPO' => 'Postponed Possession Order',
+      'STR' => 'Struck out',
+      'SUP' => 'Suspended Possession',
+      'WOD' => 'Withdrawn on the day (arrears cleared)'
+    }
+  end
+
+  def court_outcome_for_code(code)
+    court_outcomes_map[code]
+  end
+end

--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -12,7 +12,7 @@
       <li><strong>NoSP served:</strong> <%= format_date(@tenancy.nosp_served) %></li>
       <li><strong>NoSP expires:</strong> <%= format_date(@tenancy.nosp_expiry) %></li>
       <li><strong>Court Date:</strong> <%= format_date(@tenancy.court_date) %></li>
-      <li><strong>Court Outcome:</strong> <%= @tenancy.court_outcome %></li>
+      <li><strong>Court Outcome:</strong> <%= court_outcome_for_code(@tenancy.court_outcome) %></li>
     </ul>
   </div>
 </div>

--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -11,6 +11,8 @@
       <br>
       <li><strong>NoSP served:</strong> <%= format_date(@tenancy.nosp_served) %></li>
       <li><strong>NoSP expires:</strong> <%= format_date(@tenancy.nosp_expiry) %></li>
+      <li><strong>Court Date:</strong> <%= format_date(@tenancy.court_date) %></li>
+      <li><strong>Court Outcome:</strong> <%= @tenancy.court_outcome %></li>
     </ul>
   </div>
 </div>

--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -3,14 +3,14 @@
     <h1 class="heading-xlarge"><%= @tenancy.primary_contact_name %></h1>
     <ul>
       <li><strong>Reference number:</strong> <%= @tenancy.ref %></li>
-      <li><strong>Start date:</strong> <%= @tenancy.display_start_date %></li>
+      <li><strong>Start date:</strong> <%= format_date(@tenancy.start_date) %></li>
       <li><strong>Payment reference:</strong> <%= @tenancy.payment_ref %></li>
       <li><strong>Tenure:</strong> <%= tenancy_type_name(@tenancy.tenure) %></li>
       <li><strong>Patch assigned to:</strong> <%= @tenancy.patch_code %></li>
       <li><strong>Number of bedrooms:</strong> <%= @tenancy.display_number_of_bedrooms %></li>
       <br>
-      <li><strong>NoSP served:</strong> <%= @tenancy.display_nosp_served %></li>
-      <li><strong>NoSP expires:</strong> <%= @tenancy.display_nosp_expiry %></li>
+      <li><strong>NoSP served:</strong> <%= format_date(@tenancy.nosp_served) %></li>
+      <li><strong>NoSP expires:</strong> <%= format_date(@tenancy.nosp_expiry) %></li>
     </ul>
   </div>
 </div>

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -16,10 +16,6 @@ module Hackney
                   :primary_contact_postcode,
                   presence: true
 
-        def display_start_date
-          format_date(start_date)
-        end
-
         def display_assigned_to
           if case_priority.present?
             "#{case_priority.dig(:assigned_user, :name)} (#{case_priority.dig(:assigned_user, :role)})".titleize
@@ -32,12 +28,12 @@ module Hackney
           case_priority[:priority_band]
         end
 
-        def display_nosp_served
-          format_date(case_priority[:nosp_served_date])
+        def nosp_served
+          case_priority[:nosp_served_date]
         end
 
-        def display_nosp_expiry
-          format_date(case_priority[:nosp_expiry_date])
+        def nosp_expiry
+          case_priority[:nosp_expiry_date]
         end
 
         def display_number_of_bedrooms
@@ -48,12 +44,6 @@ module Hackney
           case_priority[:patch_code]
         end
 
-        private
-
-        def format_date(date)
-          return '' if date.nil?
-          Date.parse(date).to_formatted_s(:long_ordinal)
-        end
       end
     end
   end

--- a/lib/hackney/income/domain/tenancy.rb
+++ b/lib/hackney/income/domain/tenancy.rb
@@ -44,6 +44,13 @@ module Hackney
           case_priority[:patch_code]
         end
 
+        def court_date
+          case_priority[:courtdate]
+        end
+
+        def court_outcome
+          case_priority[:court_outcome]
+        end
       end
     end
   end

--- a/spec/examples/single_case_priority_response.json
+++ b/spec/examples/single_case_priority_response.json
@@ -27,6 +27,7 @@
   "nosp_served_date": "2016-08-17T00:00:00.000Z",
   "nosp_expiry_date": "2017-09-18T00:00:00.000Z",
   "active_nosp": false,
+  "court_outcome": "AAH",
   "assigned_user_id": 1,
   "is_paused_until": null,
   "pause_reason": null,

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -31,6 +31,7 @@ describe 'Viewing A Single Case' do
     then_i_should_see_transaction_history
     then_i_should_see_action_diary_table
     then_i_should_see_action_diary_buttons
+    then_the_court_outcome_is_human_readable
   end
 
   def given_i_am_logged_in
@@ -145,6 +146,10 @@ describe 'Viewing A Single Case' do
   def then_i_should_see_a_pause_button
     expect(page.body).to have_css('.button', text: 'Pause', count: 1)
     expect(page).to have_link(href: '/tenancies/1234567%2F01/pause')
+  end
+
+  def then_the_court_outcome_is_human_readable
+    expect(page.body).to have_content('Adjourned to another hearing date')
   end
 
   def stub_income_api_tenancy

--- a/spec/helpers/court_outcomes_helper_spec.rb
+++ b/spec/helpers/court_outcomes_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe CourtOutcomesHelper, type: :helper do
+  describe '#court_outcome_for_code' do
+    context 'when we have a valid code' do
+      it 'returns a human-readable string' do
+        expect(helper.court_outcome_for_code('AAH')).to eq('Adjourned to another hearing date')
+      end
+    end
+
+    context 'when we have an invalid code' do
+      it 'returns nil' do
+        expect(helper.court_outcome_for_code('foo')).to be_nil
+      end
+    end
+
+    context 'when the given code is nil' do
+      it 'returns nil' do
+        expect(helper.court_outcome_for_code(nil)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Why
* As a user, I need to view if the case has been to court and the outcome, or if they are going to court.

### What
* Add generic format date helper
* Render pretty court date
* Add human-readable court outcome

### Screenshot with changes
![Screenshot 2019-10-29 at 11 11 46](https://user-images.githubusercontent.com/55134221/67762266-f82a1500-fa3c-11e9-8b3e-f5e8d4b223e6.png)
