### PR TITLE
Add make command for syncing income api data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,5 @@ shell:
 guard:
 	docker-compose run --rm app guard
 
-sync:
+sync-uh-simulator-data:
 	docker exec -ti universal-housing-simulator_incomeapi_1 sh -c "export CAN_AUTOMATE_LETTERS=true && rake income:sync:manual_sync"

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,6 @@ shell:
 
 guard:
 	docker-compose run --rm app guard
+
+sync:
+	docker exec -ti universal-housing-simulator_incomeapi_1 sh -c "export CAN_AUTOMATE_LETTERS=true && rake income:sync:manual_sync"


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Currently when you want to run the whole application with `make run-all`, you'll have to go into the incomeapi container and run commands to populate the incomeapi with data.

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
I've popped those two commands into the Makefile so after `make run-all` you can just run `make sync` to get all the data.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
This could live in pretty much any of the repos since it'll just pick up the container name - I think this repo or incomeapi repo make the most sense.

I thought to put it here because I tend to need it most after running `make run-all`.

But since it mainly concerns incomeapi, I can see that it might make sense to be in that repo.

Or both? 🤔 

Also I'm not too sure if I've completely understood what the commands do - so if there's a better name than `sync`, please let me know!
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [x] Environment variables have been updated
