### PR TITLE
Worktray filters saving in cookies

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -111,7 +111,6 @@ class TenanciesController < ApplicationController
     }.merge(read_cookie_filter)
 
     filters[:patch_code] = request_params[:patch_code] unless request_params[:patch_code].nil?
-
     filters[:active_tab][:page] = request_params[:page] unless request_params[:page].nil?
 
     tab_specific_filter = find_tab_specific_filter(find_active_tab(active_tab_param))
@@ -157,9 +156,9 @@ class TenanciesController < ApplicationController
   TAB_FILTERS = %i[recommended_actions pause_reason].freeze
 
   def find_tab_specific_filter(tab)
-    permitted_filters = params.permit(TAB_FILTERS)
-    return { key: 'recommended_actions', value: permitted_filters[:recommended_actions] } if tab == :immediate_actions
-    return { key: 'pause_reason', value: permitted_filters[:pause_reason] } if tab == :paused
+    tab_filter_params = params.permit(TAB_FILTERS)
+    return { key: 'recommended_actions', value: tab_filter_params[:recommended_actions] } if tab == :immediate_actions
+    return { key: 'pause_reason', value: tab_filter_params[:pause_reason] } if tab == :paused
     {}
   end
 

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -111,6 +111,7 @@ class TenanciesController < ApplicationController
     }.merge(read_cookie_filter)
 
     filters[:patch_code] = request_params[:patch_code] unless request_params[:patch_code].nil?
+
     filters[:active_tab][:page] = request_params[:page] unless request_params[:page].nil?
 
     tab_specific_filter = find_tab_specific_filter(find_active_tab(active_tab_param))
@@ -133,11 +134,11 @@ class TenanciesController < ApplicationController
   def set_page_number(page, filters, tab_specific_filter)
     if tab_specific_filter[:value] && filters.dig(:active_tab, :filter)
       if tab_specific_filter[:value] != filters.dig(:active_tab, :filter).dig(:value)
-        filters[:active_tab][:page] = page.nil? ? 1 : page
+        filters[:active_tab][:page] = page || 1
       end
     end
 
-    filters[:active_tab][:page] ||= page.nil? ? 1 : page
+    filters[:active_tab][:page] ||= page || 1
   end
 
   def read_cookie_filter
@@ -153,8 +154,10 @@ class TenanciesController < ApplicationController
     :immediate_actions
   end
 
+  TAB_FILTERS = %i[recommended_actions pause_reason].freeze
+
   def find_tab_specific_filter(tab)
-    permitted_filters = params.permit(:recommended_actions, :pause_reason)
+    permitted_filters = params.permit(TAB_FILTERS)
     return { key: 'recommended_actions', value: permitted_filters[:recommended_actions] } if tab == :immediate_actions
     return { key: 'pause_reason', value: permitted_filters[:pause_reason] } if tab == :paused
     {}

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -79,7 +79,9 @@ class TenanciesController < ApplicationController
 
     if read_cookie_filter.present?
       permitted_params[:patch_code] ||= read_cookie_filter[:patch_code] if read_cookie_filter[:patch_code]
-      permitted_params[:paused] ||= 'true' if read_cookie_filter[:active_tab] == 'paused'
+      %i[paused full_patch upcoming_evictions upcoming_court_dates immediate_actions].each do |p|
+        permitted_params[p] ||= 'true' if read_cookie_filter[:active_tab] == p.to_s
+      end
     end
 
     permitted_params
@@ -101,6 +103,10 @@ class TenanciesController < ApplicationController
   end
 
   def find_active_tab(active_tab_param)
+    return :immediate_actions if active_tab_param[:immediate_actions]
     return :paused if active_tab_param[:paused]
+    return :full_patch if active_tab_param[:full_patch]
+    return :upcoming_evictions if active_tab_param[:upcoming_evictions]
+    return :upcoming_court_dates if active_tab_param[:upcoming_court_dates]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
-  def worktray_tab_link_to(text, path, filter_param = nil)
+  def worktray_tab_link_to(text, path, filter_param = nil, filter_params_list = params)
     identifier = text.downcase.gsub(/\s/, '')
 
     checked = nil
-    checked = params.key?(filter_param) if filter_param
+    checked = filter_params_list.send(filter_param) if filter_param
     checked = true if checked.nil?
 
     content_tag(:a, href: path, id: identifier, class: 'tab__link') do

