### PR TITLE
Update agreement view with breach data

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -43,7 +43,7 @@ class TenanciesController < ApplicationController
 
     if FeatureFlag.active?('create_informal_agreements')
       @agreements = use_cases.view_agreements.execute(tenancy_ref: tenancy_ref)
-      @agreement = @agreements.find { |agreement| agreement.current_state == 'live' }
+      @agreement = @agreements.find { |agreement| %w[live breached].include?(agreement.current_state) }
     end
 
     render :show

--- a/app/views/agreements/_agreement_status.html.erb
+++ b/app/views/agreements/_agreement_status.html.erb
@@ -3,11 +3,11 @@
 <div class="grid-row">
   <div class="column-half">
     <label class="govuk-label" for="actual_balance_label"><br/><h2><strong>Current balance</strong></label>
-    <label class="govuk-label" for="actual_balance"><%= number_to_currency(@agreement.starting_balance, unit: '£') %></h2><br/></label>
+    <label class="govuk-label" for="actual_balance"><%= number_to_currency(@agreement.history.last.checked_balance, unit: '£') %></h2><br/></label>
   </div>
   <div class="column-half">
     <label class="govuk-label" for="expected_balance_label"><br/><h2><strong>Expected balance</strong><br/></label>
-    <label class="govuk-label" for="expected_balance"><%= number_to_currency(@agreement.starting_balance, unit: '£') %></h2><br/></label>
+    <label class="govuk-label" for="expected_balance"><%= number_to_currency(@agreement.history.last.expected_balance, unit: '£') %></h2><br/></label>
   </div>
 </div>
-<label class="govuk-label" for="status">Last checked: <br/></label>
+<label class="govuk-label" for="status">Last checked: <%= format_date(@agreement.last_checked) %><br/></label>

--- a/app/views/agreements/_agreement_status.html.erb
+++ b/app/views/agreements/_agreement_status.html.erb
@@ -1,5 +1,11 @@
 <label class="govuk-label" for="status_label"><strong>Status</strong><br/></label>
-<label class="govuk-label" for="status"><%= @agreement.current_state.humanize %><br/></label>
+<% status = if @agreement.current_state == 'breached' 
+              "#{@agreement.current_state.humanize} (#{@agreement.history.last.description})"  
+            else
+              @agreement.current_state.humanize
+            end
+%>
+<label class="govuk-label" for="status"><%= status %><br/></label>
 <div class="grid-row">
   <div class="column-half">
     <label class="govuk-label" for="actual_balance_label"><br/><h2><strong>Current balance</strong></label>

--- a/app/views/agreements/_agreement_status_history.html.erb
+++ b/app/views/agreements/_agreement_status_history.html.erb
@@ -9,7 +9,7 @@
       <tr>
         <td><%= format_date(state.date) %></td>
         <td><%= state.state.humanize %></td>
-        <td></td>
+        <td><%= state.description %></td>
       </tr>
   <% end %>
 </table>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -20,7 +20,7 @@
         <div class="column-full">
           <ul>
             <li><h2><%= 'Agreement details' %></h2></li>
-            <li><strong>Total balance owed: </strong> <%= number_to_currency(@tenancy.current_balance, unit: '£') %></li>
+            <li><strong>Total balance owed: </strong> <%= number_to_currency(@agreement.starting_balance, unit: '£') %></li>
             <li><strong>Frequency of payment: </strong><br> <%= @agreement.frequency.humanize %></li>
             <li><strong>Instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
             <br/>

--- a/app/views/agreements/show_history.erb
+++ b/app/views/agreements/show_history.erb
@@ -38,11 +38,7 @@
             </td>
             <td><%= number_to_currency(@tenancy.current_balance, unit: '£') %></td>
             <td>
-              <% if agreement.current_state != 'live' %>
-                <%= agreement.current_state.humanize %>
-                <br>
-                <%= format_date(agreement.history.last.date) %>
-              <% end %>
+              <%= agreement.history.last.description %>
             </td>
             <td><%= link_to('View details', show_agreement_path(tenancy_ref: @tenancy.ref, id: agreement.id)) %></td>
           </tr>

--- a/lib/hackney/income/agreements_gateway.rb
+++ b/lib/hackney/income/agreements_gateway.rb
@@ -55,11 +55,15 @@ module Hackney
             t.current_state = agreement['currentState']
             t.created_at = agreement['createdAt']
             t.created_by = agreement['createdBy']
+            t.last_checked = agreement['lastChecked']
             t.notes = agreement['notes']
             t.history = agreement['history'].map do |state|
               Hackney::Income::Domain::AgreementState.new.tap do |s|
                 s.date = state['date']
                 s.state = state['state']
