### PR TITLE
Allow viewing court date

### DIFF
--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -47,6 +47,11 @@ class TenanciesController < ApplicationController
       @agreement = @agreements.find { |agreement| %w[live breached].include?(agreement.current_state) }
     end
 
+    if FeatureFlag.active?('create_formal_agreements')
+      @court_cases = use_cases.view_court_cases.execute(tenancy_ref: tenancy_ref)
+      @court_case = @court_cases.last
+    end
+
     render :show
   end
 

--- a/app/views/tenancies/case/_court_cases.html.erb
+++ b/app/views/tenancies/case/_court_cases.html.erb
@@ -9,8 +9,24 @@
                 <h2>Court case</h2>
               </div>
             </div>
+            <div class="column-half">
+              <% if @court_case.present? %>
+                <div class="column-half">
+                  <u>View details</u>
+                </div>
+              <% end %>
+              <% if @court_cases.present? %>
+                <div class="column-align-right">
+                  <u>View history</u>
+                </div>
+              <% end %>
+            </div>
           </div>
-          No valid court case at this time
+          <% if @court_case.nil? %>
+            No valid court case at this time
+          <% else %>
+            <label class="govuk-label" for="court_date">Court date: <%= format_date(@court_case.court_date) %><br/></label>
+          <% end %>
         </div>
       </div>
 

--- a/lib/hackney/income/court_cases_gateway.rb
+++ b/lib/hackney/income/court_cases_gateway.rb
@@ -42,7 +42,7 @@ module Hackney
         response = Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == 'https')) { |http| http.request(req) }
 
         raise_error(response, "when trying to get court cases using '#{uri}'")
-        
+
         court_cases = JSON.parse(response.body)['courtCases']
 
         court_cases.map do |court_case|

--- a/lib/hackney/income/domain/court_case.rb
+++ b/lib/hackney/income/domain/court_case.rb
@@ -6,10 +6,6 @@ module Hackney
 
         attr_accessor :id, :tenancy_ref, :court_date, :court_outcome, :balance_on_court_outcome_date, :strike_out_date,
                       :terms, :disrepair_counter_claim
-
-        def start_date_display_date
-          Date.parse(start_date).to_formatted_s(:long_ordinal)
-        end
       end
     end
   end

--- a/lib/hackney/income/domain/court_case.rb
+++ b/lib/hackney/income/domain/court_case.rb
@@ -1,0 +1,16 @@
+module Hackney
+  module Income
+    module Domain
+      class CourtCase
+        include ActiveModel::Validations
+
+        attr_accessor :id, :tenancy_ref, :court_date, :court_outcome, :balance_on_court_outcome_date, :strike_out_date,
+                      :terms, :disrepair_counter_claim
+
+        def start_date_display_date
+          Date.parse(start_date).to_formatted_s(:long_ordinal)
+        end
+      end
+    end
+  end
+end

--- a/lib/hackney/income/use_case_factory.rb
+++ b/lib/hackney/income/use_case_factory.rb
@@ -138,6 +138,10 @@ module Hackney
         Hackney::Income::CreateCourtCase.new(court_cases_gateway: court_cases_gateway)
       end
 
+      def view_court_cases
+        Hackney::Income::ViewCourtCases.new(court_cases_gateway: court_cases_gateway)
+      end
+
       # FIXME: gateways shouldn't be exposed by the UseCaseFactory, but ActionDiaryEntryController depends on it
       TENANCY_API_URL = ENV.fetch('TENANCY_API_URL')
       TENANCY_API_KEY = ENV.fetch('TENANCY_API_KEY')

--- a/lib/hackney/income/view_court_cases.rb
+++ b/lib/hackney/income/view_court_cases.rb
@@ -1,0 +1,15 @@
+module Hackney
+  module Income
+    class ViewCourtCases
+      def initialize(court_cases_gateway:)
+        @court_cases_gateway = court_cases_gateway
+      end
+
+      def execute(tenancy_ref:)
+        @court_cases_gateway.view_court_cases(
+          tenancy_ref: tenancy_ref
+        )
+      end
+    end
+  end
+end

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -15,6 +15,7 @@ describe 'Create court case' do
     stub_tenancy_api_tenancy
     stub_view_agreements_response
     stub_create_court_case_response
+    stub_view_court_cases_response
   end
 
   after do
@@ -34,6 +35,8 @@ describe 'Create court case' do
 
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_success_message
+    and_i_should_see_the_view_history_link
+    and_i_should_see_the_court_date
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -72,6 +75,14 @@ describe 'Create court case' do
     expect(page).to have_content('Successfully created a new court case')
   end
 
