### PR TITLE
Rename some of the env vars to make more sense

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,9 @@ jobs:
       - run:
           name: Run tests
           environment:
-            INCOME_COLLECTION_API_HOST: https://example.com/tenancy/api
-            INCOME_COLLECTION_API_KEY: abc123
-            INCOME_COLLECTION_LIST_API_HOST: https://example.com/income/api
+            TENANCY_API_URL: https://example.com/tenancy/api
+            HACKNEY_API_KEY: abc123
+            INCOME_API_URL: https://example.com/income/api
           command: |
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
-INCOME_COLLECTION_API_HOST=https://example.com/tenancy/api
-INCOME_COLLECTION_LIST_API_HOST=https://example.com/income/api
-INCOME_COLLECTION_API_KEY='TEST_API_KEY'
+TENANCY_API_URL=https://example.com/tenancy/api
+INCOME_API_URL=https://example.com/income/api
+HACKNEY_API_KEY='TEST_API_KEY'
 
 HACKNEY_JWT_SECRET='test_secret'

--- a/app.json
+++ b/app.json
@@ -21,7 +21,13 @@
     "DATABASE_USERNAME": {
       "required": true
     },
-    "INCOME_COLLECTION_API_HOST": {
+    "INCOME_API_URL": {
+      "required": true
+    },
+    "TENANCY_API_URL": {
+      "required": true
+    },
+    "HACKNEY_API_KEY": {
       "required": true
     },
     "LANG": {

--- a/docker-compose.service.yml
+++ b/docker-compose.service.yml
@@ -4,8 +4,8 @@ services:
     image: managearrears
     environment:
     - AUTH_NO_AZURE_AD=true
-    - INCOME_COLLECTION_LIST_API_HOST=http://incomeapi:3000/api/
-    - INCOME_COLLECTION_API_HOST=http://tenancyapi:80/api
+    - INCOME_API_URL=http://incomeapi:3000/api/
+    - TENANCY_API_URL=http://tenancyapi:80/api
     working_dir: /app
     command: sh -c 'cd /app && rails s'
     volumes:

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -111,44 +111,45 @@ module Hackney
       end
 
       # FIXME: gateways shouldn't be exposed by the UseCaseFactory, but ActionDiaryEntryController depends on it
-      TENANCY_API = ENV.fetch('INCOME_COLLECTION_API_HOST')
+      TENANCY_API_URL = ENV.fetch('TENANCY_API_URL')
+      HACKNEY_API_KEY = ENV.fetch('HACKNEY_API_KEY')
 
       def tenancy_gateway
         Hackney::Income::TenancyGateway.new(
-          api_host: TENANCY_API,
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          api_host: TENANCY_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       private
 
-      INCOME_API_HOST = ENV['INCOME_COLLECTION_LIST_API_HOST']
+      INCOME_API_URL = ENV['INCOME_API_URL']
 
       def users_gateway
         Hackney::Income::IncomeApiUsersGateway.new(
-          api_host: INCOME_API_HOST,
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          api_host: INCOME_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       def create_action_diary_gateway
         Hackney::Income::CreateActionDiaryEntryGateway.new(
-          api_host: INCOME_API_HOST,
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          api_host: INCOME_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       def get_diary_entries_gateway
         Hackney::Income::GetActionDiaryEntriesGateway.new(
-          api_host: TENANCY_API,
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          api_host: TENANCY_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       def transactions_gateway
         Hackney::Income::TransactionsGateway.new(
-          api_host: TENANCY_API,
-          api_key: ENV['INCOME_COLLECTION_API_KEY'],
+          api_host: TENANCY_API_URL,
+          api_key: HACKNEY_API_KEY,
           include_developer_data: Rails.application.config.include_developer_data?
         )
       end
@@ -156,36 +157,36 @@ module Hackney
       def notifications_gateway
         Hackney::Income::GovNotifyGateway.new(
           sms_sender_id: ENV['GOV_NOTIFY_SENDER_ID'],
-          api_host: INCOME_API_HOST,
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          api_host: INCOME_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       def letters_gateway
         Hackney::Income::LettersGateway.new(
-          api_host: INCOME_API_HOST,
-          api_key: ENV.fetch('INCOME_COLLECTION_API_KEY')
+          api_host: INCOME_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       def documents_gateway
         Hackney::Income::DocumentsGateway.new(
-          api_host: INCOME_API_HOST,
-          api_key: ENV.fetch('INCOME_COLLECTION_API_KEY')
+          api_host: INCOME_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       def search_tenancies_gateway
         Hackney::Income::SearchTenanciesGateway.new(
-          api_host: TENANCY_API,
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          api_host: TENANCY_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
 
       def income_api_tenancy_gateway
         Hackney::Income::TenancyGateway.new(
-          api_host: INCOME_API_HOST,
-          api_key: ENV['INCOME_COLLECTION_API_KEY']
+          api_host: INCOME_API_URL,
+          api_key: HACKNEY_API_KEY
         )
       end
     end

--- a/spec/features/creating_action_diary_entry_spec.rb
+++ b/spec/features/creating_action_diary_entry_spec.rb
@@ -55,7 +55,7 @@ describe 'creating action diary entry' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567/actions')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: body)
   end
 

--- a/spec/features/income_collection/letters/view_letter_preview_failures_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_failures_spec.rb
@@ -57,13 +57,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1.erb',
@@ -75,7 +75,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1.erb',

--- a/spec/features/income_collection/letters/view_letter_preview_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_spec.rb
@@ -58,13 +58,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'income_collection_letter_1_template',
@@ -79,7 +79,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1_template.erb',

--- a/spec/features/income_collection/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_success_spec.rb
@@ -93,13 +93,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'income_collection_letter_1_template',
@@ -114,7 +114,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response(with_doc:)
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1_template.erb',

--- a/spec/features/leasehold/letters/view_letter_preview_failures_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_failures_spec.rb
@@ -56,13 +56,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',
@@ -74,7 +74,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',

--- a/spec/features/leasehold/letters/view_letter_preview_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_spec.rb
@@ -58,13 +58,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'letter_1_template',
@@ -79,7 +79,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',

--- a/spec/features/leasehold/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_success_spec.rb
@@ -117,13 +117,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'letter_1_template',
@@ -138,7 +138,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',
@@ -153,7 +153,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response_as_lba
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         template: { id: 'letter_before_action' },
         preview: preview,
@@ -164,7 +164,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response_as_lba_with_doc_id
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: {
         template: { id: 'letter_before_action' },
         preview: preview,

--- a/spec/features/page_navigation_spec.rb
+++ b/spec/features/page_navigation_spec.rb
@@ -48,7 +48,7 @@ describe 'Page navigation' do
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -56,7 +56,7 @@ describe 'Page navigation' do
     response_json = { 'payment_transactions': [] }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -76,7 +76,7 @@ describe 'Page navigation' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -89,7 +89,7 @@ describe 'Page navigation' do
         number_per_page: '20',
         page_number: '1'
       ))
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -97,7 +97,7 @@ describe 'Page navigation' do
     response_json = { arrears_action_diary_events: [] }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -105,7 +105,7 @@ describe 'Page navigation' do
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
 
     stub_request(:get, 'https://example.com/income/api/v1/tenancies/TEST%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 

--- a/spec/features/search_tenancies_spec.rb
+++ b/spec/features/search_tenancies_spec.rb
@@ -53,7 +53,7 @@ describe 'Search page' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases/)
-    .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+    .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
     .to_return(status: 200, body: response_json, headers: {})
   end
 

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -152,7 +152,7 @@ describe 'Viewing A Single Case' do
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -179,7 +179,7 @@ describe 'Viewing A Single Case' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -199,7 +199,7 @@ describe 'Viewing A Single Case' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -212,7 +212,7 @@ describe 'Viewing A Single Case' do
         number_per_page: '20',
         page_number: '1'
       ))
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -220,7 +220,7 @@ describe 'Viewing A Single Case' do
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
 
     stub_request(:get, 'https://example.com/income/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -245,7 +245,7 @@ describe 'Viewing A Single Case' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -141,7 +141,7 @@ describe 'Worktray' do
     uri = /cases\?#{default_filters.to_param}/
 
     stub_request(:get, uri)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 end

--- a/spec/features/view_transactions_spec.rb
+++ b/spec/features/view_transactions_spec.rb
@@ -53,7 +53,7 @@ describe 'Viewing Transaction History' do
     stub_const('Hackney::Income::GetActionDiaryEntriesGateway', Hackney::Income::StubGetActionDiaryEntriesGateway)
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -62,7 +62,7 @@ describe 'Viewing Transaction History' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
     stub_request(:get, %r{/api\/v1\/tenancies\/1234567/})
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 end

--- a/spec/request/worktray_spec.rb
+++ b/spec/request/worktray_spec.rb
@@ -73,7 +73,7 @@ describe 'Viewing the Worktray', type: :request do
     uri = /cases\?#{default_filters.to_param}/
 
     stub_request(:get, uri)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_COLLECTION_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 end


### PR DESCRIPTION
There are currently two environment variables to configure which api URL to use for the tenancy and income apis:
* INCOME_COLLECTION_API_HOST
* INCOME_COLLECTION_LIST_API_HOST
It's not immediately clear which should be which from the naming of these so I've renamed them to INCOME_API_URL and TENANCY_API_URL to make it clearer. It also fixes where the Docker command to run everything was pointing these env vars to as they were currently switched.
Also, I've renamed INCOME_COLLECTION_API_KEY to HACKNEY_API_KEY since it is not for the income collection API but shared by all Hackney APIs.

I've added these in to Heroku so all should be fine deploying.