+                s.expected_balance = state['expectedBalance']
+                s.checked_balance = state['checkedBalance']
+                s.description = state['description']
               end
             end
           end

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -5,7 +5,8 @@ module Hackney
         include ActiveModel::Validations
 
         attr_accessor :id, :tenancy_ref, :agreement_type, :starting_balance, :amount, :frequency,
-                      :start_date, :current_state, :created_at, :created_by, :notes, :history
+                      :start_date, :current_state, :created_at, :created_by, :notes, :history,
+                      :last_checked
 
         def start_date_display_date
           Date.parse(start_date).to_formatted_s(:long_ordinal)

--- a/lib/hackney/income/domain/agreement_state.rb
+++ b/lib/hackney/income/domain/agreement_state.rb
@@ -4,7 +4,7 @@ module Hackney
       class AgreementState
         include ActiveModel::Validations
 
-        attr_accessor :state, :date
+        attr_accessor :state, :date, :checked_balance, :expected_balance, :description
 
         validates_presence_of :state, :date
       end

--- a/spec/features/creating_action_diary_entry_spec.rb
+++ b/spec/features/creating_action_diary_entry_spec.rb
@@ -36,29 +36,6 @@ describe 'creating action diary entry' do
     end
   end
 
-  def stub_tenancy_api_actions
-    body = {
-      arrears_action_diary_events: [
-        {
-          code: 'INC',
-          date: '01-01-2019',
-          comment: 'Example details of a particular call',
-          universal_housing_username: 'Thomas Mcinnes'
-        },
-        {
-          code: 'INC',
-          date: '01-01-2010',
-          comment: 'Comment about on the case',
-          universal_housing_username: 'Gracie Barnes'
-        }
-      ]
-    }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567/actions')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: body)
-  end
-
   def stub_use_cases
     stub_const('Hackney::Income::TenancyGateway', Hackney::Income::StubTenancyGatewayBuilder.build_stub)
     stub_const('Hackney::Income::CreateActionDiaryEntryGateway', Hackney::Income::StubActionDiaryEntryGateway)

--- a/spec/features/feature_flags/manage_feature_flags_spec.rb
+++ b/spec/features/feature_flags/manage_feature_flags_spec.rb
@@ -60,13 +60,4 @@ describe 'Feature flags' do
     expect(page).to have_content 'Create formal agreements Disabled'
     expect(FeatureFlag.active?('create_formal_agreements')).to be false
   end
-
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-    stub_const('Hackney::Income::GetActionDiaryEntriesGateway', Hackney::Income::StubGetActionDiaryEntriesGateway)
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
 end

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -116,9 +116,10 @@ describe 'Create informal agreement' do
 
   def and_i_should_see_the_agreement_status
     expect(page).to have_content('Status Live')
-    expect(page).to have_content("Current balance\n£103.57")
-    expect(page).to have_content("Expected balance\n£103.57")
+    expect(page).to have_content("Current balance\n£53.57")
+    expect(page).to have_content("Expected balance\n£53.57")
     expect(page).to have_content('Last checked')
+    expect(page).to have_content('July 19th, 2020')
   end
 
   def and_i_should_see_the_agreement_details
@@ -143,6 +144,7 @@ describe 'Create informal agreement' do
     expect(agreement_history_table).to have_content('Status')
     expect(agreement_history_table).to have_content('Live')
     expect(agreement_history_table).to have_content('Description')
+    expect(agreement_history_table).to have_content('Agreement created')
   end
 
   def and_i_should_see_a_button_to_cancel_the_agreement
@@ -190,7 +192,7 @@ describe 'Create informal agreement' do
     expect(agreements_history_table).to have_content('£103.57')
 
     expect(agreements_history_table).to have_content('Description')
-    expect(agreements_history_table).to have_content('Cancelled July 20th, 2020')
+    expect(agreements_history_table).to have_content('Cancelled on 20/07/2020')
 
     expect(agreements_history_table).to have_link('View details').once
   end
@@ -233,10 +235,14 @@ describe 'Create informal agreement' do
       "currentState": 'live',
       "createdAt": '2020-06-19',
       "createdBy": 'Hackney User',
+      "lastChecked": '2020-06-19',
       "history": [
         {
           "state": 'live',
-          "date": '2020-06-19'
+          "date": '2020-06-19',
+          "expectedBalance": '103.57',
+          "checkedBalance": '103.57',
+          "description": 'Agreement created'
         }
       ]
     }.to_json
@@ -265,15 +271,22 @@ describe 'Create informal agreement' do
             "currentState": 'live',
             "createdAt": '2020-06-19',
             "createdBy": 'Hackney User',
+            "lastChecked": '2020-07-19',
             "notes": 'Wen Ting is the master of rails',
             "history": [
               {
                 "state": 'live',
-                "date": '2020-06-19'
+                "date": '2020-06-19',
+                "expectedBalance": '103.57',
+                "checkedBalance": '103.57',
+                "description": 'Agreement created'
               },
               {
                 "state": 'live',
-                "date": '2020-07-19'
+                "date": '2020-07-19',
+                "expectedBalance": '53.57',
+                "checkedBalance": '53.57',
+                "description": 'Checked by the system'
               }
             ]
           }