--- a/app/helpers/worktray_helper.rb
+++ b/app/helpers/worktray_helper.rb
@@ -1,8 +1,8 @@
 module WorktrayHelper
-  def show_immediate_actions_filter?
+  def show_immediate_actions_filter?(filter_params = params)
     tabs_to_hide_filter = %w[paused full_patch upcoming_court_dates upcoming_evictions]
 
-    tabs_to_hide_filter.select { |filter| filter.in?(params.keys) }.empty?
+    tabs_to_hide_filter.select { |filter| filter_params.send(filter) }.empty?
   end
 
   def worktray_title

--- a/app/views/tenancies/worktray/_pause_reason_filter.html.erb
+++ b/app/views/tenancies/worktray/_pause_reason_filter.html.erb
@@ -5,7 +5,7 @@
         <div class="form-group">
           <%= hidden_field_tag(:paused, true)%>
           <label class="govuk-label" for="pause_reason"><strong>Reason for pause</strong><br/></label>
-          <%= select_tag(:pause_reason, pause_reason_filter(params[:pause_reason]), { :class => 'form-control', prompt: 'Select a pause reason'  }) %>
+          <%= select_tag(:pause_reason, pause_reason_filter(@filter_params.pause_reason), { :class => 'form-control', prompt: 'Select a pause reason'  }) %>
         </div>
       </td>
       <td>

--- a/app/views/tenancies/worktray/_recommended_action_filter.html.erb
+++ b/app/views/tenancies/worktray/_recommended_action_filter.html.erb
@@ -3,7 +3,7 @@
     <tr>
       <td>
         <label class="govuk-label form-label-bold" for="recommended_actions">Next Recommended Action<br/></label>
-        <%= select_tag(:recommended_actions, recommended_actions_dropdown_options(selected: params[:recommended_actions]), { :class => 'form-control', prompt: 'Select an action' }) %>
+        <%= select_tag(:recommended_actions, recommended_actions_dropdown_options(selected: @filter_params.recommended_actions), { :class => 'form-control', prompt: 'Select an action' }) %>
       </td>
       <td>
         <%= submit_tag('Filter by next action', class: 'button') %>

--- a/app/views/tenancies/worktray/_tabs.html.erb
+++ b/app/views/tenancies/worktray/_tabs.html.erb
@@ -15,11 +15,11 @@
   </div>
 </div>
 
-<%= worktray_tab_link_to("Immediate Actions", worktray_path) %>
-<%= worktray_tab_link_to("Paused", worktray_path(paused: true), :paused) %>
-<%= worktray_tab_link_to("Full Patch", worktray_path(full_patch: true), :full_patch) %>
-<%= worktray_tab_link_to("Upcoming Evictions", worktray_path(upcoming_evictions: true), :upcoming_evictions) %>
-<%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates) %>
+<%= worktray_tab_link_to("Immediate Actions", worktray_path, nil, @filter_params) %>
+<%= worktray_tab_link_to("Paused", worktray_path(paused: true), :paused, @filter_params) %>
+<%= worktray_tab_link_to("Full Patch", worktray_path(full_patch: true), :full_patch, @filter_params) %>
+<%= worktray_tab_link_to("Upcoming Evictions", worktray_path(upcoming_evictions: true), :upcoming_evictions, @filter_params) %>
+<%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates, @filter_params) %>
 
 <%= render 'tenancies/worktray/recommended_action_filter' if show_immediate_actions_filter? %>
 <%= render 'tenancies/worktray/pause_reason_filter' if params[:paused].present? %>

--- a/app/views/tenancies/worktray/_tabs.html.erb
+++ b/app/views/tenancies/worktray/_tabs.html.erb
@@ -8,7 +8,7 @@
       <%= hidden_field_tag(:upcoming_court_dates, params[:upcoming_court_dates]) if params[:upcoming_court_dates].present? %>
       <div class="form-group">
         <label class="form-label visually-hidden" for="patch_code"><strong>Patch</strong><br/></label>
-        <%= select_tag(:patch_code, patch_codes_options(selected: cookies[:patch_code]), { :class => 'form-control' }) %>
+        <%= select_tag(:patch_code, patch_codes_options(selected: @filter_params.patch_code), { :class => 'form-control' }) %>
         <%= submit_tag('Filter by patch', class: 'button') %>
       </div>
     <% end %>

--- a/app/views/tenancies/worktray/_tabs.html.erb
+++ b/app/views/tenancies/worktray/_tabs.html.erb
@@ -22,7 +22,7 @@
 <%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates, @filter_params) %>
 
 <%= render 'tenancies/worktray/recommended_action_filter' if show_immediate_actions_filter?(@filter_params) %>