+  def and_i_should_see_the_view_history_link
+    expect(page).to have_content('View history')
+  end
+
+  def and_i_should_see_the_court_date
+    expect(page).to have_content('Court date: July 21st, 2020')
+  end
+
   def stub_tenancy_with_arrears
     response_json = File.read(Rails.root.join('spec', 'examples', 'single_case_priority_response.json'))
 
@@ -100,14 +111,14 @@ describe 'Create court case' do
     }.to_json
 
     response_json = {
-      "id": 12,
-      "tenancyRef": '1234567/01',
-      "courtDate": '21/07/2020',
-      "courtOutcome": nil,
-      "balanceOnCourtOutcomeDate": nil,
-      "strikeOutDate": nil,
-      "terms": nil,
-      "disrepairCounterClaim": nil
+      id: 12,
+      tenancyRef: '1234567/01',
+      courtDate: '21/07/2020',
+      courtOutcome: nil,
+      balanceOnCourtOutcomeDate: nil,
+      strikeOutDate: nil,
+      terms: nil,
+      disrepairCounterClaim: nil
     }.to_json
 
     stub_request(:post, 'https://example.com/income/api/v1/court_case/1234567%2F01/')
@@ -116,5 +127,29 @@ describe 'Create court case' do
            headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
          )
          .to_return(status: 200, body: response_json, headers: {})
+  end
+
+  def stub_view_court_cases_response
+    no_court_cases_response_json = {
+      courtCases: []
+ }.to_json
+
+    one_court_case_response_json = {
+      courtCases:
+        [{
+          id: 12,
+          tenancyRef: '1234567/01',
+          courtDate: '21/07/2020',
+          courtOutcome: nil,
+          balanceOnCourtOutcomeDate: nil,
+          strikeOutDate: nil,
+          terms: nil,
+          disrepairCounterClaim: nil
+        }]
+}.to_json
+
+    stub_request(:get, 'https://example.com/income/api/v1/court_cases/1234567%2F01/')
+      .to_return({ status: 200, body: no_court_cases_response_json },
+                 status: 200, body: one_court_case_response_json)
   end
 end

--- a/spec/lib/hackney/income/court_cases_gateway_spec.rb
+++ b/spec/lib/hackney/income/court_cases_gateway_spec.rb
@@ -2,11 +2,12 @@ require 'rails_helper'
 
 describe Hackney::Income::CourtCasesGateway do
   subject { described_class.new(api_host: 'https://example.com/api', api_key: 'skeleton') }
+  let(:tenancy_ref) { "#{Faker::Lorem.characters(number: 6)}/#{Faker::Lorem.characters(number: 2)}" }
 
   describe '#create_court_case' do
     let(:request_params) do
       {
-        tenancy_ref: Faker::Lorem.characters(number: 6),
+        tenancy_ref: tenancy_ref,
         court_date: Faker::Date.between(from: 5.days.ago, to: Date.today),
         court_outcome: nil,
         balance_on_court_outcome_date: nil,
@@ -29,7 +30,7 @@ describe Hackney::Income::CourtCasesGateway do
 
     context 'when sending a successful request to the API' do
       before do
-        stub_request(:post, "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(request_params.fetch(:tenancy_ref))}/")
+        stub_request(:post, "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(tenancy_ref)}/")
           .to_return(
             status: 200
           )
@@ -40,7 +41,7 @@ describe Hackney::Income::CourtCasesGateway do
 
         assert_requested(
           :post,
-          "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(request_params.fetch(:tenancy_ref))}/",
+          "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(tenancy_ref)}/",
           headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'skeleton' },
           body: json_request_body,
           times: 1
@@ -50,7 +51,7 @@ describe Hackney::Income::CourtCasesGateway do
 
     context 'when receiving a 500 error from the API' do
       before do
-        stub_request(:post, "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(request_params.fetch(:tenancy_ref))}/")
+        stub_request(:post, "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(tenancy_ref)}/")
           .to_return(
             status: 500
           )
@@ -65,9 +66,66 @@ describe Hackney::Income::CourtCasesGateway do
         )
         assert_requested(
           :post,
-          "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(request_params.fetch(:tenancy_ref))}/",
+          "https://example.com/api/v1/court_case/#{ERB::Util.url_encode(tenancy_ref)}/",
           headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'skeleton' },
           body: json_request_body,