@@ -294,18 +307,28 @@ describe 'Create informal agreement' do
             "currentState": 'cancelled',
             "createdAt": '2020-06-19',
             "createdBy": 'Hackney User',
+            "lastChecked": '2020-07-20',
             "history": [
               {
                 "state": 'live',
-                "date": '2020-06-19'
+                "date": '2020-06-19',
+                "expectedBalance": '103.57',
+                "checkedBalance": '103.57',
+                "description": 'Agreement created'
               },
               {
                 "state": 'live',
-                "date": '2020-07-19'
+                "date": '2020-07-19',
+                "expectedBalance": '53.57',
+                "checkedBalance": '53.57',
+                "description": 'Checked by the system'
               },
               {
                 "state": 'cancelled',
-                "date": '2020-07-20'
+                "date": '2020-07-20',
+                "expectedBalance": '',
+                "checkedBalance": '',
+                "description": 'Cancelled on 20/07/2020'
               }
             ]
           }

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -7,7 +7,7 @@ describe 'Create informal agreement' do
     create_jwt_token
 
     stub_my_cases_response
-    stub_tenancy_with_arrears
+    stub_income_api_show_tenancy
     stub_tenancy_api_payments
     stub_tenancy_api_contacts
     stub_tenancy_api_actions
@@ -197,23 +197,6 @@ describe 'Create informal agreement' do
     expect(agreements_history_table).to have_link('View details').once
   end
 
