### PR TITLE
Slighty faster dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ruby:2.7.1-buster
 
-COPY Gemfile* /tmp/
-WORKDIR /tmp
-RUN bundle install --jobs=4
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     nodejs \
@@ -10,6 +7,10 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g yarn@1.22.4
+
+COPY Gemfile* /tmp/
+WORKDIR /tmp
+RUN bundle install --jobs=4
 
 WORKDIR /app
 COPY Gemfile Gemfile.lock ./


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Installing gems from a non-static file before installing static dependencies can slow down builds locally

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
Take advantage of docker layer caching and install the static deps before copying files

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
 -