### PR TITLE
Hide 'send' buttons for letter before action

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -10,10 +10,11 @@ class LettersController < ApplicationController
     @payment_refs.each_with_index do |payment_ref, i|
       @preview = generate_letter_preview(payment_ref)
 
-      if @preview[:preview].present?
-        @payment_refs.delete_at(i)
-        return @preview
-      end
+      next unless @preview[:preview].present?
+
+      @payment_refs.delete_at(i)
+      @preview[:sendable] = @preview[:template_id] != 'letter_before_action'
+      return @preview
     end
 
     flash[:notice] = 'Payment reference not found' if payment_refs_not_found?

--- a/app/views/letters/_successful_table.html.erb
+++ b/app/views/letters/_successful_table.html.erb
@@ -2,9 +2,11 @@
   <td><%= @preview.dig(:case, :payment_ref) %></td>
   <td><%= @preview.dig(:uuid) %></td>
   <td>
-    <%= button_to('Send', send_letter_path(uuid: @preview.dig(:uuid)),  method: :post, remote: true, class: 'button send_letter_button',
-      data: {
-        disable_with: "Sending..."
-      }) %>
+    <% if @preview[:sendable] %>
+      <%= button_to('Send', send_letter_path(uuid: @preview.dig(:uuid)),  method: :post, remote: true, class: 'button send_letter_button',
+        data: {
+          disable_with: "Sending..."
+        }) %>
+    <% end %>
   </td>
 </tr>

--- a/app/views/letters/preview.erb
+++ b/app/views/letters/preview.erb
@@ -59,9 +59,11 @@
         </div>
       </div>
 
-      <div>
-        <%= button_tag "Confirm and Send All", class: "button", onclick: 'submit_send_all_letters(event)' %>
-      </div>
+      <% if @preview[:sendable] %>
+        <div>
+          <%= button_tag "Confirm and Send All", class: "button", onclick: 'submit_send_all_letters(event)' %>
+        </div>
+      <% end %>
 
     </div>
 


### PR DESCRIPTION
Notably, this PR doesn't extract this policy decision - _don't use notify for certain types of letter_ - into its own component.

(My hope is we'll make that policy more visible as we work on getting the 'Download' functionality working)

If you select LBA, you'll see (with fake content):

![image](https://user-images.githubusercontent.com/429326/67502868-85a4e800-f67e-11e9-8489-ff65d87646d4.png)
