### PR TITLE
MA-256 - Do not mark Rents letters as downloaded

### DIFF
--- a/app/views/income_collection/letters/preview.html.erb
+++ b/app/views/income_collection/letters/preview.html.erb
@@ -19,7 +19,7 @@
           <strong>Template name: </strong><%= @preview.dig(:template,:name) %>
           <div class="letter_preview">
             <% if @preview[:document_id] %>
-              <%= tag.object(id: "preview-doc-#{@preview[:document_id]}", data: "#{document_path(@preview[:document_id])}.pdf?inline=true", type: 'application/pdf') %>
+              <%= tag.object(id: "preview-doc-#{@preview[:document_id]}", data: "#{document_path(@preview[:document_id])}.pdf?inline=true&documents_view=true", type: 'application/pdf') %>
             <% else %>
               <%= @preview[:preview].html_safe %>
             <% end %>


### PR DESCRIPTION
### Why 

- Viewing the `/documents/:id` endpoint triggers a use case to mark Documents as Downloaded and writes to the Action Diary.

### What 

- Add the special param to stop this happening.

### Guidance Review

- This stops the following code from running: https://github.com/LBHackney-IT/lbh-income-api/blob/master/app/controllers/documents_controller.rb#L6