-<%= render 'tenancies/worktray/pause_reason_filter' if params[:paused].present? %>
+<%= render 'tenancies/worktray/pause_reason_filter' if @filter_params.paused %>
 
 <% if @tenancies.none? %>
   <h3 class="tenancy_list tenancy_list__no_tenancies">No results found</h3>

--- a/app/views/tenancies/worktray/_tabs.html.erb
+++ b/app/views/tenancies/worktray/_tabs.html.erb
@@ -15,7 +15,7 @@
   </div>
 </div>
 
-<%= worktray_tab_link_to("Immediate Actions", worktray_path, nil, @filter_params) %>
+<%= worktray_tab_link_to("Immediate Actions", worktray_path(immediate_actions: true), :immediate_actions, @filter_params) %>
 <%= worktray_tab_link_to("Paused", worktray_path(paused: true), :paused, @filter_params) %>
 <%= worktray_tab_link_to("Full Patch", worktray_path(full_patch: true), :full_patch, @filter_params) %>
 <%= worktray_tab_link_to("Upcoming Evictions", worktray_path(upcoming_evictions: true), :upcoming_evictions, @filter_params) %>

--- a/app/views/tenancies/worktray/_tabs.html.erb
+++ b/app/views/tenancies/worktray/_tabs.html.erb
@@ -21,7 +21,7 @@
 <%= worktray_tab_link_to("Upcoming Evictions", worktray_path(upcoming_evictions: true), :upcoming_evictions, @filter_params) %>
 <%= worktray_tab_link_to("Upcoming Court Dates", worktray_path(upcoming_court_dates: true), :upcoming_court_dates, @filter_params) %>
 
-<%= render 'tenancies/worktray/recommended_action_filter' if show_immediate_actions_filter? %>
+<%= render 'tenancies/worktray/recommended_action_filter' if show_immediate_actions_filter?(@filter_params) %>
 <%= render 'tenancies/worktray/pause_reason_filter' if params[:paused].present? %>
 
 <% if @tenancies.none? %>

--- a/lib/hackney/income/filter_params/list_cases_params.rb
+++ b/lib/hackney/income/filter_params/list_cases_params.rb
@@ -2,13 +2,13 @@ module Hackney
   module Income
     module FilterParams
       class ListCasesParams
-        attr_reader :paused, :immediate_action, :full_patch, :upcoming_court_dates,
+        attr_reader :paused, :immediate_actions, :full_patch, :upcoming_court_dates,
                     :upcoming_evictions, :recommended_actions, :patch_code, :pause_reason
 
         def initialize(options)
           @page_number          = options[:page]
           @count_per_page       = options[:count_per_page]
-          @immediate_action     = options[:immediate_action]
+          @immediate_action     = options[:immediate_actions]
           @recommended_actions  = options[:recommended_actions]
           @patch_code           = options[:patch_code]
           @pause_reason         = options[:pause_reason]

--- a/lib/hackney/income/list_cases.rb
+++ b/lib/hackney/income/list_cases.rb
@@ -1,7 +1,7 @@
 module Hackney
   module Income
     class ListCases
-      Response = Struct.new(:tenancies, :paused, :page_number, :number_of_pages, :immediate_action, :full_patch, :upcoming_court_dates, :upcoming_eviction)
+      Response = Struct.new(:tenancies, :paused, :page_number, :number_of_pages, :immediate_actions, :full_patch, :upcoming_court_dates, :upcoming_eviction)
 
       def initialize(tenancy_gateway:)
         @tenancy_gateway = tenancy_gateway

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -268,6 +268,24 @@ describe TenanciesController do
       expect(assigns(:tenancy)).to be_instance_of(Hackney::Income::Domain::Tenancy)
       expect(assigns(:tenancy)).to be_valid
     end
+
+    it 'should show the pause_reason filter when already set' do
+      cookies[:filters] = {
+        active_tab: {
+            name: 'paused',
+            page: 2,
+            filter: { key: 'pause_reason', value: 'Deceased' }
+        }
+      }.to_json
+
+      expect(Hackney::Income::FilterParams::ListCasesParams).to receive(:new).with(
+        'paused' => 'true',
+        'page' => 2,
+        'pause_reason' => 'Deceased'
+      ).and_call_original
+
+      get :index, params: {}
+    end
   end
 
   context '#update' do

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -84,7 +84,7 @@ describe TenanciesController do
         expect(Hackney::Income::FilterParams::ListCasesParams).to receive(:new).with(
           'paused' => 'true',
           'page' => 1,
-          "pause_reason" => nil
+          'pause_reason' => nil
         ).and_call_original
 
         expect_any_instance_of(Hackney::Income::ListCases)

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -72,7 +72,7 @@ describe TenanciesController do
       end
 
       it 'should show a list of only paused tenancies when requested' do
