### PR TITLE
display appropriate name for new letter codes

### DIFF
--- a/lib/hackney/income/action_diary_entry_codes.rb
+++ b/lib/hackney/income/action_diary_entry_codes.rb
@@ -162,7 +162,7 @@ module Hackney
           { name: 'Arrears reinstated to offset', code: 'WON', user_accessible: false },
           { name: 'Automated green in Arrears sms message', code: 'GAT', user_accessible: false },
           { name: 'Automated green in Arrears email message', code: 'GAE', user_accessible: false },
-          { name: 'Manual green in Arrears email message', code: 'GME', user_maccessible: false },
+          { name: 'Manual green in Arrears email message', code: 'GME', user_accessible: false },
           { name: 'Manual green in Arrears sms message', code: 'GMS', user_accessible: false },
           { name: 'Manual amber in Arrears sms message', code: 'AMS', user_accessible: false },
           { name: 'Court date set', code: 'CDS', user_accessible: true },
@@ -176,7 +176,9 @@ module Hackney
           { name: 'Letter 2 in arrears LH', code: 'LL2', user_accessible: false },
           { name: 'Letter 1 in arrears SO', code: 'LS1', user_accessible: false },
           { name: 'Letter 2 in arrears SO', code: 'LS2', user_accessible: false },
-          { name: 'Letter Before Action', code: 'SLB', user_accessible: false }
+          { name: 'Letter Before Action', code: 'SLB', user_accessible: false },
+          { name: 'Income Collection Letter 1', code: 'IC1', user_accessible: false },
+          { name: 'Income Collection Letter 2', code: 'IC2', user_accessible: false }
         ]
       end
 

--- a/spec/lib/hackney/income/action_diary_entry_codes_spec.rb
+++ b/spec/lib/hackney/income/action_diary_entry_codes_spec.rb
@@ -51,4 +51,29 @@ describe Hackney::Income::ActionDiaryEntryCodes do
       expect(described_class.valid_code?('WON', user_accessible: false)).to eq(true)
     end
   end
+
+  context 'when displaying letter codes' do
+    tests = [
+      { name: 'Letter 1 in arrears FH', code: 'LF1' },
+      { name: 'Letter 2 in arrears FH', code: 'LF2' },
+      { name: 'Letter 1 in arrears LH', code: 'LL1' },
+      { name: 'Letter 2 in arrears LH', code: 'LL2' },
+      { name: 'Letter 1 in arrears SO', code: 'LS1' },
+      { name: 'Letter 2 in arrears SO', code: 'LS2' },
+      { name: 'Letter Before Action', code: 'SLB' },
+      { name: 'Income Collection Letter 1', code: 'IC1' },
+      { name: 'Income Collection Letter 2', code: 'IC2' },
+      { name: 'Automated green in Arrears sms message', code: 'GAT' },
+      { name: 'Automated green in Arrears email message', code: 'GAE' },
+      { name: 'Manual green in Arrears email message', code: 'GME' },
+      { name: 'Manual green in Arrears sms message', code: 'GMS' },
+      { name: 'Manual amber in Arrears sms message', code: 'AMS' }
+    ]
+
+    tests.each do |test_case|
+      it "correctly displays name for action code #{test_case[:code]}" do
+        expect(described_class.human_readable_action_code(test_case[:code])).to eq(test_case[:name])
+      end
+    end
+  end
 end


### PR DESCRIPTION
New letter codes were introduced in UH that we didn't have yet mapped for the front end to display nicely, also I took the opportunity to add a test to make sure that the actions that we've automated display nicely 