### PR TITLE
filter by document status

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -48,6 +48,7 @@ class DocumentsController < ApplicationController
   def filters_param
     {
       payment_ref: params.fetch(:payment_ref, nil),
+      status: params.fetch(:status, nil),
       page_number: params.fetch(:page, 1),
       documents_per_page: params.fetch(:per_page, 20)
     }

--- a/app/helpers/documents_status_helper.rb
+++ b/app/helpers/documents_status_helper.rb
@@ -1,0 +1,19 @@
+module DocumentsStatusHelper
+  def status_map
+    {
+      uploading: 'Uploading',
+      received: 'Received',
+      accepted: 'Accepted',
+      'validation-failed' => 'Validation Failed',
+      downloaded: 'Downloaded',
+      queued: 'Queued',
+      failure_reviewed: 'Failure Reviewed'
+    }
+  end
+
+  def status_dropdown_options(selected: nil)
+    options = status_map.map { |db_name, human_name| [human_name, db_name] }
+
+    options_for_select(options, selected)
+  end
+end

--- a/app/views/documents/index.erb
+++ b/app/views/documents/index.erb
@@ -3,11 +3,24 @@
     <h1>Documents</h1>
 
     <%= form_tag(documents_path, method: :get) do %>
-      <div class="form-inline">
-        <%= label_tag(:payment_ref, 'Payment reference:', class: 'form-search__label--bold') %>
-        <%= text_field_tag(:payment_ref, params[:payment_ref], class: 'form-control', autocomplete: false) %>
-        <%= submit_tag('Search', class: 'button') %>
-      </div>
+      <table>
+        <tr>
+          <td>
+            <%= label_tag(:payment_ref, 'Payment reference:', class: 'form-search__label--bold') %>
+            <%= text_field_tag(:payment_ref, params[:payment_ref], class: 'form-control', autocomplete: false) %>
+          </td>
+          <td>
+            <%= label_tag(:status, 'Status:', class: 'form-search__label--bold') %>
+            <%= select_tag(:status,
+                           status_dropdown_options(selected: params[:status]),
+                           { class: 'form-control', prompt: 'All statuses' }
+                ) %>
+          </td>
+          <td>
+            <%= submit_tag('Search', class: 'button') %>
+          </td>
+        </tr>
+      </table>
     <% end %>
 
     <hr/>

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -75,8 +75,10 @@ describe DocumentsController do
   end
 
   context '#index' do
-    let(:documents) { Array.new(2, example_document) }
-    let(:default_filters) { { documents_per_page: 20, page_number: 1, payment_ref: nil } }
+    let(:received_document) { example_document(status: :received) }
+    let(:downloaded_document) { example_document(status: :downloaded) }
+    let(:documents) { [received_document, downloaded_document] }
+    let(:default_filters) { { documents_per_page: 20, page_number: 1, payment_ref: nil, status: nil } }
 
     it 'should all the use case with appropriate default params ' do
       expect_any_instance_of(Hackney::Income::GetAllDocuments).to receive(:execute).with(filters: default_filters)
@@ -99,6 +101,20 @@ describe DocumentsController do
         get :index, params: { payment_ref: payment_ref }
 
         expect(assigns(:documents)).to eq(documents)
+      end
+    end
+
+    context 'when status param is present' do
+      let(:filters_with_payment_ref) { default_filters.merge(status: 'downloaded') }
+
+      it 'should show a list all documents' do
+        expect_any_instance_of(Hackney::Income::GetAllDocuments)
+          .to receive(:execute).with(filters: filters_with_payment_ref)
+                .and_return(documents: [downloaded_document], number_of_pages: 1)
+
+        get :index, params: { status: 'downloaded' }
+
+        expect(assigns(:documents)).to eq([downloaded_document])
       end
     end
   end

--- a/spec/document_helper.rb
+++ b/spec/document_helper.rb
@@ -2,6 +2,7 @@ def example_document(attributes = {})
   uuid = attributes.fetch(:uuid, SecureRandom.uuid)
   extension = attributes.fetch(:extension, '.pdf')
   metadata = attributes.fetch(:metadata, example_metadata)
+  status = attributes.fetch(:status, 'uploading')
 
   date_time = '2019-03-27T16:57:49.175Z'
 
@@ -12,7 +13,7 @@ def example_document(attributes = {})
     metadata: metadata,
     filename: uuid + extension,
     mime_type: 'application/pdf',
-    status: 'uploading',
+    status: status,
     created_at: date_time,
     updated_at: date_time
   )

--- a/spec/lib/hackney/income/documents_gateway_spec.rb
+++ b/spec/lib/hackney/income/documents_gateway_spec.rb
@@ -126,6 +126,19 @@ describe Hackney::Income::DocumentsGateway do
         expect(WebMock).to have_requested(:get, "#{api_host}v1/documents/").with(query: { payment_ref: '1234567890' })
       end
     end
+
+    context 'with a status parameter' do
+      before do
+        stub_request(:get, "#{api_host}v1/documents/?status=downloaded")
+          .to_return(status: 200, body: { documents: [document] }.to_json)
+      end
+
+      it 'passes a filter to the documents endpoint' do
+        subject.get_all(filters: { status: 'downloaded' })
+
+        expect(WebMock).to have_requested(:get, "#{api_host}v1/documents/").with(query: { status: 'downloaded' })
+      end
+    end
   end
 
   context 'when marking document as reviewed' do


### PR DESCRIPTION
<img width="795" alt="Screenshot 2020-01-27 at 15 23 46" src="https://user-images.githubusercontent.com/8051117/73187262-0c071500-4119-11ea-92e1-8683c4aac0cb.png">
users need to filter documents by status to quickly find failed letters

