### PR TITLE
Fix sending the wrong formatted params to the API

### DIFF
--- a/lib/hackney/income/domain/user.rb
+++ b/lib/hackney/income/domain/user.rb
@@ -11,6 +11,10 @@ module Hackney
         def income_collection?
           groups.join(' ').include?('income')
         end
+
+        def to_query(*args)
+          as_json.to_query(*args)
+        end
       end
     end
   end

--- a/lib/hackney/income/letters_gateway.rb
+++ b/lib/hackney/income/letters_gateway.rb
@@ -54,9 +54,9 @@ module Hackney
 
       def get_letter_templates(user:)
         uri = URI("#{@api_host}#{GET_LETTER_TEMPLATES_ENDPOINT}")
+        uri.query = user.to_query(:user)
 
         req = Net::HTTP::Get.new(uri)
-        req.set_form_data(user: user.to_json)
         req['X-Api-Key'] = @api_key
         res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: (uri.scheme == 'https')) { |http| http.request(req) }
 

--- a/spec/lib/hackney/income/domain/user_spec.rb
+++ b/spec/lib/hackney/income/domain/user_spec.rb
@@ -90,4 +90,55 @@ describe Hackney::Income::Domain::User do
       end
     end
   end
+
+  describe '#to_query' do
+    let(:groups) { ['group-1', 'group-2'] }
+    let(:user) do
+      described_class.new.tap do |user|
+        user.name = Faker::Name.name
+        user.email = Faker::Internet.email
+        user.id = Faker::Number.number(4)
+      end
+    end
+
+    context 'with no params supplied' do
+      it 'returns a string' do
+        expect(user.to_query).to be_a(String)
+      end
+
+      it "contains the user's ID" do
+        expect(user.to_query).to include("id=#{CGI.escape(user.id)}")
+      end
+
+      it "contains the user's Name" do
+        expect(user.to_query).to include("name=#{CGI.escape(user.name)}")
+      end
+
+      it "contains the user's Email" do
+        expect(user.to_query).to include("email=#{CGI.escape(user.email)}")
+      end
+
+      it "contains the user's Groups" do
+        url_groups = user.groups.map { |g| "groups#{CGI.escape('[]')}=#{CGI.escape(g)}" }.join('&')
+        expect(user.to_query).to include(url_groups)
+      end
+    end
+
+    context 'with a namespace param supplied' do
+      let(:namespace) { :user }
+      let(:user_query) { user.to_query(namespace) }
+
+      it 'returns a string' do
+        expect(user_query).to be_a(String)
+      end
+
+      it 'contains the namespace' do
+        expect(user_query).to include(namespace.to_s)
+      end
+
+      it 'formats the namespace in a way that Rails expects' do
+        expect(user_query).to include("#{CGI.escape('user[name]')}=#{CGI.escape(user.name)}")
+      end
+    end
+  end
 end

--- a/spec/lib/hackney/income/letters_gateway_spec.rb
+++ b/spec/lib/hackney/income/letters_gateway_spec.rb
@@ -119,7 +119,14 @@ describe Hackney::Income::LettersGateway do
     let(:name) { Faker::LeagueOfLegends.location }
 
     before do
-      stub_request(:get, "#{api_host}v1/messages/letters/get_templates")
+      user_params = {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        groups: user.groups
+      }.to_param(:user)
+
+      stub_request(:get, "#{api_host}v1/messages/letters/get_templates?#{user_params}")
         .to_return(
           status: 200,
           body: [{
@@ -130,7 +137,7 @@ describe Hackney::Income::LettersGateway do
         )
     end
 
-    it 'get\'s a list of templates' do
+    it "get's a list of templates" do
       expect(subject.get_letter_templates(user: user)).to eq([{
         id: template_id,
         name: name
@@ -139,15 +146,24 @@ describe Hackney::Income::LettersGateway do
   end
 
   context 'when failing to get letter templates' do
+    let(:user_params) do
+      {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        groups: user.groups
+      }.to_param(:user)
+    end
+
     before do
-      stub_request(:get, "#{api_host}v1/messages/letters/get_templates")
+      stub_request(:get, "#{api_host}v1/messages/letters/get_templates?#{user_params}")
         .to_return(status: 500)
     end
 
     it 'throws an error' do
       expect { subject.get_letter_templates(user: user) }.to raise_error(
         Exceptions::IncomeApiError,
-        "[Income API error: Received 500 response] when trying to get_letter_templates 'https://example.com/api/v1/messages/letters/get_templates'"
+        "[Income API error: Received 500 response] when trying to get_letter_templates 'https://example.com/api/v1/messages/letters/get_templates?#{user_params}'"
       )
     end
   end


### PR DESCRIPTION
- Using a GET request so should use query rather than form data.
- Have to override `#to_query` as we don't actually serialize the object 
to a Hash first.
- Use a namespace in the `#to_query` to allow us to setup the format of 
the query that the API expects.