-  def stub_tenancy_with_arrears
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
-
-    stub_request(:get, 'https://example.com/income/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_create_agreement_response
     request_body_json = {
       agreement_type: 'informal',
@@ -349,37 +332,5 @@ describe 'Create informal agreement' do
     stub_request(:post, 'https://example.com/income/api/v1/agreements/12/cancel')
          .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
          .to_return(status: 200, headers: {})
-  end
-
-  def stub_tenancy_api_payments
-    response_json = { 'payment_transactions': [] }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_contacts
-    response_json = { data: { contacts: [] } }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_actions
-    response_json = { arrears_action_diary_events: [] }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_tenancy
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
   end
 end

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -38,14 +38,7 @@ describe 'Create informal agreement' do
     and_i_should_see_a_link_to_view_history
 
     when_i_click_on_view_details
-    then_i_should_see_the_agreement_details_page
-    and_i_should_see_the_agreement_status
-    and_i_should_see_the_agreement_details
-    and_i_should_see_a_button_to_cancel_and_create_new_agreement
-    and_i_should_see_the_agreement_state_history
-    and_i_should_see_a_button_to_cancel_the_agreement
-
-    when_i_click_on_cancel
+    and_i_click_on_cancel
     then_i_am_asked_to_confirm_cancellation
 
     when_i_confirm_to_cancel_the_agreement
@@ -109,11 +102,6 @@ describe 'Create informal agreement' do
     click_link 'View details'
   end
 
-  def then_i_should_see_the_agreement_details_page
-    expect(page).to have_content('Agreement')
-    expect(page).to have_content('Alan Sugar')
-  end
-
   def and_i_should_see_the_agreement_status
     expect(page).to have_content('Status Live')
     expect(page).to have_content("Current balance\n£53.57")
@@ -122,36 +110,7 @@ describe 'Create informal agreement' do
     expect(page).to have_content('July 19th, 2020')
   end
 
-  def and_i_should_see_the_agreement_details
-    expect(page).to have_content('Created: June 19th, 2020')
-    expect(page).to have_content('Created by: Hackney User')
-    expect(page).to have_content('Notes: Wen Ting is the master of rails')
-
-    expect(page).to have_content('Total balance owed: £103.57')
-    expect(page).to have_content('Frequency of payment: Weekly')
-    expect(page).to have_content('Instalment amount: £50')
-    expect(page).to have_content('Start date: December 12th, 2020')
-    expect(page).to have_content('End date: December 26th, 2020')
-  end
-
-  def and_i_should_see_the_agreement_state_history
-    expect(page).to have_content('History')
-    agreement_history_table = find('table')
-
-    expect(agreement_history_table).to have_content('Date')
-    expect(agreement_history_table).to have_content('June 19th, 2020')
-    expect(agreement_history_table).to have_content('July 19th, 2020')
-    expect(agreement_history_table).to have_content('Status')
-    expect(agreement_history_table).to have_content('Live')
-    expect(agreement_history_table).to have_content('Description')
-    expect(agreement_history_table).to have_content('Agreement created')
-  end
-
-  def and_i_should_see_a_button_to_cancel_the_agreement
-    expect(page).to have_link('Cancel')
-  end
-
-  def when_i_click_on_cancel
+  def and_i_click_on_cancel
     click_link 'Cancel'
   end
 

--- a/spec/features/income_collection/agreements/view_agreements_spec.rb
+++ b/spec/features/income_collection/agreements/view_agreements_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+describe 'View agreements' do
+  before do
+    FeatureFlag.activate('create_informal_agreements')
+
+    create_jwt_token
+
+    stub_my_cases_response
+    stub_income_api_show_tenancy
+    stub_tenancy_api_payments
+    stub_tenancy_api_contacts
+    stub_tenancy_api_actions
+    stub_tenancy_api_tenancy
+  end
+
+  after do
+    FeatureFlag.deactivate('create_informal_agreements')
+  end
+
+  scenario 'viewing agreement' do
+    given_i_am_logged_in
+    and_there_there_is_a_breached_agreement
+
+    when_i_visit_the_tenancy_page
+    then_i_should_see_the_breached_agreement_status
+
+    when_i_click_on_view_details
+    then_i_should_see_the_agreement_details_page
+    and_i_should_see_the_agreement_status
+    and_i_should_see_the_agreement_details
+    and_i_should_see_a_button_to_cancel_and_create_new_agreement
+    and_i_should_see_a_button_to_cancel_the_agreement
+    and_i_should_see_the_agreement_state_history
+  end
+
+  def and_there_there_is_a_breached_agreement
+    breached_agreement =
+      {
+        "agreements": [
+          {
+            "id": 12,
+            "tenancyRef": '1234567/01',
+            "agreementType": 'informal',
+            "startingBalance": '140',
+            "amount": '20',
+            "startDate": '2020-12-12',
+            "frequency": 'weekly',
+            "currentState": 'breached',
+            "createdAt": '2020-06-19',
+            "createdBy": 'Hackney User',
+            "lastChecked": '2020-07-19',
+            "notes": 'Wen Ting is the master of rails',
+            "history": [
+              {
+                "state": 'breached',
+                "date": '2020-06-19',
+                "expectedBalance": '100',
+                "checkedBalance": '120',
+                "description": 'Breached by £20'
+              }
+            ]
+          }
+        ]
+      }.to_json
+
+    stub_view_agreements_response(response: breached_agreement)
+  end
+
+  def when_i_visit_the_tenancy_page
+    visit tenancy_path(id: '1234567/01')
+  end
+
+  def then_i_should_see_the_breached_agreement_status
+    expect(page).to have_content('Breached (Breached by £20)')
+    expect(page).to have_content("Current balance\n£120.0")
+    expect(page).to have_content("Expected balance\n£100.0")
+    expect(page).to have_content('Last checked')
+    expect(page).to have_content('July 19th, 2020')
+  end
+
+  def when_i_click_on_view_details
+    click_link 'View details'
+  end
+
+  def then_i_should_see_the_agreement_details_page
+    expect(page).to have_content('Agreement')
+    expect(page).to have_content('Alan Sugar')
+  end
+
+  def and_i_should_see_the_agreement_status
+    expect(page).to have_content('Status Breached (Breached by £20)')
+    expect(page).to have_content("Current balance\n£120")
+    expect(page).to have_content("Expected balance\n£100")
+    expect(page).to have_content('Last checked')
+    expect(page).to have_content('July 19th, 2020')
+  end
+
+  def and_i_should_see_the_agreement_details
+    expect(page).to have_content('Created: June 19th, 2020')
+    expect(page).to have_content('Created by: Hackney User')
+    expect(page).to have_content('Notes: Wen Ting is the master of rails')
+
+    expect(page).to have_content('Total balance owed: £140.0')
+    expect(page).to have_content('Frequency of payment: Weekly')
+    expect(page).to have_content('Instalment amount: £20')
+    expect(page).to have_content('Start date: December 12th, 2020')
+    expect(page).to have_content('End date: January 23rd, 2021')
+  end
+
+  def and_i_should_see_a_button_to_cancel_and_create_new_agreement
+    expect(page).to have_link('Cancel and create new')
+  end
+
+  def and_i_should_see_a_button_to_cancel_the_agreement
+    expect(page).to have_link('Cancel')
+  end
+
+  def and_i_should_see_the_agreement_state_history
+    expect(page).to have_content('History')
+    agreement_history_table = find('table')
+
+    expect(agreement_history_table).to have_content('Date')
+    expect(agreement_history_table).to have_content('June 19th, 2020')
+    expect(agreement_history_table).to have_content('Status')
+    expect(agreement_history_table).to have_content('Breached')
+    expect(agreement_history_table).to have_content('Description')
+    expect(agreement_history_table).to have_content('Breached Breached by £20')
+  end
+end

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -8,7 +8,7 @@ describe 'Create court case' do
     create_jwt_token
 
     stub_my_cases_response
-    stub_tenancy_with_arrears
+    stub_income_api_show_tenancy
     stub_tenancy_api_payments
     stub_tenancy_api_contacts
     stub_tenancy_api_actions
@@ -65,23 +65,6 @@ describe 'Create court case' do
     expect(page).to have_content('Successfully created a new court case')
   end
 
-  def stub_tenancy_with_arrears
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
-
-    stub_request(:get, 'https://example.com/income/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_create_court_case_response
     request_body_json = {
       court_decision_date: '21/07/2020',
@@ -116,37 +99,5 @@ describe 'Create court case' do
         headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
       )
       .to_return(status: 200, body: response_with_no_agreements_json)
-  end
-
-  def stub_tenancy_api_payments
-    response_json = { 'payment_transactions': [] }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_contacts
-    response_json = { data: { contacts: [] } }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_actions
-    response_json = { arrears_action_diary_events: [] }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_tenancy
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
   end
 end

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -90,14 +90,4 @@ describe 'Create court case' do
          )
          .to_return(status: 200, body: response_json, headers: {})
   end
-
-  def stub_view_agreements_response
-    response_with_no_agreements_json = { "agreements": [] }.to_json
-
-    stub_request(:get, 'https://example.com/income/api/v1/agreements/1234567%2F01/')
-      .with(
-        headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
-      )
-      .to_return(status: 200, body: response_with_no_agreements_json)
-  end
 end

--- a/spec/features/income_collection/letters/view_letter_preview_failures_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_failures_spec.rb
@@ -52,15 +52,6 @@ describe 'Viewing A Letter Preview' do
     expect(page).to have_css('td', text: 'Missing mandatory field', count: 1)
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })

