### PR TITLE
Add helpful guide for running Feature tests in Chrome in dev

### DIFF
--- a/spec/support/chrome_test_helper.rb
+++ b/spec/support/chrome_test_helper.rb
@@ -1,8 +1,25 @@
 require 'selenium/webdriver'
 
+###################################
+# How to use:
+###################################
+#
+# You need to use RSpec in your own shell. You cannot use this inside Docker.
+#
+# `require 'support/chrome_test_helper'` at the top of your feature test.
+#
+# Use `js: true` to use Headless Chrome on a context/describe
+# Include `, driver: :selenium_chrome` to use Chrome in Head mode to help debug.
+#
+# E.g.: `scenario 'Testing something awesome', js: true, driver: :selenium_chrome do`
+#
+# Call `#pause` in your `scenario` to stop the test at a point so you can see
+# how everything looks/debug.
+#
+
 # Use `:selenium_chrome` for Header version
 Capybara.javascript_driver = :selenium_chrome_headless
 
-# Use `js: true` to use Headless Chrome on a context/describe
-# Include `, driver: :selenium_chrome` to use Chrome in Head mode to help
-# debug.
+def pause
+  STDIN.gets
+end


### PR DESCRIPTION
### Why

- Sometimes we need to mock the API when developing new features.

### What

- Allow running a the service with a mocked API (using tests) to help develop UI features.