### PR TITLE
Rescue from ActionController::InvalidAuthenticityToken

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -4,6 +4,7 @@ class AgreementsController < ApplicationController
 
   def new
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
+    @start_date = (Date.today + 1.day).to_s if @start_date.nil?
   end
 
   def create

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -15,7 +15,13 @@ class AgreementsController < ApplicationController
       start_date: params.fetch(:start_date),
       created_by: @current_user.name
     )
+    redirect_to show_success_path
+  rescue Exceptions::IncomeApiError => e
+    flash[:notice] = "An error occurred: #{e.message}"
+    render :new, tenancy_ref: tenancy_ref
+  end
 
+  def show_success
     flash[:notice] = 'Successfully created a new agreement'
     redirect_to tenancy_path(id: tenancy_ref)
   end

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -1,4 +1,5 @@
 class AgreementsController < ApplicationController
+  protect_from_forgery
   before_action { redirect_to worktray_path unless FeatureFlag.active?('create_informal_agreements') }
 
   def new

--- a/app/views/agreements/_agreement_status_history.html.erb
+++ b/app/views/agreements/_agreement_status_history.html.erb
@@ -4,7 +4,7 @@
     <th class="status-column">Status</th>
     <th class="descreption-column">Descreption</th>
   </thead>
-  <% state_history.each do |state| %>
+  <% state_history.reverse_each do |state| %>
     <tbody class="summary-table__group agreements_history-table__group--summary">
       <tr>
         <td><%= format_date(state.date) %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
 
   get '/tenancies/:tenancy_ref/agreement/new', to: 'agreements#new', as: :new_agreement
   post '/tenancies/:tenancy_ref/agreement/create', to: 'agreements#create', as: :create_agreement
+  get '/tenancies/:tenancy_ref/agreement/show_success', to: 'agreements#show_success', as: :show_success
   get '/tenancies/:tenancy_ref/agreement/:id/show', to: 'agreements#show', as: :show_agreement
 
   get '/login', to: 'hackney_auth_session#new'


### PR DESCRIPTION
## Context
![image](https://user-images.githubusercontent.com/22743709/86467330-1fa05280-bd2d-11ea-9483-9e391e933ba5.png)

This occurs when calling the create action in agreements controller, potentially caused by the page caching. "If you use page caching, Rails will keep the static HTML for a page in the cache. After a while the authenticity token for this page is stale and posting a form will result in this error. In this case either don't use page caching, or disable the forgery protection for that controller action" [Source](https://appsignal.com/for/invalid_authenticity_token)

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add `protect_from_forgery` to AgreementsController 


## Guidance to review 
Adding `protect_from_forgery` to AgreementsController fixed this issue, but the success flash message is no longer shown because this flash message depends on the session cookies

Alternatively we could use:

`skip_before_action :verify_authenticity_token, :only => [:create]`

As far as I understand, this would introduce some security issues as it would disable CSRF (Cross Site Request Forgery) protection for this request. Although the API only accepts calls from the Fron-end application, this may be an issue in the future if we'd allow other requests. 

What do you think?

## Things to check
- [x] Environment variables have been updated
