### PR TITLE
Add end date calculator

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,7 @@
   "plugins": [
     "syntax-dynamic-import",
     "transform-object-rest-spread",
-    ["transform-class-properties", { "spec": true }],
+    ["transform-class-properties", { "spec": true }]
   ],
   "env": {
     "test": {

--- a/app/assets/javascripts/income_collection/EndDateCalculator.js
+++ b/app/assets/javascripts/income_collection/EndDateCalculator.js
@@ -1,3 +1,20 @@
-window.EndDateCalculator = function EndDateCalculator () {
-  return 'FOOO';
+try { var moment = require('moment') } catch(err){}
+if (!moment) {
+  var script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.src = 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js';
+  document.body.appendChild(script);
+}
+
+window.EndDateCalculator = function EndDateCalculator (totalArrears, startDate, frequency, amount) {
+  if (!totalArrears || !startDate || !frequency || !amount) return '';
+  if (new Date(startDate) == 'Invalid Date') return '';
+
+  var numberOfInstalments = Math.ceil(parseFloat(totalArrears) / parseFloat(amount)) - 1;
+  const frequencyOfPayment = (frequency == 'Monthly') ? 'months' : 'weeks'
+
+  if (frequency == 'Fortnightly') numberOfInstalments = numberOfInstalments * 2;
+  if (frequency == '4 weekly') numberOfInstalments = numberOfInstalments * 4;
+
+  return moment(startDate).add(numberOfInstalments, frequencyOfPayment).format('D MMMM YYYY');
 };

--- a/app/assets/javascripts/income_collection/EndDateCalculator.js
+++ b/app/assets/javascripts/income_collection/EndDateCalculator.js
@@ -1,10 +1,4 @@
 try { var moment = require('moment') } catch(err){}
-if (!moment) {
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.src = 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js';
-  document.body.appendChild(script);
-}
 
 window.EndDateCalculator = function EndDateCalculator (totalArrears, startDate, frequency, amount) {
   if (!totalArrears || !startDate || !frequency || !amount) return '';

--- a/app/helpers/agreement_helper.rb
+++ b/app/helpers/agreement_helper.rb
@@ -2,7 +2,9 @@ module AgreementHelper
   def frequency_of_payments
     {
       'Weekly' => 'Weekly',
-      'Monthly' => 'Monthly'
+      'Fortnightly' => 'Fortnightly',
+      '4 weekly' => '4 weekly',
+      'Calendar monthly' => 'Monthly'
     }
   end
 end

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -10,7 +10,7 @@
   <div class="column-full">
     <h1><%= 'Create agreement' %></h1>
     <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
-    <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
+    <label class="govuk-label", for="arrears"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
     <hr>
   </div>
 </div>
@@ -51,13 +51,22 @@
 
 
 <script type="text/javascript">
+  function updateEndDate() {
+    var start_date = document.getElementById("start_date").value;
+    var arrears = document.getElementById("arrears");
+    var frequency = document.getElementById("frequency_selector").value;
+    var amount = document.getElementById("amount").value;
+    document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount);
+  }
+
   document.getElementById("start_date").addEventListener('change', (event) => {
-  var end_date = document.getElementById("start_date").value;
-  document.getElementById('end_date_value').textContent = end_date;
-});
+    updateEndDate()
+  });
 
   document.getElementById("frequency_selector").addEventListener('change', (event) => {
-  var frequency_label = document.getElementById("frequency_selector").value;
-  document.getElementById('frequency_label').textContent = frequency_label + " instalment amount";
-});
+    var frequency_label = document.getElementById("frequency_selector").value;
+    document.getElementById('frequency_label').textContent = frequency_label + " instalment amount";
+
+    updateEndDate()
+  });
 </script>

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -49,7 +49,7 @@
   </div>
 </div>
 
-
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
 <script type="text/javascript">
   function updateEndDate() {
     var start_date = document.getElementById("start_date").value;

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -10,7 +10,7 @@
   <div class="column-full">
     <h1><%= 'Create agreement' %></h1>
     <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
-    <label class="govuk-label", for="arrears"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
+    <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
     <hr>
   </div>
 </div>
@@ -26,7 +26,7 @@
 
       <div class="form-group">
         <label class="govuk-label" style=font-weight:bold for="amount" id="frequency_label"><%= @frequency.nil? ? 'Weekly' : @frequency %> instalment amount</label><br/>
-        <%= number_field_tag(:amount, @amount, { class: 'form-control', required: true, min: 1 }) %>
+        <%= number_field_tag(:amount, @amount, { class: 'form-control', required: true, min: 1, max: @tenancy.current_balance, placeholder: '£' }) %>
       </div>
 
       <div class="form-group">
@@ -53,11 +53,15 @@
 <script type="text/javascript">
   function updateEndDate() {
     var start_date = document.getElementById("start_date").value;
-    var arrears = document.getElementById("arrears");
+    var arrears = '<%= @tenancy.current_balance %>';
     var frequency = document.getElementById("frequency_selector").value;
     var amount = document.getElementById("amount").value;
     document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount);
   }
