### PR TITLE
Send usernames with download request

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,6 +1,9 @@
 class DocumentsController < ApplicationController
   def show
-    document = use_cases.download_document.execute(id: params.require(:id))
+    document = use_cases.download_document.execute(
+      id: params.require(:id),
+      username: current_user.name
+    )
 
     if document.code == 404
       flash[:notice] = 'Document not found'

--- a/lib/hackney/income/documents_gateway.rb
+++ b/lib/hackney/income/documents_gateway.rb
@@ -8,8 +8,10 @@ module Hackney
         @api_key = api_key
       end
 
-      def download_document(id:)
-        res = make_request("#{@api_host}#{DOCUMENTS_ENDPOINT}#{id}/download", {})
+      def download_document(id:, username:)
+        return unless username.present?
+
+        res = make_request("#{@api_host}#{DOCUMENTS_ENDPOINT}#{id}/download", username: username)
 
         unless res.is_a? Net::HTTPSuccess
           raise Exceptions::IncomeApiError::NotFoundError.new(res), "when trying to download_letter with id: '#{id}'"

--- a/lib/hackney/income/download_document.rb
+++ b/lib/hackney/income/download_document.rb
@@ -5,9 +5,9 @@ module Hackney
         @documents_gateway = documents_gateway
       end
 
-      def execute(id:)
+      def execute(id:, username:)
         @documents_gateway.download_document(
-          id: id
+          id: id, username: username
         )
       end
     end

--- a/spec/features/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/letters/view_letter_preview_success_spec.rb
@@ -32,51 +32,23 @@ describe 'Viewing A Letter Preview' do
     end
   end
 
-  context 'when sending a leasehold letter (with old API)' do
-    before do
-      stub_my_cases_response
-      stub_get_templates_response
-      stub_success_post_send_letter_response_as_lba
-    end
-
-    scenario 'I cannot send LBA Letters' do
-      given_i_am_logged_in
-      when_i_visit_new_letter_page
-      and_i_select letter_type: 'Letter before action'
-      and_i_fill_in_the_form_and_submit
-      then_i_cannot_send_a_letter
-    end
-
-    scenario 'I cannot download LBA Letters' do
-      given_i_am_logged_in
-      when_i_visit_new_letter_page
-      and_i_select letter_type: 'Letter before action'
-      and_i_fill_in_the_form_and_submit
-      then_there_is_not_a_clickable_download_button
-      and_there_is_a_html_preview_element
-    end
-  end
-
-  context 'when sending a leasehold letter (with updated API)' do
+  context 'when previewing a letter before action' do
     before do
       stub_my_cases_response
       stub_get_templates_response
       stub_success_post_send_letter_response_as_lba_with_doc_id
-    end
 
-    scenario 'I cannot send LBA Letters' do
       given_i_am_logged_in
       when_i_visit_new_letter_page
       and_i_select letter_type: 'Letter before action'
       and_i_fill_in_the_form_and_submit
+    end
+
+    scenario 'I cannot send it' do
       then_i_cannot_send_a_letter
     end
 
-    scenario 'I can download LBA Letters' do
-      given_i_am_logged_in
-      when_i_visit_new_letter_page
-      and_i_select letter_type: 'Letter before action'
-      and_i_fill_in_the_form_and_submit
+    scenario 'I can download it' do
       then_there_is_a_clickable_download_button
       and_there_is_a_pdf_object_visible_on_the_page
     end

--- a/spec/lib/hackney/income/documents_gateway_spec.rb
+++ b/spec/lib/hackney/income/documents_gateway_spec.rb
@@ -4,42 +4,58 @@ describe Hackney::Income::DocumentsGateway do
   let(:api_key) { 'FAKE_API_KEY-53822c9d-b17d-442d-ace7-565d08215d20-53822c9d-b17d-442d-ace7-565d08215d20' }
   let(:api_host) { 'https://example.com/api/' }
   let(:template_id) { Faker::LeagueOfLegends.location }