-        expect(Hackney::Income::FilterParams::ListCasesParams).to receive(:new).with('paused' => 'true').and_call_original
+        expect(Hackney::Income::FilterParams::ListCasesParams).to receive(:new).with('paused' => 'true', 'page' => 1).and_call_original
 
         expect_any_instance_of(Hackney::Income::ListCases)
         .to receive(:execute)
@@ -114,6 +114,40 @@ describe TenanciesController do
                 .and_call_original
 
         get :index, params: { is_paused: true, pause_reason: 'Missing Data' }
+      end
+    end
+
+    context 'when retrieving filters from cookies' do
+      it 'should show page 2 of paused cases when cookie is already set' do
+        cookies[:filters] = {
+            active_tab: {
+                name: 'paused',
+                page: 2
+            }
+        }.to_json
+
+        expect(Hackney::Income::FilterParams::ListCasesParams).to receive(:new).with(
+          'paused' => 'true',
+          'page' => 2
+        ).and_call_original
+
+        get :index, params: {}
+      end
+
+      it 'should show page 3 of paused cases when cookie is already set and next page is called' do
+        cookies[:filters] = {
+            active_tab: {
+                name: 'paused',
+                page: 2
+            }
+        }.to_json
+
+        expect(Hackney::Income::FilterParams::ListCasesParams).to receive(:new).with(
+          'paused' => 'true',
+          'page' => '3'
+        ).and_call_original
+
+        get :index, params: { page: 3 }
       end
     end
   end

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -51,17 +51,22 @@ describe 'Worktray' do
   scenario 'persisting all worktray filters between pages' do
     given_i_am_logged_in
     when_i_visit_the_homepage
+    and_i_should_see_recommended_actions
+
     when_i_click_on_the_paused_tab
     when_i_visit_the_homepage
     then_i_should_see_paused_cases
+    and_i_should_not_see_recommended_actions
 
     when_i_click_on_the_upcoming_court_dates_tab
     and_i_visit_the_homepage
     then_i_should_see_the_upcoming_court_dates_tab
+    and_i_should_not_see_recommended_actions
 
     when_i_click_on_the_immediate_actions_tab
     and_i_visit_the_homepage
     then_i_should_see_immediate_actions_tab
+    and_i_should_see_recommended_actions
   end
 
   scenario 'Pagination' do
@@ -130,6 +135,14 @@ describe 'Worktray' do
   def i_should_see_the_courtdate_column_with_a_readable_date
     expect(page).to have_content('Upcoming Court Dates')
     expect(page).to have_content('September 10th, 2030')
+  end
+
+  def and_i_should_not_see_recommended_actions
+    expect(page).to_not have_field('recommended_actions')
+  end
+
+  def and_i_should_see_recommended_actions
+    expect(page).to have_field('recommended_actions')
   end
 
   def when_i_click_on_the_upcoming_eviction_dates_tab

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -39,13 +39,21 @@ describe 'Worktray' do
     then_i_should_filter_worktray_by_an_action
   end
 
-  scenario do
+  scenario 'persisting patch filter between tabs' do
     given_i_am_logged_in
     when_i_visit_the_homepage
     i_should_see_all_of_the_tabs
     then_i_should_filter_worktray_by_patch
     when_i_click_on_the_paused_tab
     then_i_see_the_patch_is_still_selected
+  end
+
+  scenario 'persisting all worktray filters between pages' do
+    given_i_am_logged_in
+    when_i_visit_the_homepage
+    when_i_click_on_the_paused_tab
+    when_i_visit_the_homepage
+    then_i_should_see_paused_cases
   end
 
   scenario 'Pagination' do

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -11,6 +11,7 @@ describe 'Worktray' do
     stub_my_cases_response(upcoming_court_dates: true)
     stub_my_cases_response(upcoming_evictions: true)
     stub_my_cases_response(recommended_actions: 'no_action')