--- a/spec/features/income_collection/letters/view_letter_preview_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_spec.rb
@@ -53,15 +53,6 @@ describe 'Viewing A Letter Preview' do
     expect(find('#successful_table')).to be_present
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })

--- a/spec/features/income_collection/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/income_collection/letters/view_letter_preview_success_spec.rb
@@ -88,15 +88,6 @@ describe 'Viewing A Letter Preview' do
     expect(page).to have_css("object#preview-doc-#{document_id}[type='application/pdf'][data='#{document_path(document_id)}.pdf?inline=true&documents_view=true']")
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })

--- a/spec/features/leasehold/letters/view_letter_preview_failures_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_failures_spec.rb
@@ -51,15 +51,6 @@ describe 'Viewing A Letter Preview' do
     expect(page).to have_css('td', text: 'Missing mandatory field', count: 1)
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })

--- a/spec/features/leasehold/letters/view_letter_preview_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_spec.rb
@@ -53,15 +53,6 @@ describe 'Viewing A Letter Preview' do
     expect(find('#successful_table')).to be_present
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })

--- a/spec/features/leasehold/letters/view_letter_preview_success_spec.rb
+++ b/spec/features/leasehold/letters/view_letter_preview_success_spec.rb
@@ -113,15 +113,6 @@ describe 'Viewing A Letter Preview' do
     expect(page).to have_css('div.letter_preview', text: preview)
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
   def stub_get_templates_response
     stub_request(:get, %r{/messages\/letters\/get_templates})
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })

--- a/spec/features/page_navigation_spec.rb
+++ b/spec/features/page_navigation_spec.rb
@@ -58,10 +58,6 @@ describe 'Page navigation' do
         }]
       }
     }.to_json
-
-    # stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/contacts')
-    #   .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-    #   .to_return(status: 200, body: response_json)
   end
 
   def stub_income_api_my_cases

--- a/spec/features/page_navigation_spec.rb
+++ b/spec/features/page_navigation_spec.rb
@@ -4,13 +4,13 @@ describe 'Page navigation' do
   before do
     create_jwt_token
 
-    stub_tenancy_api_tenancy
-    stub_tenancy_api_payments
-    stub_tenancy_api_actions
-    stub_tenancy_api_contacts
+    stub_tenancy_api_tenancy(tenancy_ref: 'TEST%2F01')
+    stub_tenancy_api_payments(tenancy_ref: 'TEST%2F01')
+    stub_tenancy_api_actions(tenancy_ref: 'TEST%2F01')
+    stub_tenancy_api_contacts(tenancy_ref: 'TEST%2F01', response: tenancy_api_contacts_response)
 
     stub_income_api_my_cases
-    stub_income_api_show_tenancy
+    stub_income_api_show_tenancy(tenancy_ref: 'TEST%2F01')
 
     stub_users_gateway
   end
@@ -44,24 +44,8 @@ describe 'Page navigation' do
     expect(page).to have_current_path(worktray_path(page: '1'))
   end
 
