### PR TITLE
Change redirect destination when creating an action diary entry

### DIFF
--- a/app/controllers/action_diary_entry_controller.rb
+++ b/app/controllers/action_diary_entry_controller.rb
@@ -23,6 +23,6 @@ class ActionDiaryEntryController < ApplicationController
     )
 
     flash[:notice] = 'Successfully created an action diary entry'
-    redirect_to tenancy_path(id: params.fetch(:tenancy_ref))
+    redirect_to worktray_path
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  get '/worktray', to: 'tenancies#index'
+  get '/worktray', to: 'tenancies#index', as: :worktray
 
   get '/search', to: 'search_tenancies#show'
 

--- a/spec/controllers/action_diary_entry_controller_spec.rb
+++ b/spec/controllers/action_diary_entry_controller_spec.rb
@@ -37,7 +37,7 @@ describe ActionDiaryEntryController, type: :controller do
       }
     end
 
-    it 'should call redirect me to the tenancy page' do
+    it 'should call redirect me to the worktray' do
       expect(create_action_diary_entry).to receive(:execute)
       post :create, params: {
         tenancy_ref: tenancy_ref,
@@ -46,7 +46,7 @@ describe ActionDiaryEntryController, type: :controller do
         comment: 'Test comment'
       }
 
-      expect(response).to redirect_to(tenancy_path(id: tenancy_ref))
+      expect(response).to redirect_to(worktray_path)
     end
 
     it 'raises an exception when a invalid code is used' do


### PR DESCRIPTION
## Context
Income Collection caseworkers would like to return to the last place they were working from in their work tray. When caseworkers click the Hackney Logo they have to re-filter their lists.

This is the first slice of the ticket, the next step is to persist filter settings.

## Changes proposed in this pull request
<!-- List all the changes -->
- Change redirect destination when creating an action diary entry

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-95