### PR TITLE
Add court outcomes partial and render it on both pages

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -66,7 +66,6 @@ class CourtCasesController < ApplicationController
   def show
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
     @court_case = court_case
-    @adjourned = court_case.court_outcome&.start_with?('Adjourned')
   end
 
   def show_success

--- a/app/views/court_cases/_court_outcome.html.erb
+++ b/app/views/court_cases/_court_outcome.html.erb
@@ -1,0 +1,12 @@
+<% if @court_case.court_outcome.present? %>
+  <ul>
+    <li><strong>Court outcome: </strong> <%= @court_case.court_outcome %> </li>
+    <li><strong>Balance on court date: </strong> <%= number_to_currency(@court_case.balance_on_court_outcome_date, unit: '£') %></li>
+    <% if @court_case.court_outcome&.start_with?('Adjourned') %> 
+      <li><strong>Terms: </strong> <%= @court_case.terms %></li>
+      <li><strong>Disrepair counter claim: </strong> <%= @court_case.disrepair_counter_claim %></li>
+    <% end %> 
+    <li><strong>Strike out date: </strong><%= format_date(@court_case.strike_out_date) %></li>
+    <br/>
+  </ul>
+<% end %>

--- a/app/views/court_cases/show.html.erb
+++ b/app/views/court_cases/show.html.erb
@@ -45,21 +45,13 @@
     </div>
     <div class="column-half">
         <div class="column-align-right">
-          <%= link_to 'Edit outcome', new_court_case_path(@tenancy.ref), class:'button' %>
+          <% court_outcome_button_title = @court_case.court_outcome.nil? ? 'Add court outcome' : 'Edit court outcome' %>
+          <%= link_to court_outcome_button_title, new_court_case_path(@tenancy.ref), class:'button' %>
         </div>
     </div>
   </div>
   <div class="column-two-thirds">
-      <ul>
-        <li><strong>Court outcome: </strong> <%= @court_case.court_outcome %> </li>
-        <li><strong>Balance on court date: </strong> <%= number_to_currency(@court_case.balance_on_court_outcome_date, unit: '£') %></li>
-        <% if @adjourned %> 
-          <li><strong>Terms: </strong> <%= @court_case.terms %></li>
-          <li><strong>Disrepair counter claim: </strong> <%= @court_case.disrepair_counter_claim %></li>
-        <% end %> 
-        <li><strong>Strike out date: </strong><%= format_date(@court_case.strike_out_date) %></li>
-        <br/>
-      </ul>
+      <%= render :partial => 'court_cases/court_outcome' %>
       <hr>
   </div>
 </div>

--- a/app/views/tenancies/case/_court_cases.html.erb
+++ b/app/views/tenancies/case/_court_cases.html.erb
@@ -12,7 +12,7 @@
             <div class="column-half">
               <% if @court_case.present? %>
                 <div class="column-half">
-                  <u>View details</u>
+                  <%= link_to('View details', show_court_case_path(tenancy_ref: @tenancy.ref, court_case_id: @court_case.id)) %>
                 </div>
               <% end %>
               <% if @court_cases.present? %>
@@ -25,7 +25,8 @@
           <% if @court_case.nil? %>
             No valid court case at this time
           <% else %>
-            <label class="govuk-label" for="court_date">Court date: <%= format_date(@court_case.court_date) %><br/></label>
+            <label class="govuk-label" for="court_date"><strong>Court date: </strong> <%= format_date(@court_case.court_date) %><br/></label>
+            <%= render :partial => 'court_cases/court_outcome' %>
           <% end %>
         </div>
       </div>
@@ -35,11 +36,13 @@
           <% if @court_case.nil? %>
             <% court_case_button_title = 'Add court date' %>
             <%= link_to court_case_button_title, new_court_case_path(@tenancy.ref), class:'button' %>
-          <% else %>
+          <% elsif @court_case.court_outcome.nil? %>
             <% court_case_button_title = 'Edit court date' %>
             <%= link_to court_case_button_title, edit_court_date_path(@tenancy.ref, @court_case.id), class:'button' %>
             <% court_case_button_title = 'Add court outcome' %>
             <%= link_to court_case_button_title, edit_court_outcome_path(@tenancy.ref, @court_case.id), class:'button' %>
+          <% else%>
+            <%= link_to 'Cancel and create new court case', new_court_case_path(@tenancy.ref), class:'button' %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
## Context
Minor refactoring, both case profile and view court case page renders the same court outcome
details.

## Changes in this pull request
- Add court outcomes partial and render it on both pages

## Things to check
- [x] Environment variables have been updated
