### PR TITLE
Make sure the User's JSON string is consistent

### DIFF
--- a/lib/hackney/income/domain/user.rb
+++ b/lib/hackney/income/domain/user.rb
@@ -15,6 +15,15 @@ module Hackney
         def to_query(*args)
           as_json.to_query(*args)
         end
+
+        def as_json(*_args)
+          {
+            'id' => id,
+            'name' => name,
+            'email' => email,
+            'groups' => groups
+          }
+        end
       end
     end
   end

--- a/spec/lib/hackney/income/domain/user_spec.rb
+++ b/spec/lib/hackney/income/domain/user_spec.rb
@@ -187,7 +187,7 @@ describe Hackney::Income::Domain::User do
       "{\"id\":\"#{id}\",\"name\":\"#{name}\",\"email\":\"#{email}\",\"groups\":[#{formatted_groups}]}"
     end
 
-    it 'returns a consistent json string' do
+    it 'returns a consistent json string regardless of rspec seed' do
       expect(user.to_json).to eq(expected_json_string)
     end
   end

--- a/spec/lib/hackney/income/domain/user_spec.rb
+++ b/spec/lib/hackney/income/domain/user_spec.rb
@@ -141,4 +141,54 @@ describe Hackney::Income::Domain::User do
       end
     end
   end
+
+  describe '#as_json' do
+    let(:groups) { ['group-1', 'group-2'] }
+    let(:name) { Faker::Name.name }
+    let(:email) { Faker::Internet.email }
+    let(:id) { Faker::Number.number(4) }
+    let(:user) do
+      described_class.new.tap do |user|
+        user.name = name
+        user.email = email
+        user.id = id
+      end
+    end
+
+    it 'orders the attributes' do
+      expect(user.as_json.keys).to eq(%w[id name email groups])
+    end
+
+    it 'only cares about certain attributes' do
+      expect(user.as_json).to eq(
+        'id' => id,
+        'name' => name,
+        'email' => email,
+        'groups' => groups
+      )
+    end
+  end
+
+  describe '#to_json' do
+    let(:groups) { ['group-1', 'group-2'] }
+    let(:name) { Faker::Name.name }
+    let(:email) { Faker::Internet.email }
+    let(:id) { Faker::Number.number(4) }
+    let(:user) do
+      described_class.new.tap do |user|
+        user.name = name
+        user.email = email
+        user.id = id
+      end
+    end
+    let(:expected_json_string) do
+      formatted_groups = groups.map { |g| "\"#{g}\"" }.join(',')
+
+      "{\"id\":\"#{id}\",\"name\":\"#{name}\",\"email\":\"#{email}\",\"groups\":[#{formatted_groups}]}"
+    end
+
+    it 'returns a consistent json string' do
+      expect(user.to_json).to eq(expected_json_string)
+    end
+  end
 end


### PR DESCRIPTION
When we test API calls we send a JSON User object. Sometimes the order 
of the fields is inconsistent. This breaks our tests. Always ensure we 
have the consistent JSON string. See the following Job for an example of 
a random failing test

https://app.circleci.com/jobs/github/LBHackney-IT/LBH-IncomeCollection/1576