### PR TITLE
Add param to path in object preview tag to remove duplicate action diary write 

### DIFF
--- a/app/views/letters/preview.erb
+++ b/app/views/letters/preview.erb
@@ -14,7 +14,7 @@
           <strong>Template name: </strong><%= @preview.dig(:template,:name) %>
           <div class="letter_preview">
             <% if @preview[:document_id] %>
-              <%= tag.object(id: "preview-doc-#{@preview[:document_id]}", data: "#{document_path(@preview[:document_id])}.pdf?inline=true", type: 'application/pdf') %>
+              <%= tag.object(id: "preview-doc-#{@preview[:document_id]}", data: "#{document_path(@preview[:document_id])}.pdf?inline=true&documents_view=true", type: 'application/pdf') %>
             <% else %>
               <%= @preview[:preview].html_safe %>
             <% end %>

--- a/spec/features/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/letters/view_letter_preview_success_spec.rb
@@ -105,7 +105,7 @@ describe 'Viewing A Letter Preview' do
   end
 
   def and_there_is_a_pdf_object_visible_on_the_page
-    expect(page).to have_css("object#preview-doc-#{document_id}[type='application/pdf'][data='#{document_path(document_id)}.pdf?inline=true']")
+    expect(page).to have_css("object#preview-doc-#{document_id}[type='application/pdf'][data='#{document_path(document_id)}.pdf?inline=true&documents_view=true']")
   end
 
   def and_there_is_a_html_preview_element


### PR DESCRIPTION
**What?**

- Add param to path when documents controller is hit by the object tag 

**Why?**

- There is an object tag in the preview which hits the documents controller. This triggers a premature action diary write. The param is checked in the backend to disable this behaviour. 