### PR TITLE
Allow caseworkers to view agreement details

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -2,12 +2,10 @@ class AgreementsController < ApplicationController
   before_action { redirect_to worktray_path unless FeatureFlag.active?('create_informal_agreements') }
 
   def new
-    @tenancy_ref = params.fetch(:tenancy_ref)
-    @tenancy = use_cases.view_tenancy.execute(tenancy_ref: @tenancy_ref)
+    @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
   end
 
   def create
-    tenancy_ref = params.fetch(:tenancy_ref)
     use_cases.create_agreement.execute(
       tenancy_ref: tenancy_ref,
       frequency: params.fetch(:frequency).downcase,
@@ -20,6 +18,18 @@ class AgreementsController < ApplicationController
   end
 
   def show
-    @tenancy_ref = params.fetch(:tenancy_ref)
+    @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
+    @agreement = use_cases.view_agreements.execute(tenancy_ref: tenancy_ref)
+                .find { |agreement| agreement.id == agreement_id }
+  end
+
+  private
+
+  def tenancy_ref
+    @tenancy_ref ||= params.fetch(:tenancy_ref)
+  end
+
+  def agreement_id
+    @agreement_id ||= params.fetch(:id).to_i
   end
 end

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -18,4 +18,8 @@ class AgreementsController < ApplicationController
     flash[:notice] = 'Successfully created a new agreement'
     redirect_to tenancy_path(id: tenancy_ref)
   end
+
+  def show
+    @tenancy_ref = params.fetch(:tenancy_ref)
+  end
 end

--- a/app/views/agreements/_agreement_status.html.erb
+++ b/app/views/agreements/_agreement_status.html.erb
@@ -1,4 +1,13 @@
-<label class="govuk-label" for="status"><strong>Status: </strong><%= @agreement.current_state.humanize %><br/></label>
-<label class="govuk-label" for="status"><strong>Expected balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
-<label class="govuk-label" for="status"><strong>Actual balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
-<label class="govuk-label" for="status"><strong>Last checked: </strong><br/></label>
+<label class="govuk-label" for="status_label"><strong>Status</strong><br/></label>
+<label class="govuk-label" for="status"><%= @agreement.current_state.humanize %><br/></label>
+<div class="grid-row">
+  <div class="column-half">
+    <label class="govuk-label" for="actual_balance_label"><br/><h2><strong>Current balance</strong></label>
+    <label class="govuk-label" for="actual_balance"><%= number_to_currency(@agreement.starting_balance, unit: '£') %></h2><br/></label>
+  </div>
+  <div class="column-half">
+    <label class="govuk-label" for="expected_balance_label"><br/><h2><strong>Expected balance</strong><br/></label>
+    <label class="govuk-label" for="expected_balance"><%= number_to_currency(@agreement.starting_balance, unit: '£') %></h2><br/></label>
+  </div>
+</div>
+<label class="govuk-label" for="status">Last checked: <br/></label>

--- a/app/views/agreements/_agreement_status.html.erb
+++ b/app/views/agreements/_agreement_status.html.erb
@@ -1,0 +1,4 @@
+<label class="govuk-label" for="status"><strong>Status: </strong><%= @agreement.current_state.humanize %><br/></label>
+<label class="govuk-label" for="status"><strong>Expected balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
+<label class="govuk-label" for="status"><strong>Actual balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
+<label class="govuk-label" for="status"><strong>Last checked: </strong><br/></label>

--- a/app/views/agreements/_agreement_status_history.html.erb
+++ b/app/views/agreements/_agreement_status_history.html.erb
@@ -1,0 +1,9 @@
+<table class="transactions-table fixed-layout" data-expand-actions-and-transactions>
+  <thead>
+    <th class="date-column">Date</th>
+    <th class="status-column">Status</th>
+    <th class="descreption-column">Descreption</th>
+  </thead>
+</table>
+
+

--- a/app/views/agreements/_agreement_status_history.html.erb
+++ b/app/views/agreements/_agreement_status_history.html.erb
@@ -1,9 +1,17 @@
-<table class="transactions-table fixed-layout" data-expand-actions-and-transactions>
+<table class="agreements_history-table fixed-layout">
   <thead>
     <th class="date-column">Date</th>
     <th class="status-column">Status</th>
     <th class="descreption-column">Descreption</th>
   </thead>
+  <% agreement_status_history.each do |state| %>
+    <tbody class="summary-table__group agreements_history-table__group--summary">
+      <tr>
+          <td><%= format_date(state.date) %></td>
+          <td><%= state.state.humanize %></td>
+          <td></td>
+      </tr>
+  <% end %>
 </table>
 
 

--- a/app/views/agreements/_agreement_status_history.html.erb
+++ b/app/views/agreements/_agreement_status_history.html.erb
@@ -4,12 +4,12 @@
     <th class="status-column">Status</th>
     <th class="descreption-column">Descreption</th>
   </thead>
-  <% agreement_status_history.each do |state| %>
+  <% state_history.each do |state| %>
     <tbody class="summary-table__group agreements_history-table__group--summary">
       <tr>
-          <td><%= format_date(state.date) %></td>
-          <td><%= state.state.humanize %></td>
-          <td></td>
+        <td><%= format_date(state.date) %></td>
+        <td><%= state.state.humanize %></td>
+        <td></td>
       </tr>
   <% end %>
 </table>

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -10,7 +10,7 @@
   <div class="column-full">
     <h1><%= 'Create agreement' %></h1>
     <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
-    <label class="govuk-label"><strong>Total arrears balance owed: </strong>£<%= @tenancy.current_balance %><br/></label>
+    <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
     <hr>
   </div>
 </div>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -62,6 +62,6 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <%= render('agreements/agreement_status_history') %>
+    <%= render('agreements/agreement_status_history', agreement_status_history: @agreement.history) %>
   </div>
 </div>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -62,6 +62,6 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <%= render('agreements/agreement_status_history', agreement_status_history: @agreement.history) %>
+    <%= render('agreements/agreement_status_history', state_history: @agreement.history) %>
   </div>
 </div>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title do %><%= @tenancy_ref %> - View agreement<% end %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <%= link_to('Return to case profile', tenancy_path(id: @tenancy_ref), class: 'link--back') %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1><%= 'Agreement' %></h1>
+    <hr>
+  </div>
+</div>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -16,8 +16,8 @@
 <div class="grid-row">
   <div class="column-one-third">
     <h2><%= @tenancy.primary_contact_name %></h2>
-    <label class="govuk-label" for="status"><strong>Created: </strong><br/></label>
-    <label class="govuk-label" for="status"><strong>Created by: </strong><br/></label>
+    <label class="govuk-label" for="status"><strong>Created: </strong><%= format_date(@agreement.created_at) %><br/></label>
+    <label class="govuk-label" for="status"><strong>Created by: </strong><%= @agreement.created_by %><br/></label>
     <label class="govuk-label" for="status"><br/><strong>Notes: </strong><br/></label>
   </div>
   <div class="column-two-thirds">

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -12,3 +12,35 @@
     <hr>
   </div>
 </div>
+
+<div class="grid-row">
+  <div class="column-one-third">
+    <h2><%= @tenancy.primary_contact_name %></h2>
+  </div>
+  <div class="column-two-thirds">
+    <div class="grid-row">
+      <div class="grid-row rounded-box">
+        <div class="column-full">
+          <%= render :partial => 'agreements/agreement_status' %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <hr>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h2 class="pull-left">History</h2>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+  </div>
+</div>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -10,32 +10,38 @@
   <div class="column-full">
     <h1><%= 'Agreement' %></h1>
     <hr>
+    <h2><%= @tenancy.primary_contact_name %></h2>
   </div>
 </div>
 
 <div class="grid-row">
   <div class="column-one-third">
-    <h2><%= @tenancy.primary_contact_name %></h2>
-    <label class="govuk-label" for="status"><strong>Created: </strong><%= format_date(@agreement.created_at) %><br/></label>
-    <label class="govuk-label" for="status"><strong>Created by: </strong><%= @agreement.created_by %><br/></label>
-    <label class="govuk-label" for="status"><br/><strong>Notes: </strong><br/></label>
+    <div class="grid-row grey-box">
+        <div class="column-full">
+          <ul>
+            <li><h2><%= 'Agreement details' %></h2></li>
+            <li><strong>Total balance owed: </strong> <%= number_to_currency(@tenancy.current_balance, unit: '£') %></li>
+            <li><strong>Frequency of payment: </strong> <%= @agreement.frequency.humanize %></li>
+            <li><strong>Instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
+            <br/>
+            <li><strong>Start date: </strong> <%= format_date(@agreement.start_date) %></li>
+            <li><strong>End date:</strong></li>
+          </ul>
+        </div>
+    </div>
+    <div class="grid-row rounded-box">
+        <div class="column-full">
+          <label class="govuk-label" for="status"><strong>Created: </strong><%= format_date(@agreement.created_at) %><br/></label>
+          <label class="govuk-label" for="status"><strong>Created by: </strong><%= @agreement.created_by %><br/></label>
+          <label class="govuk-label" for="status"><br/><strong>Notes: </strong><br/></label>
+        </div>
+      </div>
   </div>
   <div class="column-two-thirds">
     <div class="grid-row">
       <div class="grid-row rounded-box">
         <div class="column-full">
           <%= render :partial => 'agreements/agreement_status' %>
-        </div>
-      </div>
-      <div class="grid-row grey-box">
-        <div class="column-full">
-          <ul>
-            <li><strong>Total arrears balance owed: </strong> <%= number_to_currency(@tenancy.current_balance, unit: '£') %></li>
-            <li><strong>Frequency of payment: </strong> <%= @agreement.frequency.humanize %></li>
-            <li><strong><%= @agreement.frequency.humanize %> instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
-            <li><strong>Start date: </strong> <%= format_date(@agreement.start_date) %></li>
-            <li><strong>End date:</strong></li>
-          </ul>
         </div>
       </div>
       <div class="grid-row">
@@ -50,11 +56,6 @@
 <div class="grid-row">
   <div class="column-full">
     <hr>
-  </div>
-</div>
-
-<div class="grid-row">
-  <div class="column-full">
     <h2 class="pull-left">History</h2>
   </div>
 </div>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -30,7 +30,6 @@
       <div class="grid-row grey-box">
         <div class="column-full">
           <ul>
-            <li><strong>Rent owed: </strong> <%= number_to_currency(@tenancy.rent, unit: '£') %></li>
             <li><strong>Total arrears balance owed: </strong> <%= number_to_currency(@tenancy.current_balance, unit: '£') %></li>
             <li><strong>Frequency of payment: </strong> <%= @agreement.frequency.humanize %></li>
             <li><strong><%= @agreement.frequency.humanize %> instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -16,12 +16,32 @@
 <div class="grid-row">
   <div class="column-one-third">
     <h2><%= @tenancy.primary_contact_name %></h2>
+    <label class="govuk-label" for="status"><strong>Created: </strong><br/></label>
+    <label class="govuk-label" for="status"><strong>Created by: </strong><br/></label>
+    <label class="govuk-label" for="status"><br/><strong>Notes: </strong><br/></label>
   </div>
   <div class="column-two-thirds">
     <div class="grid-row">
       <div class="grid-row rounded-box">
         <div class="column-full">
           <%= render :partial => 'agreements/agreement_status' %>
+        </div>
+      </div>
+      <div class="grid-row grey-box">
+        <div class="column-full">
+          <ul>
+            <li><strong>Rent owed: </strong> <%= number_to_currency(@tenancy.rent, unit: '£') %></li>
+            <li><strong>Total arrears balance owed: </strong> <%= number_to_currency(@tenancy.current_balance, unit: '£') %></li>
+            <li><strong>Frequency of payment: </strong> <%= @agreement.frequency.humanize %></li>
+            <li><strong><%= @agreement.frequency.humanize %> instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
+            <li><strong>Start date: </strong> <%= format_date(@agreement.start_date) %></li>
+            <li><strong>End date:</strong></li>
+          </ul>
+        </div>
+      </div>
+      <div class="grid-row">
+        <div class="column-full">
+          <%= link_to 'Cancel and create new', new_agreement_path(@tenancy.ref), class:'button' %>
         </div>
       </div>
     </div>
@@ -42,5 +62,6 @@
 
 <div class="grid-row">
   <div class="column-full">
+    <%= render('agreements/agreement_status_history') %>
   </div>
 </div>

--- a/app/views/tenancies/case/_agreements.html.erb
+++ b/app/views/tenancies/case/_agreements.html.erb
@@ -22,10 +22,7 @@
               </div>
             </div>
           </div>
-          <label class="govuk-label" for="status"><strong>Status: </strong><%= @agreement.current_state.humanize %><br/></label>
-          <label class="govuk-label" for="status"><strong>Expected balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
-          <label class="govuk-label" for="status"><strong>Actual balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
-          <label class="govuk-label" for="status"><strong>Last checked: </strong><br/></label>
+          <%= render :partial => 'agreements/agreement_status' %>
           <% end %>
         </div>
       </div>

--- a/app/views/tenancies/case/_agreements.html.erb
+++ b/app/views/tenancies/case/_agreements.html.erb
@@ -7,22 +7,22 @@
             <h2>Arrears Agreement</h2>
             There are currently no live agreement
           <% else %>
-          <div class="grid-row">
-            <div class="column-half">
-              <div class="column-align-left">
-                <h2>Arrears Agreement</h2>
-              </div>
-            </div>
-            <div class="column-half">
+            <div class="grid-row">
               <div class="column-half">
-                <%= link_to('View details', show_agreement_path(tenancy_ref: @tenancy.ref, id: @agreement.id)) %>
+                <div class="column-align-left">
+                  <h2>Arrears Agreement</h2>
+                </div>
               </div>
-              <div class="column-align-right">
-                <%= link_to('View history') %>
+              <div class="column-half">
+                <div class="column-half">
+                  <%= link_to('View details', show_agreement_path(tenancy_ref: @tenancy.ref, id: @agreement.id)) %>
+                </div>
+                <div class="column-align-right">
+                  <%= link_to('View history') %>
+                </div>
               </div>
             </div>
-          </div>
-          <%= render :partial => 'agreements/agreement_status' %>
+            <%= render :partial => 'agreements/agreement_status' %>
           <% end %>
         </div>
       </div>

--- a/app/views/tenancies/case/_agreements.html.erb
+++ b/app/views/tenancies/case/_agreements.html.erb
@@ -7,11 +7,25 @@
             <h2>Arrears Agreement</h2>
             There are currently no live agreement
           <% else %>
-            <h2>Arrears Agreement</h2>
-            <label class="govuk-label" for="status"><strong>Status: </strong><%= @agreement.current_state.humanize %><br/></label>
-            <label class="govuk-label" for="status"><strong>Expected balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
-            <label class="govuk-label" for="status"><strong>Actual balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
-            <label class="govuk-label" for="status"><strong>Last checked: </strong><br/></label>
+          <div class="grid-row">
+            <div class="column-half">
+              <div class="column-align-left">
+                <h2>Arrears Agreement</h2>
+              </div>
+            </div>
+            <div class="column-half">
+              <div class="column-half">
+                <%= link_to('View details', show_agreement_path(tenancy_ref: @tenancy.ref, id: @agreement.id)) %>
+              </div>
+              <div class="column-align-right">
+                <%= link_to('View history') %>
+              </div>
+            </div>
+          </div>
+          <label class="govuk-label" for="status"><strong>Status: </strong><%= @agreement.current_state.humanize %><br/></label>
+          <label class="govuk-label" for="status"><strong>Expected balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
+          <label class="govuk-label" for="status"><strong>Actual balance: </strong><%= number_to_currency(@agreement.starting_balance, unit: '£') %><br/></label>
+          <label class="govuk-label" for="status"><strong>Last checked: </strong><br/></label>
           <% end %>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,8 +38,10 @@ Rails.application.routes.draw do
   get '/feature-flags', to: 'feature_flags#index', as: :feature_flags_dashboard
   post '/feature-flags/:feature_name/activate', to: 'feature_flags#activate', as: :activate_feature_flag
   post '/feature-flags/:feature_name/deactivate', to: 'feature_flags#deactivate', as: :deactivate_feature_flag
+
   get '/tenancies/:tenancy_ref/agreement/new', to: 'agreements#new', as: :new_agreement
   post '/tenancies/:tenancy_ref/agreement/create', to: 'agreements#create', as: :create_agreement
+  get '/tenancies/:tenancy_ref/agreement/:id/show', to: 'agreements#show', as: :show_agreement
 
   get '/login', to: 'hackney_auth_session#new'
   get '/logout', to: 'hackney_auth_session#destroy'

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -5,7 +5,7 @@ module Hackney
         include ActiveModel::Validations
 
         attr_accessor :id, :tenancy_ref, :agreement_type, :starting_balance, :amount, :frequency,
-                      :start_date, :current_state, :history
+                      :start_date, :current_state, :created_at, :created_by, :history
 
         def start_date_display_date
           Date.parse(start_date).to_formatted_s(:long_ordinal)

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -4,7 +4,7 @@ module Hackney
       class Agreement
         include ActiveModel::Validations
 
-        attr_accessor :tenancy_ref, :agreement_type, :starting_balance, :amount, :frequency,
+        attr_accessor :id, :tenancy_ref, :agreement_type, :starting_balance, :amount, :frequency,
                       :start_date, :current_state, :history
 
         def start_date_display_date

--- a/lib/hackney/income/domain/agreement_state.rb
+++ b/lib/hackney/income/domain/agreement_state.rb
@@ -1,0 +1,13 @@
+module Hackney
+  module Income
+    module Domain
+      class AgreementState
+        include ActiveModel::Validations
+
+        attr_accessor :state, :date
+
+        validates_presence_of :state, :date
+      end
+    end
+  end
+end

--- a/lib/hackney/income/view_agreements_gateway.rb
+++ b/lib/hackney/income/view_agreements_gateway.rb
@@ -31,6 +31,8 @@ module Hackney
             t.start_date = agreement['startDate']
             t.frequency = agreement['frequency']
             t.current_state = agreement['currentState']
+            t.created_at = agreement['createdAt']
+            t.created_by = agreement['createdBy']
             t.history = agreement['history'].map do |state|
               Hackney::Income::Domain::AgreementState.new.tap do |s|
                 s.date = state['date']

--- a/lib/hackney/income/view_agreements_gateway.rb
+++ b/lib/hackney/income/view_agreements_gateway.rb
@@ -23,6 +23,7 @@ module Hackney
 
         agreements.map do |agreement|
           Hackney::Income::Domain::Agreement.new.tap do |t|
+            t.id = agreement['id']
             t.tenancy_ref = agreement['tenancyRef']
             t.agreement_type = agreement['agreementType']
             t.starting_balance = agreement['startingBalance']

--- a/lib/hackney/income/view_agreements_gateway.rb
+++ b/lib/hackney/income/view_agreements_gateway.rb
@@ -31,6 +31,12 @@ module Hackney
             t.start_date = agreement['startDate']
             t.frequency = agreement['frequency']
             t.current_state = agreement['currentState']
+            t.history = agreement['history'].map do |state|
+              Hackney::Income::Domain::AgreementState.new.tap do |s|
+                s.date = state['date']
+                s.state = state['state']
+              end
+            end
           end
         end
       end

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -33,6 +33,9 @@ describe 'Create informal agreement' do
     and_i_should_see_the_new_agreement
     and_i_should_see_a_button_to_cancel_and_create_new_agreement
     and_i_should_see_a_link_to_view_details
+
+    when_i_click_on_view_details
+    then_i_should_see_the_agreement_details_page
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -77,6 +80,14 @@ describe 'Create informal agreement' do
 
   def and_i_should_see_a_link_to_view_details
     expect(page).to have_link(href: '/tenancies/1234567%2F01/agreement/12/show')
+  end
+
+  def when_i_click_on_view_details
+    click_link 'View details'
+  end
+
+  def then_i_should_see_the_agreement_details_page
+    expect(page).to have_content('Agreement')
   end
 
   def stub_tenancy_with_arrears

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -32,6 +32,7 @@ describe 'Create informal agreement' do
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_new_agreement
     and_i_should_see_a_button_to_cancel_and_create_new_agreement
+    and_i_should_see_a_link_to_view_details
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -72,6 +73,10 @@ describe 'Create informal agreement' do
 
   def and_i_should_see_a_button_to_cancel_and_create_new_agreement
     expect(page).to have_content('Cancel and create new')
+  end
+
+  def and_i_should_see_a_link_to_view_details
+    expect(page).to have_link(href: '/tenancies/1234567%2F01/agreement/12/show')
   end
 
   def stub_tenancy_with_arrears

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -31,11 +31,13 @@ describe 'Create informal agreement' do
     and_i_click_on_create
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_new_agreement
+    and_i_should_see_the_agreement_status
     and_i_should_see_a_button_to_cancel_and_create_new_agreement
     and_i_should_see_a_link_to_view_details
 
     when_i_click_on_view_details
     then_i_should_see_the_agreement_details_page
+    and_i_should_see_the_agreement_status
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -68,10 +70,6 @@ describe 'Create informal agreement' do
 
   def and_i_should_see_the_new_agreement
     expect(page).to have_content('Arrears Agreement')
-    expect(page).to have_content('Status: Live')
-    expect(page).to have_content('Expected balance: £103.57')
-    expect(page).to have_content('Actual balance: £103.57')
-    expect(page).to have_content('Last checked:')
   end
 
   def and_i_should_see_a_button_to_cancel_and_create_new_agreement
@@ -88,6 +86,14 @@ describe 'Create informal agreement' do
 
   def then_i_should_see_the_agreement_details_page
     expect(page).to have_content('Agreement')
+    expect(page).to have_content('Alan Sugar')
+  end
+
+  def and_i_should_see_the_agreement_status
+    expect(page).to have_content('Status: Live')
+    expect(page).to have_content('Expected balance: £103.57')
+    expect(page).to have_content('Actual balance: £103.57')
+    expect(page).to have_content('Last checked:')
   end
 
   def stub_tenancy_with_arrears

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -114,9 +114,14 @@ describe 'Create informal agreement' do
 
   def and_i_should_see_the_agreement_state_history
     expect(page).to have_content('History')
-    expect(page).to have_content('Date')
-    expect(page).to have_content('Status')
-    expect(page).to have_content('Descreption')
+    agreement_history_table = find('table')
+
+    expect(agreement_history_table).to have_content('Date')
+    expect(agreement_history_table).to have_content('June 19th, 2020')
+    expect(agreement_history_table).to have_content('July 19th, 2020')
+    expect(agreement_history_table).to have_content('Status')
+    expect(agreement_history_table).to have_content('Live')
+    expect(agreement_history_table).to have_content('Descreption')
   end
 
   def stub_tenancy_with_arrears
@@ -187,6 +192,10 @@ describe 'Create informal agreement' do
               {
                 "state": 'live',
                 "date": '2020-06-19'
+              },
+              {
+                "state": 'live',
+                "date": '2020-07-19'
               }
             ]
           }

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -104,7 +104,6 @@ describe 'Create informal agreement' do
     expect(page).to have_content('Created by:')
     expect(page).to have_content('Notes:')
 