-  def stub_tenancy_api_tenancy
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_payments
-    response_json = { 'payment_transactions': [] }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_contacts
-    response_json = {
+  def tenancy_api_contacts_response
+    {
       data: {
         contacts: [{
           post_code: 'E8 1DY',
@@ -75,9 +59,9 @@ describe 'Page navigation' do
       }
     }.to_json
 
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
+    # stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/contacts')
+    #   .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
+    #   .to_return(status: 200, body: response_json)
   end
 
   def stub_income_api_my_cases
@@ -89,22 +73,6 @@ describe 'Page navigation' do
         number_per_page: '20',
         page_number: '1'
       ))
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_actions
-    response_json = { arrears_action_diary_events: [] }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/TEST%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_income_api_show_tenancy
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
-
-    stub_request(:get, 'https://example.com/income/api/v1/tenancies/TEST%2F01')
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end

--- a/spec/features/search_tenancies_spec.rb
+++ b/spec/features/search_tenancies_spec.rb
@@ -48,15 +48,6 @@ describe 'Search page' do
     expect(page.results.length).to eq(0)
   end
 
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases/)
-    .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-    .to_return(status: 200, body: response_json, headers: {})
-  end
-
   def stub_search_response
     stub_const('Hackney::Income::SearchTenanciesGateway', Hackney::Income::StubSearchTenanciesGatewayBuilder.build_stub)
   end

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -6,7 +6,7 @@ describe 'Viewing A Single Case' do
 
     stub_tenancy_api_tenancy
     stub_tenancy_api_payments
-    stub_tenancy_api_contacts
+    stub_tenancy_api_contacts(response: tenancy_api_contacts_response)
     stub_tenancy_api_actions
 
     stub_income_api_my_cases
@@ -144,43 +144,8 @@ describe 'Viewing A Single Case' do
     expect(page.body).to have_content('Adjourned to another hearing date')
   end
 
-  def stub_tenancy_api_tenancy
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_payments
-    response_json = {
-      payment_transactions: [
-        {
-          ref: '',
-          amount: '¤93.38',
-          date: '2019-09-05 00:00:00Z',
-          type: 'DBR',
-          property_ref: '00042611    ',
-          description: 'Basic Rent (No VAT) '
-        },
-        {
-          ref: '',
-          amount: '¤5.63',
-          date: '2010-09-05 00:00:00Z',
-          type: 'DCB',
-          property_ref: '00042611',
-          description: 'Cleaning (Block)'
-        }
-      ]
-    }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/payments')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_contacts
-    response_json = {
+  def tenancy_api_contacts_response
+    {
       data: {
         contacts: [{
           post_code: 'E8 1DY',
@@ -193,10 +158,6 @@ describe 'Viewing A Single Case' do
         }]
       }
     }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/contacts')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
-      .to_return(status: 200, body: response_json)
   end
 
   def stub_income_api_my_cases
@@ -209,39 +170,6 @@ describe 'Viewing A Single Case' do
         page_number: '1'
       ))
       .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_income_api_show_tenancy
-    response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
-
-    stub_request(:get, 'https://example.com/income/api/v1/tenancies/1234567%2F01')
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
-
-  def stub_tenancy_api_actions
-    response_json = {
-      arrears_action_diary_events: [
-        {
-          code: 'INC',
-          date: '01-01-2019',
-          comment: 'Example details of a particular call',
-          universal_housing_username: 'Thomas Mcinnes',
-          balance: '¤400.00'
-        },
-        {
-          code: 'INC',
-          date: '01-01-2010',
-          comment: 'Comment about on the case',
-          universal_housing_username: 'Gracie Barnes',
-          balance: '¤500.00'
-        }
-      ]
-    }.to_json
-
-    stub_request(:get, 'https://example.com/tenancy/api/v1/tenancies/1234567%2F01/actions')
-      .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
       .to_return(status: 200, body: response_json)
   end
 

--- a/spec/features/view_my_worktray_spec.rb
+++ b/spec/features/view_my_worktray_spec.rb
@@ -256,28 +256,4 @@ describe 'Worktray' do
     select('Missing Data', from: 'pause_reason')
     click_button 'Filter by pause reason'
   end
-
-  def stub_my_cases_response(override_params = {})
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-
-    default_filters = {
-      is_paused: false,
-      number_per_page: 20,
-      page_number: 1,
-      full_patch: false,
-      patch: nil,
-      recommended_actions: nil,
-      upcoming_court_dates: false,
-      upcoming_evictions: false,
-      pause_reason: nil
-    }.merge(override_params).reject { |_k, v| v.nil? }
-
-    uri = /cases\?#{default_filters.to_param.gsub('+', '%20')}/
-
-    stub_request(:get, uri)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
 end

--- a/spec/features/view_transactions_spec.rb
+++ b/spec/features/view_transactions_spec.rb
@@ -5,6 +5,7 @@ describe 'Viewing Transaction History' do
     create_jwt_token
 
     stub_my_cases_response
+    stub_action_diary_entries_gateway
     stub_income_api_response
     stub_tenancy_api_show_tenancy
   end
