### PR TITLE
Add upcoming court dates tab

### DIFF
--- a/app/views/tenancies/index.html.erb
+++ b/app/views/tenancies/index.html.erb
@@ -9,6 +9,7 @@
         <%= hidden_field_tag(:recommended_actions, params[:recommended_actions]) if params[:recommended_actions].present? %>
         <%= hidden_field_tag(:paused, params[:paused]) if params[:paused].present? %>
         <%= hidden_field_tag(:full_patch, params[:full_patch]) if params[:full_patch].present? %>
+        <%= hidden_field_tag(:upcoming_court_dates, params[:upcoming_court_dates]) if params[:upcoming_court_dates].present? %>
         <div class="form-group">
           <label class="form-label visually-hidden" for="code"><strong>Patch</strong><br/></label>
           <%= select_tag(:patch_code, patch_codes_options(selected: cookies[:patch_code]), { :class => 'form-control' }) %>
@@ -21,7 +22,7 @@
   <%= worktray_tab_link_to("Immediate Actions", worktray_path) %>
   <%= worktray_tab_link_to("Paused", worktray_path(paused: true), :paused) %>
   <%= worktray_tab_link_to("Full Patch", worktray_path(full_patch: true), :full_patch) %>
-  <%# <%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates) %>
+  <%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates) %>
   <%# <%= worktray_tab_link_to("Upcoming Evictions", worktray_path(upcoming_evictions: true), :upcoming_evictions) %>
 
   <%= render 'tenancies/worktray/recommended_action_filter' if show_immediate_actions_filter? %>

--- a/spec/features/view_my_cases_spec.rb
+++ b/spec/features/view_my_cases_spec.rb
@@ -57,7 +57,7 @@ describe 'Viewing My Cases' do
     expect(page).to have_link(href: '/worktray')
     expect(page).to have_link(href: '/worktray?paused=true')
     expect(page).to have_link(href: '/worktray?full_patch=true')
-    # expect(page).to have_link(href: '/worktray?upcoming_court_dates=true')
+    expect(page).to have_link(href: '/worktray?upcoming_court_dates=true')
     # expect(page).to have_link(href: '/worktray?upcoming_evictions=true')
   end
 


### PR DESCRIPTION
### WHAT
Added an upcoming court dates tab
### WHY
So we can filter cases by the earliest upcoming court dates

<img width="890" alt="Screenshot 2019-11-06 at 11 02 19" src="https://user-images.githubusercontent.com/40758489/68293043-0e5f5300-0085-11ea-8e9b-420cf3d7731c.png">
