### PR TITLE
Add a feature flag system that uses env vars

### DIFF
--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -1,0 +1,13 @@
+class FeatureFlagsController < ApplicationController
+  def index; end
+
+  def activate
+    FeatureFlag.activate(params[:feature_name])
+    redirect_to feature_flags_dashboard_path
+  end
+
+  def deactivate
+    FeatureFlag.deactivate(params[:feature_name])
+    redirect_to feature_flags_dashboard_path
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,0 +1,23 @@
+class FeatureFlag
+  FEATURES = %w[
+    create_informal_agreements
+  ].freeze
+
+  def self.activate(feature_name)
+    raise unless feature_name.in?(FEATURES)
+
+    ENV[feature_name] = 'true'
+  end
+
+  def self.deactivate(feature_name)
+    raise unless feature_name.in?(FEATURES)
+
+    ENV[feature_name] = 'false'
+  end
+
+  def self.active?(feature_name)
+    raise unless feature_name.in?(FEATURES)
+
+    ENV[feature_name].present? && ENV[feature_name] == 'true'
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,12 +4,16 @@ class FeatureFlag
   ].freeze
 
   def self.activate(feature_name)
+    return if Rails.env.production? # Features should be activated using ENV vars in production
+
     raise unless feature_name.in?(FEATURES)
 
     ENV[feature_name] = 'true'
   end
 
   def self.deactivate(feature_name)
+    return if Rails.env.production? # Features should be deactivated using ENV vars in production
+
     raise unless feature_name.in?(FEATURES)
 
     ENV[feature_name] = 'false'

--- a/app/views/feature_flags/index.html.erb
+++ b/app/views/feature_flags/index.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title, 'Feature flags' %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Feature</th>
+      <th class="govuk-table__header">Status</th>
+      <th class="govuk-table__header">Action</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% FeatureFlag::FEATURES.each do |feature_name| %>
+      <tr class="govuk-table__row">
+
+        <td class="govuk-table__cell">
+          <%= feature_name.humanize %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= FeatureFlag.active?(feature_name) ? 'Enabled' : 'Disabled' %>
+        </td>
+
+        <td class="govuk-table__cell">
+          <% if FeatureFlag.active?(feature_name) %>
+            <%= button_to "Deactivate #{feature_name.humanize}", deactivate_feature_flag_path(feature_name), class: 'govuk-button' %>
+          <% else %>
+            <%= button_to "Activate #{feature_name.humanize}", activate_feature_flag_path(feature_name), class: 'govuk-button' %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/feature_flags/index.html.erb
+++ b/app/views/feature_flags/index.html.erb
@@ -5,7 +5,9 @@
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Feature</th>
       <th class="govuk-table__header">Status</th>
-      <th class="govuk-table__header">Action</th>
+      <% unless Rails.env.production? %>
+        <th class="govuk-table__header">Action</th>
+      <% end %>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -20,13 +22,15 @@
           <%= FeatureFlag.active?(feature_name) ? 'Enabled' : 'Disabled' %>
         </td>
 
-        <td class="govuk-table__cell">
-          <% if FeatureFlag.active?(feature_name) %>
-            <%= button_to "Deactivate #{feature_name.humanize}", deactivate_feature_flag_path(feature_name), class: 'govuk-button' %>
-          <% else %>
-            <%= button_to "Activate #{feature_name.humanize}", activate_feature_flag_path(feature_name), class: 'govuk-button' %>
-          <% end %>
-        </td>
+        <% unless Rails.env.production? %>
+          <td class="govuk-table__cell">
+            <% if FeatureFlag.active?(feature_name) %>
+              <%= button_to "Deactivate #{feature_name.humanize}", deactivate_feature_flag_path(feature_name), class: 'govuk-button' %>
+            <% else %>
+              <%= button_to "Activate #{feature_name.humanize}", activate_feature_flag_path(feature_name), class: 'govuk-button' %>
+            <% end %>
+          </td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,10 @@ Rails.application.routes.draw do
   post '/tenancies/:tenancy_ref/action_diary', to: 'action_diary_entry#create', as: :create_action_diary_entry
   get '/tenancies/:tenancy_ref/action_diary', to: 'action_diary_entry#index', as: :action_diary_entries
 
+  get '/feature-flags', to: 'feature_flags#index', as: :feature_flags_dashboard
+  post '/feature-flags/:feature_name/activate', to: 'feature_flags#activate', as: :activate_feature_flag
+  post '/feature-flags/:feature_name/deactivate', to: 'feature_flags#deactivate', as: :deactivate_feature_flag
+
   get '/login', to: 'hackney_auth_session#new'
   get '/logout', to: 'hackney_auth_session#destroy'
 

--- a/spec/features/feature_flags/manage_feature_flags_spec.rb
+++ b/spec/features/feature_flags/manage_feature_flags_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe 'Feature flags' do
+  before do
+    create_jwt_token
+
+    stub_my_cases_response
+  end
+
+  scenario 'manage feature flags' do
+    given_i_am_logged_in
+    and_there_is_a_feature_flag
+
+    when_i_visit_the_feature_flags_dashboard
+    then_i_should_see_the_existing_feature_flag
+
+    when_i_activate_the_feature
+    then_the_feature_is_activated
+
+    when_i_deactivate_the_feature
+    then_the_feature_is_deactivated
+  end
+
+  def and_there_is_a_feature_flag
+    FeatureFlag.deactivate('create_informal_agreements')
+  end
+
+  def when_i_visit_the_feature_flags_dashboard
+    visit feature_flags_dashboard_path
+  end
+
+  def then_i_should_see_the_existing_feature_flag
+    expect(page).to have_content 'Create informal agreements Disabled'
+  end
+
+  def when_i_activate_the_feature
+    click_button 'Activate Create informal agreements'
+  end
+
+  def then_the_feature_is_activated
+    expect(page).to have_content 'Create informal agreements Enabled'
+    expect(FeatureFlag.active?('create_informal_agreements')).to be true
+  end
+
+  def when_i_deactivate_the_feature
+    click_button 'Deactivate Create informal agreements'
+  end
+
+  def then_the_feature_is_deactivated
+    expect(page).to have_content 'Create informal agreements Disabled'
+    expect(FeatureFlag.active?('create_informal_agreements')).to be false
+  end
+
+  def stub_my_cases_response
+    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
+    stub_const('Hackney::Income::GetActionDiaryEntriesGateway', Hackney::Income::StubGetActionDiaryEntriesGateway)
+    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
+    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
+      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
+      .to_return(status: 200, body: response_json)
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to be able delivering thin slices of a larger feature and switch
on the feature when it is ready to rollout. We also want to be able to keep track of features that are not in production yet.

I was going to use [rollout gem](https://github.com/fetlife/rollout) that has a lot of capabilities for implementing a feature flag system using redis, but there was some issue with the communication with Redis server from front-end so I ended up using ENV variables instead, should be enough for what we trying to achieve.

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add a feature flag system that allows as to define a feature flag and switch it on/off
- Add `create_informal_agreement' flag
- Add a dashboard that allows non-developers to switch on a feature e.g in staging and test them before we release them into prod.

![image](https://user-images.githubusercontent.com/22743709/85125953-6ddd2e00-b224-11ea-9d5f-c2cbc2121afc.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Are we happy with this approach? 

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-248
## Things to check

- [x] Environment variables have been updated