+    stub_my_cases_response(recommended_actions: 'send_NOSP')
     stub_my_cases_response(patch: 'E01')
     stub_my_cases_response(is_paused: true, patch: 'E01')
     stub_my_cases_response(page_number: 2)
@@ -64,9 +65,11 @@ describe 'Worktray' do
     and_i_should_not_see_recommended_actions
 
     when_i_click_on_the_immediate_actions_tab
+    and_i_select_send_nosp_from_recommended_actions
     and_i_visit_the_homepage
     then_i_should_see_immediate_actions_tab
     and_i_should_see_recommended_actions
+    and_i_see_send_nosp_filter_applied
   end
 
   scenario 'Pagination' do
@@ -145,6 +148,10 @@ describe 'Worktray' do
     expect(page).to have_field('recommended_actions')
   end
 
+  def and_i_see_send_nosp_filter_applied
+    expect(page.body).to have_css('option[selected]', text: 'Send NOSP')
+  end
+
   def when_i_click_on_the_upcoming_eviction_dates_tab
     visit '/worktray?upcoming_evictions=true'
     expect(page).to have_field('upcomingevictions_tab', checked: true)
@@ -199,6 +206,11 @@ describe 'Worktray' do
   def then_i_should_filter_worktray_by_an_action
     visit '/worktray'
     select('No Action', from: 'recommended_actions')
+    click_button 'Filter by next action'
+  end
+
+  def and_i_select_send_nosp_from_recommended_actions
+    select('Send NOSP', from: 'recommended_actions')
     click_button 'Filter by next action'
   end
 

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -52,23 +52,25 @@ describe 'Worktray' do
   scenario 'persisting all worktray filters between pages' do
     given_i_am_logged_in
     when_i_visit_the_homepage
-    and_i_should_see_recommended_actions
+    and_i_should_see_recommended_actions_filter
 
     when_i_click_on_the_paused_tab
     when_i_visit_the_homepage
     then_i_should_see_paused_cases
-    and_i_should_not_see_recommended_actions
+    and_i_should_see_reasons_for_pause_filter
+    and_i_should_not_see_recommended_actions_filter
 
     when_i_click_on_the_upcoming_court_dates_tab
     and_i_visit_the_homepage
     then_i_should_see_the_upcoming_court_dates_tab
-    and_i_should_not_see_recommended_actions
+    and_i_should_not_see_recommended_actions_filter
+    and_i_should_not_see_reasons_for_pause_filter
 
     when_i_click_on_the_immediate_actions_tab
     and_i_select_send_nosp_from_recommended_actions
     and_i_visit_the_homepage
     then_i_should_see_immediate_actions_tab
-    and_i_should_see_recommended_actions
+    and_i_should_see_recommended_actions_filter
     and_i_see_send_nosp_filter_applied
   end
 
@@ -140,12 +142,20 @@ describe 'Worktray' do
     expect(page).to have_content('September 10th, 2030')
   end
 
-  def and_i_should_not_see_recommended_actions
+  def and_i_should_not_see_recommended_actions_filter
     expect(page).to_not have_field('recommended_actions')
   end
 
-  def and_i_should_see_recommended_actions
+  def and_i_should_see_recommended_actions_filter
     expect(page).to have_field('recommended_actions')
+  end
+
+  def and_i_should_see_reasons_for_pause_filter
+    expect(page).to have_field('pause_reason')
+  end
+
+  def and_i_should_not_see_reasons_for_pause_filter
+    expect(page).to_not have_field('pause_reason')
   end
 
   def and_i_see_send_nosp_filter_applied

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -54,6 +54,14 @@ describe 'Worktray' do
     when_i_click_on_the_paused_tab
     when_i_visit_the_homepage
     then_i_should_see_paused_cases
+
+    when_i_click_on_the_upcoming_court_dates_tab
+    and_i_visit_the_homepage
+    then_i_should_see_the_upcoming_court_dates_tab
+
+    when_i_click_on_the_immediate_actions_tab
+    and_i_visit_the_homepage
+    then_i_should_see_immediate_actions_tab
   end
 
   scenario 'Pagination' do
@@ -89,8 +97,12 @@ describe 'Worktray' do
     visit '/'
   end
 
+  def and_i_visit_the_homepage
+    when_i_visit_the_homepage
+  end
+
   def i_should_see_all_of_the_tabs
-    expect(page).to have_link(href: '/worktray')
+    expect(page).to have_link(href: '/worktray?immediate_actions=true')
     expect(page).to have_link(href: '/worktray?paused=true')
     expect(page).to have_link(href: '/worktray?full_patch=true')
     expect(page).to have_link(href: '/worktray?upcoming_court_dates=true')
