### PR TITLE
Add documents view param to documents controller

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -2,7 +2,8 @@ class DocumentsController < ApplicationController
   def show
     document = use_cases.download_document.execute(
       id: params.require(:id),
-      username: current_user.name
+      username: current_user.name,
+      documents_view: params[:documents_view]
     )
 
     if document.code == 404

--- a/app/views/documents/index.erb
+++ b/app/views/documents/index.erb
@@ -34,7 +34,7 @@
               <td><%= (document[:status] || '').capitalize %></td>
               <td><%= document[:created_at].to_formatted_s(:long_ordinal) %></td>
               <td><%= document[:updated_at].to_formatted_s(:long_ordinal) %></td>
-              <td><%= link_to('Download', document_path(document[:id])) %></td>
+              <td><%= link_to('Download', document_path(id: document[:id], documents_view: true)) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/documents/index.erb
+++ b/app/views/documents/index.erb
@@ -34,7 +34,7 @@
               <td><%= (document[:status] || '').capitalize %></td>
               <td><%= document[:created_at].to_formatted_s(:long_ordinal) %></td>
               <td><%= document[:updated_at].to_formatted_s(:long_ordinal) %></td>
-              <td><%= link_to('Download', document_path(id: document[:id], documents_view: true)) %></td>
+              <td><%= link_to('Download', document_path(document[:id], documents_view: true)) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/lib/hackney/income/documents_gateway.rb
+++ b/lib/hackney/income/documents_gateway.rb
@@ -8,10 +8,10 @@ module Hackney
         @api_key = api_key
       end
 
-      def download_document(id:, username:)
+      def download_document(id:, username:, documents_view:)
         return unless username.present?
 
-        res = make_request("#{@api_host}#{DOCUMENTS_ENDPOINT}#{id}/download", username: username)
+        res = make_request("#{@api_host}#{DOCUMENTS_ENDPOINT}#{id}/download", username: username, documents_view: documents_view)
 
         unless res.is_a? Net::HTTPSuccess
           raise Exceptions::IncomeApiError::NotFoundError.new(res), "when trying to download_letter with id: '#{id}'"

--- a/lib/hackney/income/download_document.rb
+++ b/lib/hackney/income/download_document.rb
@@ -5,9 +5,11 @@ module Hackney
         @documents_gateway = documents_gateway
       end
 
-      def execute(id:, username:)
+      def execute(id:, username:, documents_view:)
         @documents_gateway.download_document(
-          id: id, username: username
+          id: id,
+          username: username,
+          documents_view: documents_view
         )
       end
     end

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -20,7 +20,7 @@ describe DocumentsController do
 
         expect_any_instance_of(Hackney::Income::DocumentsGateway)
           .to receive(:download_document)
-          .with(id: id, username: @user.name)
+          .with(id: id, username: @user.name, documents_view: nil)
           .and_return(document_response)
 
         get :show, params: params
@@ -37,6 +37,27 @@ describe DocumentsController do
           expect(response.header['Content-Disposition']).to eq('inline')
         end
       end
+    end
+
+    context 'when downloading document from the document view' do
+      let(:params) { { id: id, documents_view: true } }
+
+      before do
+        document_response['Content-Disposition'] = res_content_disposition
+        allow(document_response).to receive(:body).and_return(res_body)
+        allow(document_response).to receive(:content_type).and_return(res_content_type)
+
+        expect_any_instance_of(Hackney::Income::DocumentsGateway)
+          .to receive(:download_document)
+          .with(id: id, username: @user.name, documents_view: 'true')
+          .and_return(document_response)
+
+        get :show, params: params
+      end
+
+      it { expect(response.content_type).to eq(res_content_type) }
+      it { expect(response.header['Content-Disposition']).to eq(res_content_disposition) }
+      it { expect(response.body).to eq(res_body) }
     end
 
     context 'when not found' do


### PR DESCRIPTION
**What?**

- Add param to document controller 

**Why**

- This param is required for the api to determine where the document is being downloaded from. This will determine whether or not the status will be updated to `downloaded` when the documents controller is hit (this is not desired behaviour when the documents controller is hit from the documents view).