@@ -47,15 +48,6 @@ describe 'Viewing Transaction History' do
   def then_i_should_see_a_search_button
     expect(page.body).to have_css('.button--dark-grey', text: 'Search', count: 1)
     expect(page).to have_link(href: '/search')
-  end
-
-  def stub_my_cases_response
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-    stub_const('Hackney::Income::GetActionDiaryEntriesGateway', Hackney::Income::StubGetActionDiaryEntriesGateway)
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-    stub_request(:get, /cases\?full_patch=false&is_paused=false&number_per_page=20&page_number=1&upcoming_court_dates=false&upcoming_evictions=false/)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
   end
 
   def stub_income_api_response

--- a/spec/lib/hackney/income/agreement_gateway_spec.rb
+++ b/spec/lib/hackney/income/agreement_gateway_spec.rb
@@ -91,10 +91,14 @@ describe Hackney::Income::AgreementsGateway do
               currentState: 'live',
               createdBy: Faker::Number.number(digits: 8),
               createdAt: Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s,
+              lastChecked: Faker::Date.between(from: 3.days.ago, to: 2.days.ago).to_s,
               history: [
                 {
                   state: 'live',
-                  date: Faker::Date.between(from: 2.days.ago, to: Date.today).to_s
+                  date: Faker::Date.between(from: 2.days.ago, to: Date.today).to_s,
+                  checkedBalance: Faker::Commerce.price(range: 10...100),
+                  expectedBalance: Faker::Commerce.price(range: 10...100),
+                  description: Faker::ChuckNorris.fact
                 }
               ]
             },
@@ -109,10 +113,14 @@ describe Hackney::Income::AgreementsGateway do
               currentState: 'live',
               createdBy: Faker::Number.number(digits: 8),
               createdAt: Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s,
+              lastChecked: Faker::Date.between(from: 3.days.ago, to: 2.days.ago).to_s,
               history: [
                 {
                   state: 'live',
-                  date: Faker::Date.between(from: 2.days.ago, to: Date.today).to_s
+                  date: Faker::Date.between(from: 2.days.ago, to: Date.today).to_s,
+                  checkedBalance: Faker::Commerce.price(range: 10...100),
+                  expectedBalance: Faker::Commerce.price(range: 10...100),
+                  description: Faker::ChuckNorris.fact
                 }
               ]
             }
@@ -142,8 +150,12 @@ describe Hackney::Income::AgreementsGateway do
           expect(agreement.current_state).to eq(agreements_response[:agreements][i].fetch(:currentState))
           expect(agreement.created_at).to eq(agreements_response[:agreements][i].fetch(:createdAt))
           expect(agreement.created_by).to eq(agreements_response[:agreements][i].fetch(:createdBy))
+          expect(agreement.last_checked).to eq(agreements_response[:agreements][i].fetch(:lastChecked))
           expect(agreement.history.first.date).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:date))
           expect(agreement.history.first.state).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:state))
+          expect(agreement.history.first.checked_balance).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:checkedBalance))
+          expect(agreement.history.first.expected_balance).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:expectedBalance))
+          expect(agreement.history.first.description).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:description))
         end
       end
     end

--- a/spec/lib/hackney/income/view_agreements_spec.rb
+++ b/spec/lib/hackney/income/view_agreements_spec.rb
@@ -14,6 +14,7 @@ describe Hackney::Income::ViewAgreements do
         a.current_state = 'live'
         a.created_at = Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s
         a.created_by = Faker::Name.name
