### PR TITLE
Separate api keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,9 @@ jobs:
           name: Run tests
           environment:
             TENANCY_API_URL: https://example.com/tenancy/api
-            HACKNEY_API_KEY: abc123
+            TENANCY_API_KEY: TEST_TENANCY_API_KEY
             INCOME_API_URL: https://example.com/income/api
+            INCOME_API_KEY: TEST_INCOME_API_KEY
           command: |
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,7 @@
 TENANCY_API_URL=https://example.com/tenancy/api
-INCOME_API_URL=https://example.com/income/api
 HACKNEY_API_KEY='TEST_API_KEY'
+
+INCOME_API_URL=https://example.com/income/api
+INCOME_API_KEY='TEST_INCOME_API_KEY'
 
 HACKNEY_JWT_SECRET='test_secret'

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 TENANCY_API_URL=https://example.com/tenancy/api
-HACKNEY_API_KEY='TEST_API_KEY'
+TENANCY_API_KEY='TEST_TENANCY_API_KEY'
 
 INCOME_API_URL=https://example.com/income/api
 INCOME_API_KEY='TEST_INCOME_API_KEY'

--- a/app.json
+++ b/app.json
@@ -27,7 +27,10 @@
     "TENANCY_API_URL": {
       "required": true
     },
-    "HACKNEY_API_KEY": {
+    "TENANCY_API_KEY": {
+      "required": true
+    },
+    "INCOME_API_KEY": {
       "required": true
     },
     "LANG": {

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -118,12 +118,12 @@ module Hackney
 
       # FIXME: gateways shouldn't be exposed by the UseCaseFactory, but ActionDiaryEntryController depends on it
       TENANCY_API_URL = ENV.fetch('TENANCY_API_URL')
-      HACKNEY_API_KEY = ENV.fetch('HACKNEY_API_KEY')
+      TENANCY_API_KEY = ENV.fetch('TENANCY_API_KEY')
 
       def tenancy_gateway
         Hackney::Income::TenancyGateway.new(
           api_host: TENANCY_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: TENANCY_API_KEY
         )
       end
 
@@ -149,14 +149,14 @@ module Hackney
       def get_diary_entries_gateway
         Hackney::Income::GetActionDiaryEntriesGateway.new(
           api_host: TENANCY_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: TENANCY_API_KEY
         )
       end
 
       def transactions_gateway
         Hackney::Income::TransactionsGateway.new(
           api_host: TENANCY_API_URL,
-          api_key: HACKNEY_API_KEY,
+          api_key: TENANCY_API_KEY,
           include_developer_data: Rails.application.config.include_developer_data?
         )
       end
@@ -186,7 +186,7 @@ module Hackney
       def search_tenancies_gateway
         Hackney::Income::SearchTenanciesGateway.new(
           api_host: TENANCY_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: TENANCY_API_KEY
         )
       end
 

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -130,18 +130,19 @@ module Hackney
       private
 
       INCOME_API_URL = ENV['INCOME_API_URL']
+      INCOME_API_KEY = ENV['INCOME_API_KEY']
 
       def users_gateway
         Hackney::Income::IncomeApiUsersGateway.new(
           api_host: INCOME_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: INCOME_API_KEY
         )
       end
 
       def create_action_diary_gateway
         Hackney::Income::CreateActionDiaryEntryGateway.new(
           api_host: INCOME_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: INCOME_API_KEY
         )
       end
 
@@ -164,21 +165,21 @@ module Hackney
         Hackney::Income::GovNotifyGateway.new(
           sms_sender_id: ENV['GOV_NOTIFY_SENDER_ID'],
           api_host: INCOME_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: INCOME_API_KEY
         )
       end
 
       def letters_gateway
         Hackney::Income::LettersGateway.new(
           api_host: INCOME_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: INCOME_API_KEY
         )
       end
 
       def documents_gateway
         Hackney::Income::DocumentsGateway.new(
           api_host: INCOME_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: INCOME_API_KEY
         )
       end
 
@@ -192,7 +193,7 @@ module Hackney
       def income_api_tenancy_gateway
         Hackney::Income::TenancyGateway.new(
           api_host: INCOME_API_URL,
-          api_key: HACKNEY_API_KEY
+          api_key: INCOME_API_KEY
         )
       end
     end

--- a/spec/features/creating_action_diary_entry_spec.rb
+++ b/spec/features/creating_action_diary_entry_spec.rb
@@ -12,7 +12,7 @@ describe 'creating action diary entry' do
     allow(create_action_diary_entry_class).to receive(:new).and_return(create_action_diary_entry_double)
     stub_const('Hackney::Income::CreateActionDiaryEntry', create_action_diary_entry_class)
     stub_use_cases
-    stub_income_api_actions
+    stub_tenancy_api_actions
   end
 
   context 'filling in the form as a user' do
@@ -36,7 +36,7 @@ describe 'creating action diary entry' do
     end
   end
 
-  def stub_income_api_actions
+  def stub_tenancy_api_actions
     body = {
       arrears_action_diary_events: [
         {
@@ -55,7 +55,7 @@ describe 'creating action diary entry' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567/actions')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: body)
   end
 

--- a/spec/features/income_collection/letters/view_letter_preview_failures_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_failures_spec.rb
@@ -57,13 +57,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1.erb',
@@ -75,7 +75,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1.erb',

--- a/spec/features/income_collection/letters/view_letter_preview_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_spec.rb
@@ -58,13 +58,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'income_collection_letter_1_template',
@@ -79,7 +79,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1_template.erb',

--- a/spec/features/income_collection/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_success_spec.rb
@@ -93,13 +93,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'income_collection_letter_1_template',
@@ -114,7 +114,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response(with_doc:)
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/income_collection_letter_1_template.erb',

--- a/spec/features/leasehold/letters/view_letter_preview_failures_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_failures_spec.rb
@@ -56,13 +56,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',
@@ -74,7 +74,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',

--- a/spec/features/leasehold/letters/view_letter_preview_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_spec.rb
@@ -58,13 +58,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'letter_1_template',
@@ -79,7 +79,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',

--- a/spec/features/leasehold/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_success_spec.rb
@@ -117,13 +117,13 @@ describe 'Viewing A Letter Preview' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: [
         {
           'id' => 'letter_1_template',
@@ -138,7 +138,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         'template' => {
           'path' => 'lib/hackney/pdf/templates/letter_1_template.erb',
@@ -153,7 +153,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response_as_lba
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         template: { id: 'letter_before_action' },
         preview: preview,
@@ -164,7 +164,7 @@ describe 'Viewing A Letter Preview' do
 
   def stub_success_post_send_letter_response_as_lba_with_doc_id
     stub_request(:post, %r{/messages\/letters})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: {
         template: { id: 'letter_before_action' },
         preview: preview,

--- a/spec/features/page_navigation_spec.rb
+++ b/spec/features/page_navigation_spec.rb
@@ -4,13 +4,13 @@ describe 'Page navigation' do
   before do
     create_jwt_token
 
-    stub_income_api_tenancy
-    stub_income_api_payments
+    stub_tenancy_api_tenancy
+    stub_tenancy_api_payments
     stub_tenancy_api_actions
-    stub_income_api_contacts
+    stub_tenancy_api_contacts
 
     stub_income_api_my_cases
-    stub_tenancy_api_show_tenancy
+    stub_income_api_show_tenancy
 
     stub_users_gateway
   end
@@ -44,23 +44,23 @@ describe 'Page navigation' do
     expect(page).to have_current_path(worktray_path(page: '1'))
   end
 
-  def stub_income_api_tenancy
+  def stub_tenancy_api_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_income_api_payments
+  def stub_tenancy_api_payments
     response_json = { 'payment_transactions': [] }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_income_api_contacts
+  def stub_tenancy_api_contacts
     response_json = {
       data: {
         contacts: [{
@@ -76,7 +76,7 @@ describe 'Page navigation' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -97,11 +97,11 @@ describe 'Page navigation' do
     response_json = { arrears_action_diary_events: [] }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_tenancy_api_show_tenancy
+  def stub_income_api_show_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
 
     stub_request(:get, 'https://example.com/income/api/v1/tenancies/TEST%2F01')

--- a/spec/features/page_navigation_spec.rb
+++ b/spec/features/page_navigation_spec.rb
@@ -6,10 +6,10 @@ describe 'Page navigation' do
 
     stub_income_api_tenancy
     stub_income_api_payments
-    stub_income_api_actions
+    stub_tenancy_api_actions
     stub_income_api_contacts
 
-    stub_tenancy_api_my_cases
+    stub_income_api_my_cases
     stub_tenancy_api_show_tenancy
 
     stub_users_gateway
@@ -80,7 +80,7 @@ describe 'Page navigation' do
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_tenancy_api_my_cases
+  def stub_income_api_my_cases
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
 
     stub_request(:get, 'https://example.com/income/api/v1/cases')
@@ -89,11 +89,11 @@ describe 'Page navigation' do
         number_per_page: '20',
         page_number: '1'
       ))
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_income_api_actions
+  def stub_tenancy_api_actions
     response_json = { arrears_action_diary_events: [] }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/actions')
@@ -105,7 +105,7 @@ describe 'Page navigation' do
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
 
     stub_request(:get, 'https://example.com/income/api/v1/tenancies/TEST%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 

--- a/spec/features/search_tenancies_spec.rb
+++ b/spec/features/search_tenancies_spec.rb
@@ -53,7 +53,7 @@ describe 'Search page' do
 
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases/)
-    .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+    .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
     .to_return(status: 200, body: response_json, headers: {})
   end
 

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -4,13 +4,13 @@ describe 'Viewing A Single Case' do
   before do
     create_jwt_token
 
-    stub_income_api_tenancy
-    stub_income_api_payments
-    stub_income_api_contacts
-    stub_income_api_actions
+    stub_tenancy_api_tenancy
+    stub_tenancy_api_payments
+    stub_tenancy_api_contacts
+    stub_tenancy_api_actions
 
-    stub_tenancy_api_my_cases
-    stub_tenancy_api_show_tenancy
+    stub_income_api_my_cases
+    stub_income_api_show_tenancy
 
     stub_users_gateway
   end
@@ -149,7 +149,7 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_content('Adjourned to another hearing date')
   end
 
-  def stub_income_api_tenancy
+  def stub_tenancy_api_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
@@ -157,7 +157,7 @@ describe 'Viewing A Single Case' do
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_income_api_payments
+  def stub_tenancy_api_payments
     response_json = {
       payment_transactions: [
         {
@@ -184,7 +184,7 @@ describe 'Viewing A Single Case' do
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_income_api_contacts
+  def stub_tenancy_api_contacts
     response_json = {
       data: {
         contacts: [{
@@ -204,7 +204,7 @@ describe 'Viewing A Single Case' do
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_tenancy_api_my_cases
+  def stub_income_api_my_cases
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
 
     stub_request(:get, 'https://example.com/income/api/v1/cases')
@@ -213,19 +213,19 @@ describe 'Viewing A Single Case' do
         number_per_page: '20',
         page_number: '1'
       ))
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_tenancy_api_show_tenancy
+  def stub_income_api_show_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
 
     stub_request(:get, 'https://example.com/income/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_income_api_actions
+  def stub_tenancy_api_actions
     response_json = {
       arrears_action_diary_events: [
         {

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -153,7 +153,7 @@ describe 'Viewing A Single Case' do
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -180,7 +180,7 @@ describe 'Viewing A Single Case' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -200,7 +200,7 @@ describe 'Viewing A Single Case' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
@@ -246,7 +246,7 @@ describe 'Viewing A Single Case' do
     }.to_json
 
     stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -175,7 +175,7 @@ describe 'Worktray' do
     uri = /cases\?#{default_filters.to_param}/
 
     stub_request(:get, uri)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 end

--- a/spec/features/view_transactions_spec.rb
+++ b/spec/features/view_transactions_spec.rb
@@ -71,7 +71,7 @@ describe 'Viewing Transaction History' do
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
 
     stub_request(:get, %r{tenancy/api\/v1\/tenancies\/1234567/})
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 end

--- a/spec/features/view_transactions_spec.rb
+++ b/spec/features/view_transactions_spec.rb
@@ -5,7 +5,8 @@ describe 'Viewing Transaction History' do
     create_jwt_token
 
     stub_my_cases_response
-    stub_view_case_response
+    stub_income_api_response
+    stub_tenancy_api_show_tenancy
   end
 
   scenario do
@@ -53,15 +54,23 @@ describe 'Viewing Transaction History' do
     stub_const('Hackney::Income::GetActionDiaryEntriesGateway', Hackney::Income::StubGetActionDiaryEntriesGateway)
     response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
     stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 
-  def stub_view_case_response
+  def stub_income_api_response
     stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
 
+    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
+    stub_request(:get, 'https://example.com/income/api/v1/tenancies/1234567%2F01')
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
+      .to_return(status: 200, body: response_json)
+  end
+
+  def stub_tenancy_api_show_tenancy
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-    stub_request(:get, %r{/api\/v1\/tenancies\/1234567/})
+
+    stub_request(:get, %r{tenancy/api\/v1\/tenancies\/1234567/})
       .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end

--- a/spec/request/worktray_spec.rb
+++ b/spec/request/worktray_spec.rb
@@ -73,7 +73,7 @@ describe 'Viewing the Worktray', type: :request do
     uri = /cases\?#{default_filters.to_param}/
 
     stub_request(:get, uri)
-      .with(headers: { 'X-Api-Key' => ENV['HACKNEY_API_KEY'] })
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 end


### PR DESCRIPTION
Income api and tenancy api now have different api keys


> ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️
 **SET UP THE `TENANCY_API_KEY` AND `INCOME_API_KEY` BEFORE MERGING AND DEPLOYING**
⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 