### PR TITLE
Adding step in readme to run the sync and get data in the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@
 make run-all
 ```
 
+Your worktray in the app will probably be empty, so to get data in there run the sync and refresh:
+```sh
+make sync-uh-simulator-data
+```
+
 ## Run tests
 
 ```


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
After running `make run-all` you need to run `make sync-uh-simulator-data` to actually get data in the app, but this isn't in the README yet. 
## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
Just adding a step in the README to say to use `make sync-uh-simulator-data`
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Not sure if my wording is the best, so please let me know if I can improve it!