-    expect(page).to have_content('Rent owed: £0.00')
     expect(page).to have_content('Total arrears balance owed: £103.57')
     expect(page).to have_content('Frequency of payment: Weekly')
     expect(page).to have_content('Weekly instalment amount: £50')

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -38,6 +38,9 @@ describe 'Create informal agreement' do
     when_i_click_on_view_details
     then_i_should_see_the_agreement_details_page
     and_i_should_see_the_agreement_status
+    and_i_should_see_the_agreement_details
+    and_i_should_see_a_button_to_cancel_and_create_new_agreement
+    and_i_should_see_the_agreement_state_history
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -96,6 +99,26 @@ describe 'Create informal agreement' do
     expect(page).to have_content('Last checked:')
   end
 
+  def and_i_should_see_the_agreement_details
+    expect(page).to have_content('Created:')
+    expect(page).to have_content('Created by:')
+    expect(page).to have_content('Notes:')
+
+    expect(page).to have_content('Rent owed: £0.00')
+    expect(page).to have_content('Total arrears balance owed: £103.57')
+    expect(page).to have_content('Frequency of payment: Weekly')
+    expect(page).to have_content('Weekly instalment amount: £50')
+    expect(page).to have_content('Start date: December 12th, 2020')
+    expect(page).to have_content('End date:')
+  end
+
+  def and_i_should_see_the_agreement_state_history
+    expect(page).to have_content('History')
+    expect(page).to have_content('Date')
+    expect(page).to have_content('Status')
+    expect(page).to have_content('Descreption')
+  end
+
   def stub_tenancy_with_arrears
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
 