@@ -100,6 +112,14 @@ describe 'Worktray' do
   def when_i_click_on_the_paused_tab
     page = Page::Worktray.new
     page.click_paused_tab!
+  end
+
+  def when_i_click_on_the_immediate_actions_tab
+    click_link 'Immediate Actions'
+  end
+
+  def when_i_click_on_the_upcoming_court_dates_tab
+    click_link 'Upcoming Court Dates'
   end
 
   def when_i_click_on_the_upcoming_court_dates_tab
@@ -125,6 +145,18 @@ describe 'Worktray' do
   def then_i_should_see_paused_cases
     page = Page::Worktray.new
     expect(page).to have_field('paused_tab', checked: true)
+    expect(page.results.length).to eq(2)
+  end
+
+  def then_i_should_see_the_upcoming_court_dates_tab
+    page = Page::Worktray.new
+    expect(page).to have_field('upcomingcourtdates_tab', checked: true)
+    expect(page.results.length).to eq(2)
+  end
+
+  def then_i_should_see_immediate_actions_tab
+    page = Page::Worktray.new
+    expect(page).to have_field('immediateactions_tab', checked: true)
     expect(page.results.length).to eq(2)
   end
 

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -11,6 +11,7 @@ describe 'Worktray' do
     stub_my_cases_response(upcoming_court_dates: true)
     stub_my_cases_response(upcoming_evictions: true)
     stub_my_cases_response(recommended_actions: 'no_action')
+    stub_my_cases_response(is_paused: true, pause_reason: 'Missing Data')
     stub_my_cases_response(recommended_actions: 'send_NOSP')
     stub_my_cases_response(patch: 'E01')
     stub_my_cases_response(is_paused: true, patch: 'E01')
@@ -55,9 +56,11 @@ describe 'Worktray' do
     and_i_should_see_recommended_actions_filter
 
     when_i_click_on_the_paused_tab
+    and_i_select_missing_data_from_reason_for_pause
     when_i_visit_the_homepage
     then_i_should_see_paused_cases
     and_i_should_see_reasons_for_pause_filter
+    and_i_should_see_missing_data_is_selected_form_reason_for_pause
     and_i_should_not_see_recommended_actions_filter
 
     when_i_click_on_the_upcoming_court_dates_tab
@@ -124,6 +127,11 @@ describe 'Worktray' do
     page.click_paused_tab!
   end
 
+  def and_i_select_missing_data_from_reason_for_pause
+    select('Missing Data', from: 'pause_reason')
+    click_button 'Filter by pause reason'
+  end
+
   def when_i_click_on_the_immediate_actions_tab
     click_link 'Immediate Actions'
   end
@@ -156,6 +164,10 @@ describe 'Worktray' do
 
   def and_i_should_not_see_reasons_for_pause_filter
     expect(page).to_not have_field('pause_reason')
+  end
+
+  def and_i_should_see_missing_data_is_selected_form_reason_for_pause
+    expect(page.body).to have_css('option[selected]', text: 'Missing Data')
   end
 
   def and_i_see_send_nosp_filter_applied
@@ -258,7 +270,8 @@ describe 'Worktray' do
       patch: nil,
       recommended_actions: nil,
       upcoming_court_dates: false,
-      upcoming_evictions: false
+      upcoming_evictions: false,
+      pause_reason: nil
     }.merge(override_params).reject { |_k, v| v.nil? }
 
     uri = /cases\?#{default_filters.to_param.gsub('+', '%20')}/


### PR DESCRIPTION
pairing with @C-gyorfi 

## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We currently only store the patch code in browser cookies, there is a user need to store the current state of the worktray in those cookies, so that the user will alway be able to go back to exactly where they were on the worktray (ie: if I'm on the 3rd page of the worktray, then I click to view a case, then click back to the work tray I want to be back on the 3rd page of the worktray)

## Changes proposed in this pull request
<!-- List all the changes -->
- store which tab the user was on
  - if tab was filtered, store the filter state
- store which page the user was on


## Guidance to review
Some of the complexities in storing and reloading filter params from cookies:
- We want to update/delete tab specific filters when a tab changes
- We want to update page number when the tab changes 
- We want to update page number when a tab does NOT change but the tab specific filter has changes

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-95

## Things to check
- [x] Environment variables have been updated
