### PR TITLE
Record agreement notes when creating new agreements

### DIFF
--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -21,12 +21,12 @@
 
       <div class="form-group">
         <label class="govuk-label" for="frequency"><strong>Frequency of payments</strong><br/></label>
-        <%= select_tag(:frequency, options_for_select(frequency_of_payments), { :class => 'form-control', id: 'frequency_selector' }) %>
+        <%= select_tag(:frequency, options_for_select(frequency_of_payments, @frequency), { :class => 'form-control', id: 'frequency_selector' }) %>
       </div>
 
       <div class="form-group">
-        <label class="govuk-label" style=font-weight:bold for="instalment_amount" id="frequency_label">Weekly instalment amount</label><br/>
-        <%= number_field_tag(:instalment_amount, @amount, { class: 'form-control', required: true, min: 1 }) %>
+        <label class="govuk-label" style=font-weight:bold for="amount" id="frequency_label"><%= @frequency.nil? ? 'Weekly' : @frequency %> instalment amount</label><br/>
+        <%= number_field_tag(:amount, @amount, { class: 'form-control', required: true, min: 1 }) %>
       </div>
 
       <div class="form-group">
@@ -41,7 +41,7 @@
 
       <div class="form-group">
         <label class="govuk-label" for="agreement_notes"><strong>Notes</strong><br/></label>
-        <%= text_area_tag(:agreement_notes, @agreement_notes, { class: 'form-control' }) %>
+        <%= text_area_tag(:notes, @notes, { class: 'form-control' }) %>
       </div>
 
       <%= submit_tag 'Create', class: 'button' %>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -33,7 +33,7 @@
         <div class="column-full">
           <label class="govuk-label" for="status"><strong>Created: </strong><%= format_date(@agreement.created_at) %><br/></label>
           <label class="govuk-label" for="status"><strong>Created by: </strong><%= @agreement.created_by %><br/></label>
-          <label class="govuk-label" for="status"><br/><strong>Notes: </strong><br/></label>
+          <label class="govuk-label" for="status"><br/><strong>Notes: </strong><%= @agreement.notes %><br/></label>
         </div>
       </div>
   </div>

--- a/lib/hackney/income/agreements_gateway.rb
+++ b/lib/hackney/income/agreements_gateway.rb
@@ -9,13 +9,14 @@ module Hackney
         @api_key = api_key
       end
 
-      def create_agreement(tenancy_ref:, agreement_type:, frequency:, amount:, start_date:, created_by:)
+      def create_agreement(tenancy_ref:, agreement_type:, frequency:, amount:, start_date:, created_by:, notes:)
         body_data = {
           agreement_type: agreement_type,
           frequency: frequency,
           amount: amount,
           start_date: start_date,
-          created_by: created_by
+          created_by: created_by,
+          notes: notes
         }.to_json
 
         uri = URI.parse("#{@api_host}/v1/agreement/#{ERB::Util.url_encode(tenancy_ref)}/")
@@ -54,6 +55,7 @@ module Hackney
             t.current_state = agreement['currentState']
             t.created_at = agreement['createdAt']
             t.created_by = agreement['createdBy']
+            t.notes = agreement['notes']
             t.history = agreement['history'].map do |state|
               Hackney::Income::Domain::AgreementState.new.tap do |s|
                 s.date = state['date']

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -5,14 +5,15 @@ module Hackney
         @agreement_gateway = agreement_gateway
       end
 
-      def execute(tenancy_ref:, agreement_type: 'informal', frequency:, amount:, start_date:, created_by:)
+      def execute(tenancy_ref:, agreement_type: 'informal', frequency:, amount:, start_date:, created_by:, notes:)
         @agreement_gateway.create_agreement(
           tenancy_ref: tenancy_ref,
           agreement_type: agreement_type,
           frequency: frequency,
           amount: amount,
           start_date: start_date,
-          created_by: created_by
+          created_by: created_by,
+          notes: notes
         )
       end
     end

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -5,7 +5,7 @@ module Hackney
         include ActiveModel::Validations
 
         attr_accessor :id, :tenancy_ref, :agreement_type, :starting_balance, :amount, :frequency,
-                      :start_date, :current_state, :created_at, :created_by, :history
+                      :start_date, :current_state, :created_at, :created_by, :notes, :history
 
         def start_date_display_date
           Date.parse(start_date).to_formatted_s(:long_ordinal)

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -68,8 +68,9 @@ describe 'Create informal agreement' do
 
   def when_i_fill_in_the_agreement_details
     select('Weekly', from: 'frequency')
-    fill_in 'instalment_amount', with: '50'
+    fill_in 'amount', with: '50'
     fill_in 'start_date', with: '12/12/2020'
+    fill_in 'notes', with: 'Wen Ting is the master of rails'
   end
 
   def and_i_click_on_create
@@ -111,7 +112,7 @@ describe 'Create informal agreement' do
   def and_i_should_see_the_agreement_details
     expect(page).to have_content('Created: June 19th, 2020')
     expect(page).to have_content('Created by: Hackney User')
-    expect(page).to have_content('Notes:')
+    expect(page).to have_content('Notes: Wen Ting is the master of rails')
 
     expect(page).to have_content('Total balance owed: £103.57')
     expect(page).to have_content('Frequency of payment: Weekly')
@@ -175,7 +176,8 @@ describe 'Create informal agreement' do
       frequency: 'weekly',
       amount: '50',
       start_date: '12/12/2020',
-      created_by: 'Hackney User'
+      created_by: 'Hackney User',
+      notes: 'Wen Ting is the master of rails'
     }.to_json
 
     response_json = {
@@ -221,6 +223,7 @@ describe 'Create informal agreement' do
             "currentState": 'live',
             "createdAt": '2020-06-19',
             "createdBy": 'Hackney User',
+            "notes": 'Wen Ting is the master of rails',
             "history": [
               {
                 "state": 'live',

--- a/spec/lib/hackney/income/agreement_gateway_spec.rb
+++ b/spec/lib/hackney/income/agreement_gateway_spec.rb
@@ -11,7 +11,8 @@ describe Hackney::Income::AgreementsGateway do
         frequency: %w[weekly monthly].sample,
         amount: Faker::Commerce.price(range: 10...100),
         start_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
-        created_by: Faker::Name.name
+        created_by: Faker::Name.name,
+        notes: Faker::ChuckNorris.fact
       }
     end
 
@@ -21,7 +22,8 @@ describe Hackney::Income::AgreementsGateway do
         frequency: request_params.fetch(:frequency),
         amount: request_params.fetch(:amount),
         start_date: request_params.fetch(:start_date),
-        created_by: request_params.fetch(:created_by)
+        created_by: request_params.fetch(:created_by),
+        notes: request_params.fetch(:notes)
       }.to_json
     end
 

--- a/spec/lib/hackney/income/create_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_agreement_spec.rb
@@ -9,7 +9,8 @@ describe Hackney::Income::CreateAgreement do
       frequency: %w[weekly monthly].sample,
       amount: Faker::Commerce.price(range: 10...100),
       start_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
-      created_by: Faker::Name.name
+      created_by: Faker::Name.name,
+      notes: Faker::ChuckNorris.fact
     }
   end
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow caseworkers to add notes when creating a new agreement

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Start recording notes on create agreement form
- Render notes when reviewing an existing agreement
- Refactor agreements controller to persist form data when the create
agreement request blows up, so users don't need to refill the form to
resubmit

### After
![image](https://user-images.githubusercontent.com/22743709/86766309-45399e80-c042-11ea-9e72-92f344ed2136.png)

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-267

## Things to check
- [x] Environment variables have been updated
