### PR TITLE
Remove cancel button from agreement details page for cancelled

### DIFF
--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -46,8 +46,10 @@
       </div>
       <div class="grid-row">
         <div class="column-full">
-          <%= link_to 'Cancel and create new', new_agreement_path(@tenancy.ref), class:'button' %>
-          <%= link_to 'Cancel', confirm_agreement_cancellation_path(tenancy_ref: @tenancy.ref, id: @agreement.id), class:'button' %>
+          <% unless @agreement.current_state == 'cancelled' %>
+            <%= link_to 'Cancel and create new', new_agreement_path(@tenancy.ref), class:'button' %>
+            <%= link_to 'Cancel', confirm_agreement_cancellation_path(tenancy_ref: @tenancy.ref, id: @agreement.id), class:'button' %>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Context
Currently, we render cancel `cancel` and `cancel and create new` buttons on every `agreement details` page, but we should not show these for old cancelled agreements

## Changes in this pull request
- Remove `cancel` and `cancel and create new` buttons when reviewing old cancelled agreements
![image](https://user-images.githubusercontent.com/22743709/86913014-e6ddf000-c115-11ea-9069-947c11d51290.png)
