### PR TITLE
Use correct key from API to fix 'send' visibility

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -13,7 +13,7 @@ class LettersController < ApplicationController
       next unless @preview[:preview].present?
 
       @payment_refs.delete_at(i)
-      @preview[:sendable] = @preview[:template_id] != 'letter_before_action'
+      @preview[:sendable] = @preview.dig(:template, :id) != 'letter_before_action'
       return @preview
     end
 

--- a/spec/features/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/letters/view_letter_preview_success_spec.rb
@@ -133,10 +133,10 @@ describe 'Viewing A Letter Preview' do
     stub_request(:post, %r{/messages\/letters})
       .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
       .to_return(status: 200, body: {
-        'template_id' => 'letter_before_action',
-        'preview' => preview,
-        'uuid' => uuid,
-        'errors' => []
+        template: { id: 'letter_before_action' },
+        preview: preview,
+        uuid: uuid,
+        errors: []
       }.to_json)
   end
 end


### PR DESCRIPTION
This PR changes the lookup for finding out which letter is being sent, as the app should behave differently if it's a 'letter before action' - namely, it should not send via gov-notify.

It also corrects the corresponding response specs.

The original break (introduced in 534b43) highlights one of the things that can go wrong with this feature being split across an app boundary.