+          times: 1
+        )
+      end
+    end
+  end
+
+  describe '#view_court_cases' do
+    let(:response_body) do
+      { courtCases: 
+        [{
+          id: Faker::Number.number(digits: 3),
+          tenancyRef: tenancy_ref,
+          courtDate: Faker::Date.between(from: 5.days.ago, to: Date.today),
+          courtOutcome: nil,
+          balanceOnCourtOutcomeDate: nil,
+          strikeOutDate: nil,
+          terms: nil,
+          disrepairCounterClaim: nil
+        }]
+      }.to_json
+    end
+
+    context 'when sending a successful request to the API' do
+      before do
+        stub_request(:get, "https://example.com/api/v1/court_cases/#{ERB::Util.url_encode(tenancy_ref)}/")
+          .to_return(
+            status: 200,
+            body: response_body
+          )
+      end
+
+      it 'should send the required params' do
+        court_cases = subject.view_court_cases(tenancy_ref: tenancy_ref)
+
+        expect(court_cases.count).to be(1)
+      end
+    end
+
+    context 'when receiving a 500 error from the API' do
+      before do
+        stub_request(:get, "https://example.com/api/v1/court_cases/#{ERB::Util.url_encode(tenancy_ref)}/")
+          .to_return(
+            status: 500
+          )
+      end
+
+      it 'should raise and error' do
+        expect do
+          subject.view_court_cases(tenancy_ref: tenancy_ref)
+        end.to raise_error(
+          Exceptions::IncomeApiError,
+          "[Income API error: Received 500 response] when trying to get court cases using 'https://example.com/api/v1/court_cases/#{ERB::Util.url_encode(tenancy_ref)}/'"
+        )
+        assert_requested(
+          :get,
+          "https://example.com/api/v1/court_cases/#{ERB::Util.url_encode(tenancy_ref)}/",
+          headers: { 'Content-Type': 'application/json', 'X-Api-Key': 'skeleton' },
           times: 1
         )
       end

--- a/spec/lib/hackney/income/court_cases_gateway_spec.rb
+++ b/spec/lib/hackney/income/court_cases_gateway_spec.rb
@@ -77,7 +77,7 @@ describe Hackney::Income::CourtCasesGateway do
 
   describe '#view_court_cases' do
     let(:response_body) do
-      { courtCases: 
+      { courtCases:
         [{
           id: Faker::Number.number(digits: 3),
           tenancyRef: tenancy_ref,
@@ -87,8 +87,7 @@ describe Hackney::Income::CourtCasesGateway do
           strikeOutDate: nil,
           terms: nil,
           disrepairCounterClaim: nil
-        }]
-      }.to_json
+        }] }.to_json
     end
 
     context 'when sending a successful request to the API' do

--- a/spec/lib/hackney/income/view_court_cases_spec.rb
+++ b/spec/lib/hackney/income/view_court_cases_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Hackney::Income::ViewCourtCases do
+  let!(:tenancy_ref) { "#{Faker::Lorem.characters(number: 6)}/#{Faker::Lorem.characters(number: 2)}" }
+
+  let!(:court_cases) do
+    [
+      Hackney::Income::Domain::CourtCase.new.tap do |a|
+        a.tenancy_ref = tenancy_ref
+        a.court_date = Faker::Date.between(from: 5.days.ago, to: Date.today)
+        a.court_outcome = nil
+        a.balance_on_court_outcome_date = nil
+        a.strike_out_date = nil
+        a.terms = nil
+        a.disrepair_counter_claim = nil
+      end
+    ]
+  end
+  let!(:view_court_cases_gateway) { double('Court Cases Gateway', view_court_cases: court_cases) }
+
+  subject { described_class.new(court_cases_gateway: view_court_cases_gateway) }
+
+  context 'when viewing court cases for a tenancy' do
+    it 'should retrieve all court cases for a given tenancy' do
+      expect(view_court_cases_gateway).to receive(:view_court_cases).once.with(tenancy_ref: tenancy_ref)
+      expect(subject.execute(tenancy_ref: tenancy_ref)).to eq(court_cases)
+    end
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Once an officer adds a court date, we want the court date to be shown on the case profile

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add `view court cases` method to the court cases gateway
- Add court case model
- Add `view court cases` use case
- Update court cases partial to show the court date if there is a court case (need to add logic to this about valid/active court cases, right now it just takes the last one)
![image](https://user-images.githubusercontent.com/32230328/90128667-258f4780-dd5f-11ea-9ee7-e2603d445c21.png)

Next steps:
- Allow editing court date
- Allow adding court outcome
- Dispay court case with court outcome
- Add court case details page
- Add court cases history page

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
Partly: https://hackney.atlassian.net/browse/MAAP-366?atlOrigin=eyJpIjoiM2Y2NDk3MzU5OWRhNDkxMWE4ZGJlNTE0Y2NmYjM3YTEiLCJwIjoiaiJ9
## Things to check

- [x] Environment variables have been updated
