### PR TITLE
Include a manual staging deploy from branches other than master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - store_artifacts:
           path: coverage
 
-  deploy_to_staging:
+  deploy_to_staging: &deploy_to_staging
     docker:
        - image: circleci/ruby:2.5.3-node-browsers
     working_directory: ~/repo
@@ -75,6 +75,8 @@ jobs:
             git push --force git@heroku.com:$HEROKU_STAGING_APP_NAME.git HEAD:refs/heads/master
             sleep 5 # sleep for 5 seconds to wait for dynos
             heroku restart
+  deploy_to_staging_manual:
+    <<: *deploy_to_staging
 
   deploy_to_production:
     docker:
@@ -107,6 +109,19 @@ workflows:
           filters:
             branches:
               only: master
+      - permit_manual_staging_release:
+          type: approval
+          requires:
+            - build_and_check
+          filters:
+            branches:
+              ignore: master
+      - deploy_to_staging_manual:
+          requires:
+            - permit_manual_staging_release
+          filters:
+            branches:
+              ignore: master
       - permit_production_release:
           type: approval
           requires:


### PR DESCRIPTION
### Why

- We need to deploy non-master branches to staging before we merge into master 

### What

- Add workflow to allow staging to be deployed manually.