### PR TITLE
Add end date calculator to agreements history page

### DIFF
--- a/app/helpers/agreement_helper.rb
+++ b/app/helpers/agreement_helper.rb
@@ -7,4 +7,22 @@ module AgreementHelper
       'Calendar monthly' => 'Monthly'
     }
   end
+
+  def show_end_date(total_arrears:, start_date:, frequency:, amount:)
+    return nil if total_arrears.nil? || start_date.nil? || frequency.nil? || amount.nil?
+
+    start_date = Date.parse(start_date)
+    number_of_instalments = total_arrears.to_f.fdiv(amount.to_f).ceil - 1
+    end_date = if frequency == 'weekly'
+                 start_date + number_of_instalments.weeks
+               elsif frequency == 'fortnightly'
+                 start_date + (number_of_instalments * 2).weeks
+               elsif frequency == '4 weekly'
+                 start_date + (number_of_instalments * 4).weeks
+               else
+                 start_date + number_of_instalments.months
+               end
+
+    format_date(end_date.to_s)
+  end
 end

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -21,11 +21,15 @@
           <ul>
             <li><h2><%= 'Agreement details' %></h2></li>
             <li><strong>Total balance owed: </strong> <%= number_to_currency(@tenancy.current_balance, unit: '£') %></li>
-            <li><strong>Frequency of payment: </strong> <%= @agreement.frequency.humanize %></li>
+            <li><strong>Frequency of payment: </strong><br> <%= @agreement.frequency.humanize %></li>
             <li><strong>Instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
             <br/>
             <li><strong>Start date: </strong> <%= format_date(@agreement.start_date) %></li>
-            <li><strong>End date: </strong><label class="govuk-label" id="end_date_value"></label></li>
+            <li><strong>End date: </strong><%= show_end_date(total_arrears: @agreement.starting_balance,
+                                                             start_date: @agreement.start_date, 
+                                                             frequency: @agreement.frequency,
+                                                             amount: @agreement.amount) %>
+            </li>
           </ul>
         </div>
     </div>
@@ -68,20 +72,3 @@
     <%= render('agreements/agreement_status_history', state_history: @agreement.history) %>
   </div>
 </div>
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
-<script type="text/javascript">
-  $(function () {
-      shows_end_date()
-  });
-
-  function shows_end_date() {
-    {
-      var start_date = '<%= @agreement.start_date %>';
-      var arrears = '<%= @tenancy.current_balance %>';
-      var frequency = '<%= @agreement.frequency.humanize %>';
-      var amount = '<%= @agreement.amount %>';
-      document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount);
-    }
-  }
-</script>

--- a/app/views/agreements/show_history.erb
+++ b/app/views/agreements/show_history.erb
@@ -31,7 +31,11 @@
           <tr>
             <td><%= agreement.current_state.humanize %></td>
             <td><%= format_date(agreement.start_date) %></td>
-            <td></td>
+            <td><%= show_end_date(total_arrears: agreement.starting_balance,
+                                                             start_date: agreement.start_date, 
+                                                             frequency: agreement.frequency,
+                                                             amount: agreement.amount) %>
+            </td>
             <td><%= number_to_currency(@tenancy.current_balance, unit: '£') %></td>
             <td>
               <% if agreement.current_state != 'live' %>

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -130,7 +130,7 @@ describe 'Create informal agreement' do
     expect(page).to have_content('Frequency of payment: Weekly')
     expect(page).to have_content('Instalment amount: £50')
     expect(page).to have_content('Start date: December 12th, 2020')
-    expect(page).to have_content('End date:')
+    expect(page).to have_content('End date: December 26th, 2020')
   end
 
   def and_i_should_see_the_agreement_state_history
@@ -184,6 +184,7 @@ describe 'Create informal agreement' do
     expect(agreements_history_table).to have_content('December 12th, 2020')
 
     expect(agreements_history_table).to have_content('End date')
+    expect(agreements_history_table).to have_content('December 26th, 2020')
 
     expect(agreements_history_table).to have_content('Balance owed')
     expect(agreements_history_table).to have_content('£103.57')

--- a/spec/helpers/agreement_helper_spec.rb
+++ b/spec/helpers/agreement_helper_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+describe AgreementHelper do
+  describe '#show_end_date' do
+    let(:params) do
+      {
+        total_arrears: nil,
+        start_date: nil,
+        frequency: nil,
+        amount: nil
+      }
+    end
+    it 'should return nil if params are missing' do
+      expect(helper.show_end_date(params)).to eq(nil)
+    end
+
+    context 'weekly installments' do
+      let(:params) do
+        {
+          total_arrears: '20',
+          start_date: '2020-12-01',
+          frequency: 'weekly',
+          amount: '20'
+        }
+      end
+      it 'calculates the end date for a single instalment' do
+        expected_end_date = 'December 1st, 2020'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+
+      it 'calculates end date when its exactly 2 weeks to complete' do
+        params[:total_arrears] = 40
+        expected_end_date = 'December 8th, 2020'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+
+      it 'calculates end date when the last payment is less than the agreed amount' do
+        params[:total_arrears] = 50
+        expected_end_date = 'December 15th, 2020'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+    end
+
+    context 'monthly installments' do
+      let(:params) do
+        {
+          total_arrears: '40',
+          start_date: '2020-12-01',
+          frequency: 'monthly',
+          amount: '20'
+        }
+      end
+      it 'calculates the end date for 2 instalments' do
+        expected_end_date = 'January 1st, 2021'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+    end
+
+    context 'fortnightly installments' do
+      let(:params) do
+        {
+          total_arrears: '40',
+          start_date: '2020-12-01',
+          frequency: 'fortnightly',
+          amount: '20'
+        }
+      end
+      it 'calculates the end date for 2 instalments' do
+        expected_end_date = 'December 15th, 2020'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+    end
+
+    context '4 weekly installments' do
+      let(:params) do
+        {
+          total_arrears: '50',
+          start_date: '2020-12-01',
+          frequency: '4 weekly',
+          amount: '20'
+        }
+      end
+      it 'calculates the end date for 3 instalments' do
+        expected_end_date = 'January 26th, 2021'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We shouldn't render end dates using JS on pages where the agreement details are not editable

## Changes in this pull request
- Add `show_end_date` method to `agreement_helper`
- Use this helper to render end dates on agreements history and agreement details pages

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-265

## Things to check
- [x] Environment variables have been updated