@@ -127,7 +150,7 @@ describe 'Create informal agreement' do
       "agreementType": 'informal',
       "startingBalance": '103.57',
       "amount": '50',
-      "startDate": '2020-06-19',
+      "startDate": '2020-12-12',
       "frequency": 'weekly',
       "currentState": 'live',
       "history": [
@@ -157,7 +180,7 @@ describe 'Create informal agreement' do
             "agreementType": 'informal',
             "startingBalance": '103.57',
             "amount": '50',
-            "startDate": '2020-06-19',
+            "startDate": '2020-12-12',
             "frequency": 'weekly',
             "currentState": 'live',
             "history": [

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -100,8 +100,8 @@ describe 'Create informal agreement' do
   end
 
   def and_i_should_see_the_agreement_details
-    expect(page).to have_content('Created:')
-    expect(page).to have_content('Created by:')
+    expect(page).to have_content('Created: June 19th, 2020')
+    expect(page).to have_content('Created by: 100518888746922116647')
     expect(page).to have_content('Notes:')
 
     expect(page).to have_content('Total arrears balance owed: £103.57')
@@ -157,6 +157,8 @@ describe 'Create informal agreement' do
       "startDate": '2020-12-12',
       "frequency": 'weekly',
       "currentState": 'live',
+      "createdAt": '2020-06-19',
+      "createdBy": '100518888746922116647',
       "history": [
         {
           "state": 'live',
@@ -187,6 +189,8 @@ describe 'Create informal agreement' do
             "startDate": '2020-12-12',
             "frequency": 'weekly',
             "currentState": 'live',
+            "createdAt": '2020-06-19',
+            "createdBy": '100518888746922116647',
             "history": [
               {
                 "state": 'live',

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -93,10 +93,10 @@ describe 'Create informal agreement' do
   end
 
   def and_i_should_see_the_agreement_status
-    expect(page).to have_content('Status: Live')
-    expect(page).to have_content('Expected balance: £103.57')
-    expect(page).to have_content('Actual balance: £103.57')
-    expect(page).to have_content('Last checked:')
+    expect(page).to have_content('Status Live')
+    expect(page).to have_content("Current balance\n£103.57")
+    expect(page).to have_content("Expected balance\n£103.57")
+    expect(page).to have_content('Last checked')
   end
 
   def and_i_should_see_the_agreement_details
@@ -104,9 +104,9 @@ describe 'Create informal agreement' do
     expect(page).to have_content('Created by: 100518888746922116647')
     expect(page).to have_content('Notes:')
 
-    expect(page).to have_content('Total arrears balance owed: £103.57')
+    expect(page).to have_content('Total balance owed: £103.57')
     expect(page).to have_content('Frequency of payment: Weekly')
-    expect(page).to have_content('Weekly instalment amount: £50')
+    expect(page).to have_content('Instalment amount: £50')
     expect(page).to have_content('Start date: December 12th, 2020')
     expect(page).to have_content('End date:')
   end

--- a/spec/lib/hackney/income/view_agreements_gateway_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_gateway_spec.rb
@@ -56,6 +56,7 @@ describe Hackney::Income::ViewAgreementsGateway do
       agreements = subject.view_agreements(tenancy_ref: tenancy_ref)
 
       agreements.each_with_index do |agreement, i|
+        expect(agreement.id).to eq(agreements_response[:agreements][i].fetch(:id))
         expect(agreement.tenancy_ref).to eq(agreements_response[:agreements][i].fetch(:tenancyRef))
         expect(agreement.agreement_type).to eq(agreements_response[:agreements][i].fetch(:agreementType))
         expect(agreement.starting_balance).to eq(agreements_response[:agreements][i].fetch(:startingBalance))

--- a/spec/lib/hackney/income/view_agreements_gateway_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_gateway_spec.rb
@@ -64,6 +64,8 @@ describe Hackney::Income::ViewAgreementsGateway do
         expect(agreement.start_date).to eq(agreements_response[:agreements][i].fetch(:startDate))
         expect(agreement.frequency).to eq(agreements_response[:agreements][i].fetch(:frequency))
         expect(agreement.current_state).to eq(agreements_response[:agreements][i].fetch(:currentState))
+        expect(agreement.history.first.date).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:date))
+        expect(agreement.history.first.state).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:state))
       end
     end
   end

--- a/spec/lib/hackney/income/view_agreements_gateway_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_gateway_spec.rb
@@ -17,6 +17,8 @@ describe Hackney::Income::ViewAgreementsGateway do
             startDate: Faker::Date.between(from: 2.days.ago, to: Date.today).to_s,
             frequency: %w[weekly monthly].sample,
             currentState: 'live',
+            createdBy: Faker::Number.number(digits: 8),
+            createdAt: Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s,
             history: [
               {
                 state: 'live',
@@ -33,6 +35,8 @@ describe Hackney::Income::ViewAgreementsGateway do
             startDate: Faker::Date.between(from: 2.days.ago, to: Date.today).to_s,
             frequency: %w[weekly monthly].sample,
             currentState: 'live',
+            createdBy: Faker::Number.number(digits: 8),
+            createdAt: Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s,
             history: [
               {
                 state: 'live',
@@ -64,6 +68,8 @@ describe Hackney::Income::ViewAgreementsGateway do
         expect(agreement.start_date).to eq(agreements_response[:agreements][i].fetch(:startDate))
         expect(agreement.frequency).to eq(agreements_response[:agreements][i].fetch(:frequency))
         expect(agreement.current_state).to eq(agreements_response[:agreements][i].fetch(:currentState))
+        expect(agreement.created_at).to eq(agreements_response[:agreements][i].fetch(:createdAt))
+        expect(agreement.created_by).to eq(agreements_response[:agreements][i].fetch(:createdBy))
         expect(agreement.history.first.date).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:date))
         expect(agreement.history.first.state).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:state))
       end

--- a/spec/lib/hackney/income/view_agreements_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_spec.rb
@@ -12,6 +12,8 @@ describe Hackney::Income::ViewAgreements do
         a.start_date = Faker::Date.between(from: 10.days.ago, to: Date.today).to_s
         a.frequency = %w[weekly monthly].sample
         a.current_state = 'live'
+        a.created_at = Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s
+        a.created_by = Faker::Number.number(digits: 8)
         a.history = [
           Hackney::Income::Domain::AgreementState.new.tap do |s|
             s.date = Faker::Date.between(from: 2.days.ago, to: Date.today).to_s
@@ -27,6 +29,8 @@ describe Hackney::Income::ViewAgreements do
         a.start_date = Faker::Date.between(from: 15.days.ago, to: 11.days.ago).to_s
         a.frequency = %w[weekly monthly].sample
         a.current_state = 'breached'
+        a.created_at = Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s
+        a.created_by = Faker::Number.number(digits: 8)
         a.history = [
           Hackney::Income::Domain::AgreementState.new.tap do |s|
             s.date = Faker::Date.between(from: 1.day.ago, to: Date.today).to_s

--- a/spec/lib/hackney/income/view_agreements_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_spec.rb
@@ -4,23 +4,39 @@ describe Hackney::Income::ViewAgreements do
   let!(:tenancy_ref) { Faker::Lorem.characters(number: 8) }
   let!(:agreements) do
     [
-      Hackney::Income::Domain::Agreement.new.tap do |t|
-        t.tenancy_ref = tenancy_ref
-        t.agreement_type = 'informal'
-        t.starting_balance = Faker::Commerce.price(range: 10...1000)
-        t.amount = Faker::Commerce.price(range: 10...100)
-        t.start_date = Faker::Date.between(from: 10.days.ago, to: Date.today).to_s,
-                       t.frequency = %w[weekly monthly].sample,
-                       t.current_state = 'live'
+      Hackney::Income::Domain::Agreement.new.tap do |a|
+        a.tenancy_ref = tenancy_ref
+        a.agreement_type = 'informal'
+        a.starting_balance = Faker::Commerce.price(range: 10...1000)
+        a.amount = Faker::Commerce.price(range: 10...100)
+        a.start_date = Faker::Date.between(from: 10.days.ago, to: Date.today).to_s
+        a.frequency = %w[weekly monthly].sample
+        a.current_state = 'live'
+        a.history = [
+          Hackney::Income::Domain::AgreementState.new.tap do |s|
+            s.date = Faker::Date.between(from: 2.days.ago, to: Date.today).to_s
+            s.state = 'live'
+          end
+        ]
       end,
-      Hackney::Income::Domain::Agreement.new.tap do |t|
-        t.tenancy_ref = tenancy_ref
-        t.agreement_type = 'informal'
-        t.starting_balance = Faker::Commerce.price(range: 10...1000)
-        t.amount = Faker::Commerce.price(range: 10...100)
-        t.start_date = Faker::Date.between(from: 15.days.ago, to: 11.days.ago).to_s,
-                       t.frequency = %w[weekly monthly].sample,
-                       t.current_state = 'breached'
+      Hackney::Income::Domain::Agreement.new.tap do |a|
+        a.tenancy_ref = tenancy_ref
+        a.agreement_type = 'informal'
+        a.starting_balance = Faker::Commerce.price(range: 10...1000)
+        a.amount = Faker::Commerce.price(range: 10...100)
+        a.start_date = Faker::Date.between(from: 15.days.ago, to: 11.days.ago).to_s
+        a.frequency = %w[weekly monthly].sample
+        a.current_state = 'breached'
+        a.history = [
+          Hackney::Income::Domain::AgreementState.new.tap do |s|
+            s.date = Faker::Date.between(from: 1.day.ago, to: Date.today).to_s
+            s.state = 'breached'
+          end,
+          Hackney::Income::Domain::AgreementState.new.tap do |s|
+            s.date = Faker::Date.between(from: 10.days.ago, to: 2.days.ago).to_s
+            s.state = 'live'
+          end
+        ]
       end
     ]
   end


### PR DESCRIPTION
## Context
We want to allow caseworkers to add an agreement so that tenants can repay their arrears over an agreed term. This is the third slice, to build the UI for agreements -> in which we add the `Agreement details` page.
Next tasks:
- Add cancel button(this also needs a new API endpoint)
- Agreements history page 
- Implement notes 
- Add JS calculator to the create agreement page 

## Changes in this pull request
- Add 'view details` link to agreements partial
- Render `agreement details` page
- Show `Created by` and `Created at` information, `agreement details` and `agreement state history`

### After

## Guidance to review

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-173

## Things to check

- [x] Environment variables have been updated