+
+  document.getElementById("amount").addEventListener('change', (event) => {
+    updateEndDate()
+  });
 
   document.getElementById("start_date").addEventListener('change', (event) => {
     updateEndDate()

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -25,7 +25,7 @@
             <li><strong>Instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
             <br/>
             <li><strong>Start date: </strong> <%= format_date(@agreement.start_date) %></li>
-            <li><strong>End date:</strong></li>
+            <li><strong>End date: </strong><label class="govuk-label" id="end_date_value"></label></li>
           </ul>
         </div>
     </div>
@@ -68,3 +68,20 @@
     <%= render('agreements/agreement_status_history', state_history: @agreement.history) %>
   </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
+<script type="text/javascript">
+  $(function () {
+      shows_end_date()
+  });
+
+  function shows_end_date() {
+    {
+      var start_date = '<%= @agreement.start_date %>';
+      var arrears = '<%= @tenancy.current_balance %>';
+      var frequency = '<%= @agreement.frequency.humanize %>';
+      var amount = '<%= @agreement.amount %>';
+      document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount);
+    }
+  }
+</script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0"
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "moment": "^2.27.0"
   },
   "devDependencies": {
     "babel-jest": "^26.1.0",

--- a/spec/javascript/EndDateCalculator.spec.js
+++ b/spec/javascript/EndDateCalculator.spec.js
@@ -1,5 +1,94 @@
 import EndDateCalculator from '../../app/assets/javascripts/income_collection/EndDateCalculator.js'
 
-test('returns an empty string', () => {
-  expect(window.EndDateCalculator()).toEqual('FOOO')
-})
+describe('EndDateCalculator', function() {
+  describe('when the params are invalid', function() {    
+    it('returns empty string if any of the params are missing', function() {
+      var totalArrears = '1000';
+      var startDate = '2020-12-1';
+      var frequency = '';
+      var amount = '50';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual('')
+    });
+
+    it('returns empty string when the start date is invalid', function() {
+      var totalArrears = '1000';
+      var startDate = 'foo';
+      var frequency = "Weekly";
+      var amount = '50';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual('')
+    });
+  });
+
+  describe('Weekly payments', function() {
+    it('calcules end date when arrears paid in a single instalment', function() {
+      var frequency = 'Weekly';
+      var totalArrears = '20';
+      var amount = '20';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '1 December 2020';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
+    });
+
+    it('calculates end date when its exactly 2 weeks to complete', function() {
+      var frequency = 'Weekly';
+      var totalArrears = '100';
+      var amount = '50';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '8 December 2020';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
+    });
+
+    it('calculates end date when its exactly 3 weeks to complete', function() {
+      var frequency = 'Weekly';
+      var totalArrears = '150';
+      var amount = '50';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '15 December 2020';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
+    });
+
+    it('calculates end date when the last payment is less than the agreed amount', function() {
+      var frequency = 'Weekly';
+      var totalArrears = '120';
+      var amount = '50';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '15 December 2020';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
+    });
+  });
+
+  describe('Monthly payments', function() {
+    it('calcules end date when arrears paid in 2 instalment', function() {
+      var frequency = 'Monthly';
+      var totalArrears = '40';
+      var amount = '20';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '1 January 2021';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
+    });
+  }); 
+
+  describe('Fortnightly payments', function() {
+    it('calcules end date when arrears paid in 2 instalment', function() {
+      var frequency = 'Fortnightly';
+      var totalArrears = '40';
+      var amount = '20';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '15 December 2020';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
+    });
+  }); 
+
+  describe('4 weekly payments', function() {
+    it('calcules end date when arrears paid in 3 instalment', function() {
+      var frequency = '4 weekly';
+      var totalArrears = '50';
+      var amount = '20';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '26 January 2021';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
+    });
+  }); 
+});
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,6 +2987,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+moment@^2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
+  integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to auto-generate the end date when a new agreement is created.

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add the `EndDateCalculator.js` and tests
- Call the end date calculator on `create agreement` and `show agreement` pages

## Guidance to review
Although I've added the JS end date calculator to the show agreement page I'm keen to use a Ruby end date calculator when the agreement is not editable. 

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-265

## Things to check
- [x] Environment variables have been updated