-  let(:user_id) { Faker::Number.number(4) }
   let(:payment_ref) { Faker::Number.number(8) }
   let(:uuid) { SecureRandom.uuid }
   let(:id) { Faker::Number.number(2) }
 
   subject { described_class.new(api_key: api_key, api_host: api_host) }
 
-  context 'when successfully downloading a sent letter' do
+  context 'downloading a letter' do
     before do
-      stub_request(:get, "#{api_host}v1/documents/#{id}/download").to_return(status: 200, body: 'file', headers: {})
+      stub_request(:get, "#{api_host}v1/documents/#{id}/download")
+        .with(query: { username: username })
+        .to_return(status: 200, body: 'file', headers: {})
+
+      subject.download_document(id: id, username: username)
     end
 
-    it 'retrieves a sent letter' do
-      subject.download_document(id: id)
+    context 'with a username' do
+      let(:username) { Faker::Lorem.characters(10) }
 
-      expect have_requested(:get, "#{api_host}v1/documents/#{id}/download").once
+      it 'calls the correct endpoint with a username' do
+        expect(WebMock).to have_requested(:get, "#{api_host}v1/documents/#{id}/download?username=#{username}").once
+      end
+    end
+
+    context 'without a username' do
+      let(:username) { nil }
+
+      it 'does not make a web request' do
+        expect(WebMock).to_not have_requested(:any, /.*/)
+      end
     end
   end
 
-  context 'when failing to downloading a sent letter' do
+  context 'when trying to download a letter than does not exist' do
     before do
-      stub_request(:get, "#{api_host}v1/documents/#{id}/download").to_return(status: 404)
+      stub_request(:get, "#{api_host}v1/documents/#{id}/download")
+        .with(query: hash_including({}))
+        .to_return(status: 404)
     end
 
-    it 'throws 404 error' do
-      expect { subject.download_document(id: id) }.to raise_error(
-        Exceptions::IncomeApiError::NotFoundError,
-        "[Income API error: Received 404 response] when trying to download_letter with id: '#{id}'"
-      )
+    it 'throws a custom NotFoundErrr' do
+      expect { subject.download_document(id: id, username: 'example') }
+        .to raise_error(
+          Exceptions::IncomeApiError::NotFoundError,
+          "[Income API error: Received 404 response] when trying to download_letter with id: '#{id}'"
+        )
     end
   end
 
   context 'when retrieving all saved documents' do
     let(:metadata) do
       example_metadata(
-        user_id: user_id,
+        user_id: 1,
         payment_ref: payment_ref,
         id: template_id
       )
@@ -59,7 +75,7 @@ describe Hackney::Income::DocumentsGateway do
 
     it 'get a list of all documents' do
       documents = subject.get_all
-      expect have_requested(:get, "#{api_host}v1/documents").once
+      expect(WebMock).to have_requested(:get, "#{api_host}v1/documents/").once
 
       expect(documents).to eq([{
                                  id: id,
@@ -74,15 +90,15 @@ describe Hackney::Income::DocumentsGateway do
                                }])
     end
 
-    context 'when payment_ref param is present' do
+    context 'with a payment reference parameter' do
       before do
         stub_request(:get, "#{api_host}v1/documents/?payment_ref=1234567890").to_return(status: 200, body: [document].to_json)
       end
 
-      it 'get a list of all documents' do
+      it 'passes a filter to the documents endpoint' do
         subject.get_all(filters: { payment_ref: '1234567890' })
 
-        expect have_requested(:get, "#{api_host}v1/documents").with(query: { payment_ref: 'payment_ref' })
+        expect(WebMock).to have_requested(:get, "#{api_host}v1/documents/").with(query: { payment_ref: '1234567890' })
       end
     end
   end


### PR DESCRIPTION
This PR will allow the `income-api` to write action diary entries with names against them. They're not very useful without names!

It also includes some work on the related specs - there are a few that were now obsolete, and a few that had ineffectual assertions due to bad syntax.