### PR TITLE
Ensure preview and download pdf works

### DIFF
--- a/app/assets/stylesheets/components/letter_preview.scss
+++ b/app/assets/stylesheets/components/letter_preview.scss
@@ -4,6 +4,12 @@
   max-height: 50vh;
   overflow: scroll;
 
+  object {
+    width: 100%;
+    max-width: 100%;
+    height: 50vh;
+  }
+
   .right{
     float: right;
     text-align: right;

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,8 +6,15 @@ class DocumentsController < ApplicationController
       flash[:notice] = 'Document not found'
       redirect_to documents_path
     else
+      options = {
+        content_type: document.content_type,
+        status: document.code
+      }
 
-      send_data document.body, content_type: document.content_type, disposition: document['Content-Disposition'], status: document.code
+      options[:disposition]   = 'inline' if params[:inline]
+      options[:disposition] ||= document['Content-Disposition']
+
+      send_data(document.body, options)
     end
   end
 

--- a/app/views/letters/_successful_table.html.erb
+++ b/app/views/letters/_successful_table.html.erb
@@ -8,11 +8,9 @@
           disable_with: "Sending..."
         }) %>
     <% elsif @preview[:document_id] %>
-	    <%= link_to "Download",
-        document_path(@preview[:document_id]),
-        id: "download-letter-doc-#{@preview[:document_id]}",
-        class: 'button'
-      %>
+      <a href="<%= document_path(@preview[:document_id]) %>" class="button" id="download-letter-doc-<%= @preview[:document_id] %>" download>
+        Download
+      </a>
     <% end %>
   </td>
 </tr>

--- a/app/views/letters/preview.erb
+++ b/app/views/letters/preview.erb
@@ -14,7 +14,7 @@
           <strong>Template name: </strong><%= @preview.dig(:template,:name) %>
           <div class="letter_preview">
             <% if @preview[:document_id] %>
-              <%= tag.object(id: "preview-doc-#{@preview[:document_id]}", data: "#{document_path(@preview[:document_id])}.pdf", type: 'application/pdf') %>
+              <%= tag.object(id: "preview-doc-#{@preview[:document_id]}", data: "#{document_path(@preview[:document_id])}.pdf?inline=true", type: 'application/pdf') %>
             <% else %>
               <%= @preview[:preview].html_safe %>
             <% end %>

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -19,6 +19,8 @@ describe DocumentsController do
 
   context '#show' do
     context 'when downloading document' do
+      let(:params) { { id: id } }
+
       before do
         document_response['Content-Disposition'] = res_content_disposition
         allow(document_response).to receive(:body).and_return(res_body)
@@ -28,7 +30,7 @@ describe DocumentsController do
           id: id
         ).and_return(document_response)
 
-        get :show, params: { id: id }
+        get :show, params: params
       end
 
       it { expect(response.content_type).to eq(res_content_type) }
@@ -36,6 +38,14 @@ describe DocumentsController do
       it { expect(response.header['Content-Disposition']).to eq(res_content_disposition) }
 
       it { expect(response.body).to eq(res_body) }
+
+      context 'and when the inline param is present' do
+        let(:params) { { id: id, inline: true } }
+
+        it 'has Content Disposition as `inline`' do
+          expect(response.header['Content-Disposition']).to eq('inline')
+        end
+      end
     end
 
     context 'when not found' do

--- a/spec/features/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/letters/view_letter_preview_success_spec.rb
@@ -127,6 +127,7 @@ describe 'Viewing A Letter Preview' do
 
   def then_there_is_a_clickable_download_button
     expect(page).to have_link('Download', href: document_path(document_id), id: "download-letter-doc-#{document_id}")
+    find("#download-letter-doc-#{document_id}[download]")
   end
 
   def then_there_is_not_a_clickable_download_button
@@ -134,7 +135,7 @@ describe 'Viewing A Letter Preview' do
   end
 
   def and_there_is_a_pdf_object_visible_on_the_page
-    expect(page).to have_css("object#preview-doc-#{document_id}[type='application/pdf'][data='#{document_path(document_id)}.pdf']")
+    expect(page).to have_css("object#preview-doc-#{document_id}[type='application/pdf'][data='#{document_path(document_id)}.pdf?inline=true']")
   end
 
   def and_there_is_a_html_preview_element


### PR DESCRIPTION
### Why

- Previewing PDFs and downloading them had odd behaviour 

### What

- Add ability to view documents (PDFs) inline
- Ensure download button does not have odd behaviour. 