### PR TITLE
display error message when a worktray could not be retrieved

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -23,12 +23,15 @@ class TenanciesController < ApplicationController
       format.html {}
       format.json do
         render json: {
-          tenancies: @tenancies,
-          page: @page_number,
-          number_of_pages: @number_of_pages
+            tenancies: @tenancies,
+            page: @page_number,
+            number_of_pages: @number_of_pages
         }.to_json
       end
     end
+  rescue Exceptions::IncomeApiError => e
+    Raven.capture_exception(e)
+    flash[:notice] = 'An error occurred while loading your worktray, this may be caused by an Universal Housing outage'
   end
 
   def show

--- a/app/views/tenancies/index.html.erb
+++ b/app/views/tenancies/index.html.erb
@@ -8,8 +8,10 @@
   <%= render partial: 'tenancies/leasehold/buttons' %>
 <% end  %>
 
-<% if current_user.income_collection? %>
-  <%= render partial: 'tenancies/worktray/tabs' %>
-<% end %>
+<% unless @tenancies.nil? %>
+  <% if current_user.income_collection? %>
+    <%= render partial: 'tenancies/worktray/tabs' %>
+  <% end %>
 
-<%= render 'common/pagination'%>
+  <%= render 'common/pagination'%>
+<% end %>

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -257,6 +257,20 @@ describe TenanciesController do
         get :index, params: { page: 3 }
       end
     end
+
+    context 'When worktray can not be loaded' do
+      it 'should show an error message' do
+        expect_any_instance_of(Hackney::Income::TenancyGateway)
+            .to receive(:get_tenancies)
+                    .and_raise(
+                      Exceptions::IncomeApiError.new(Net::HTTPResponse.new(1.1, 400, 'NOT OK')), 'Failed to send sms: Invalid phone number provided:'
+                    )
+
+        get :index
+
+        expect(flash[:notice]).to eq('An error occurred while loading your worktray, this may be caused by an Universal Housing outage')
+      end
+    end
   end
 
   context '#pause' do


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When the income api can't load a work tray, the user sees a not very useful error message

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
when the api throws an exception, show error message and send the exception to sentry
<img width="811" alt="Screenshot 2020-06-05 at 11 32 52" src="https://user-images.githubusercontent.com/8051117/83869266-3b134000-a724-11ea-9162-6546ddf5539a.png">


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-209 

## Things to check

- [ ] Environment variables have been updated