+        a.last_checked = Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s
         a.history = [
           Hackney::Income::Domain::AgreementState.new.tap do |s|
             s.date = Faker::Date.between(from: 2.days.ago, to: Date.today).to_s
@@ -31,14 +32,21 @@ describe Hackney::Income::ViewAgreements do
         a.current_state = 'breached'
         a.created_at = Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s
         a.created_by = Faker::Name.name
+        a.last_checked = Faker::Date.between(from: 3.days.ago, to: 2.days.ago).to_s
         a.history = [
           Hackney::Income::Domain::AgreementState.new.tap do |s|
             s.date = Faker::Date.between(from: 1.day.ago, to: Date.today).to_s
             s.state = 'breached'
+            s.checked_balance = Faker::Commerce.price(range: 10...100)
+            s.expected_balance = Faker::Commerce.price(range: 10...100)
+            s.description = Faker::ChuckNorris.fact
           end,
           Hackney::Income::Domain::AgreementState.new.tap do |s|
             s.date = Faker::Date.between(from: 10.days.ago, to: 2.days.ago).to_s
             s.state = 'live'
+            s.checked_balance = Faker::Commerce.price(range: 10...100)
+            s.expected_balance = Faker::Commerce.price(range: 10...100)
+            s.description = Faker::ChuckNorris.fact
           end
         ]
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 require 'tenancy_helper'
 require 'document_helper'
 require 'support/mock_auth_helper'
+require 'support/api_response_helper'
 require 'support/chrome_test_helper'
 
 ENV['RAILS_ENV'] = 'test'

--- a/spec/request/worktray_spec.rb
+++ b/spec/request/worktray_spec.rb
@@ -51,29 +51,4 @@ describe 'Viewing the Worktray', type: :request do
       expect(response).not_to render_template('leasehold/buttons')
     end
   end
-
-  private
-
-  def stub_my_cases_response(override_params = {})
-    stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
-
-    response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
-
-    default_filters = {
-      is_paused: false,
-      number_per_page: 20,
-      page_number: 1,
-      full_patch: false,
-      patch: nil,
-      recommended_actions: nil,
-      upcoming_court_dates: false,
-      upcoming_evictions: false
-    }.merge(override_params).reject { |_k, v| v.nil? }
-
-    uri = /cases\?#{default_filters.to_param}/
-
-    stub_request(:get, uri)
-      .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
-      .to_return(status: 200, body: response_json)
-  end
 end

--- a/spec/support/api_response_helper.rb
+++ b/spec/support/api_response_helper.rb
@@ -1,0 +1,67 @@
+def stub_my_cases_response(override_params = {})
+  stub_const('Hackney::Income::IncomeApiUsersGateway', Hackney::Income::StubIncomeApiUsersGateway)
+
+  response_json = File.read(Rails.root.join('spec', 'examples', 'my_cases_response.json'))
+
+  default_filters = {
+    is_paused: false,
+    number_per_page: 20,
+    page_number: 1,
+    full_patch: false,
+    patch: nil,
+    recommended_actions: nil,
+    upcoming_court_dates: false,
+    upcoming_evictions: false,
+    pause_reason: nil
+  }.merge(override_params).reject { |_k, v| v.nil? }
+
+  uri = /cases\?#{default_filters.to_param.gsub('+', '%20')}/
+
+  stub_request(:get, uri)
+    .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
+    .to_return(status: 200, body: response_json)
+end
+
+def stub_action_diary_entries_gateway
+  stub_const('Hackney::Income::GetActionDiaryEntriesGateway', Hackney::Income::StubGetActionDiaryEntriesGateway)
+end
+
+def stub_tenancy_api_payments(tenancy_ref: '1234567%2F01')
+  response_json = { 'payment_transactions': [] }.to_json
+
+  stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/#{tenancy_ref}/payments")
+    .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
+    .to_return(status: 200, body: response_json)
+end
+
+def stub_income_api_show_tenancy(tenancy_ref: '1234567%2F01')
+  response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
+
+  stub_request(:get, "https://example.com/income/api/v1/tenancies/#{tenancy_ref}")
+    .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
+    .to_return(status: 200, body: response_json)
+end
+
+def stub_tenancy_api_contacts(tenancy_ref: '1234567%2F01', response: nil)
+  response ||= { data: { contacts: [] } }.to_json
+
+  stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/#{tenancy_ref}/contacts")
+    .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
+    .to_return(status: 200, body: response)
+end
+
+def stub_tenancy_api_actions(tenancy_ref: '1234567%2F01', response: nil)
+  response ||= { arrears_action_diary_events: [] }.to_json
+
+  stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/#{tenancy_ref}/actions")
+    .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
+    .to_return(status: 200, body: response)
+end
+
+def stub_tenancy_api_tenancy(tenancy_ref: '1234567%2F01')
+  response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_response.json'))
+
+  stub_request(:get, "https://example.com/tenancy/api/v1/tenancies/#{tenancy_ref}")
+    .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
+    .to_return(status: 200, body: response_json)
+end

--- a/spec/support/api_response_helper.rb
+++ b/spec/support/api_response_helper.rb
@@ -65,3 +65,13 @@ def stub_tenancy_api_tenancy(tenancy_ref: '1234567%2F01')
     .with(headers: { 'X-Api-Key' => ENV['TENANCY_API_KEY'] })
     .to_return(status: 200, body: response_json)
 end
+
+def stub_view_agreements_response(response: nil)
+  response ||= { "agreements": [] }.to_json
+
+  stub_request(:get, 'https://example.com/income/api/v1/agreements/1234567%2F01/')
+    .with(
+      headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
+    )
+    .to_return(status: 200, body: response)
+end


### PR DESCRIPTION
## Context
As a caseworker, I want to see the agreement state details so that I know when was the status checked by the system, what is the current state and why(e.g expected balance is lower than the checked balance).

## Changes in this pull request
- Update the `agreement status` partial to show `state`, `checked balance`, `expected balance` and `last checked` date

### Update view:
![image](https://user-images.githubusercontent.com/22743709/89195232-64bfda80-d5a0-11ea-8009-fa2be19e85f9.png)


## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-175

## Things to check
- [x] Environment variables have been updated
