### PR TITLE
Allow adding Adjourned court outcomes with terms

### DIFF
--- a/app/assets/stylesheets/components/govuk_hint.scss
+++ b/app/assets/stylesheets/components/govuk_hint.scss
@@ -1,3 +1,0 @@
-.govuk-hint {
-  color: $govuk-secondary-text-colour;
-}

--- a/app/assets/stylesheets/hackney.scss
+++ b/app/assets/stylesheets/hackney.scss
@@ -54,7 +54,6 @@
 @import 'components/tabs';
 @import 'components/privacy_notice';
 @import 'components/box';
-@import 'components/govuk_hint';
 
 /* Include page-specific classes */
 @import 'pages/cases';

--- a/app/views/court_cases/_court_outcome.html.erb
+++ b/app/views/court_cases/_court_outcome.html.erb
@@ -3,8 +3,8 @@
     <li><strong>Court outcome: </strong> <%= @court_case.court_outcome %> </li>
     <li><strong>Balance on court date: </strong> <%= number_to_currency(@court_case.balance_on_court_outcome_date, unit: '£') %></li>
     <% if @court_case.court_outcome&.start_with?('Adjourned') %> 
-      <li><strong>Terms: </strong> <%= @court_case.terms %></li>
-      <li><strong>Disrepair counter claim: </strong> <%= @court_case.disrepair_counter_claim %></li>
+      <li><strong>Terms: </strong> <%= @court_case.terms ? 'Yes' : 'No' %></li>
+      <li><strong>Disrepair counter claim: </strong> <%= @court_case.disrepair_counter_claim ? 'Yes' : 'No' %></li>
     <% end %> 
     <li><strong>Strike out date: </strong><%= format_date(@court_case.strike_out_date) %></li>
     <br/>

--- a/app/views/court_cases/edit_court_outcome.html.erb
+++ b/app/views/court_cases/edit_court_outcome.html.erb
@@ -17,20 +17,27 @@
   <div class="column-full">
     <h2><%= 'Court outcome' %></h2>
     <%= form_tag('update', method: :post) do %>
-
       <div class="form-group">
-        <label class="govuk-label" for="frequency"><strong>What was the outcome from court?</strong><br/></label>
-        <%= select_tag(:court_outcome, options_for_select(court_outcomes, @court_outcome), { :class => 'form-control', id: 'court_outcome_selector' }) %>
+        <fieldset>
+          <legend>
+            <h3>What was the outcome from court?</h3> <br>
+          </legend>
+          <% court_outcomes.each do |outcome| %>
+            <div class="multiple-choice">
+              <%= radio_button_tag :court_outcome, outcome, @court_outcome == outcome %>
+              <label for="court_outcome"><%= outcome %></label>
+            </div>
+          <% end %>
+        </fieldset>
       </div>
-
       <div class="form-group">
-        <label class="govuk-label" for="balance" id="balance_label"><strong>Balance on court outcome date:</strong></label><br/>
+        <label class="form-label" for="balance" id="balance_label"><strong>Balance on court outcome date</strong></label><br/>
         <%= number_field_tag(:balance_on_court_outcome_date, @balance_on_court_outcome_date, { class: 'form-control', required: true, min: 1, placeholder: '£', step: 0.01 }) %>
       </div>
 
       <div class="form-group">
-        <label class="govuk-date-field" for="strike_out_date"><strong>Strike out date (optional)</strong><br/></label>
-        <label class="govuk-hint" for="strike_out_date_hint_text">Does the court order have an end date?<br/></label>
+        <label class="form-label" for="strike_out_date"><strong>Strike out date (optional)</strong><br/></label>
+        <label class="form-hint" for="strike_out_date_hint_text">Does the court order have an end date?<br/></label>
         <%= date_field_tag :strike_out_date, @strike_out_date, class: 'form-control' %>
       </div>
 

--- a/app/views/court_cases/edit_terms.html.erb
+++ b/app/views/court_cases/edit_terms.html.erb
@@ -1,0 +1,53 @@
+<% content_for :title do %><%= @tenancy_ref %> - Add court outcome<% end %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <%= link_to('Cancel and go back', tenancy_path(id: @tenancy_ref), class: 'link--back') %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1><%= 'Add court outcome' %></h1>
+    <hr>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <h2><%= 'Adjournement details' %></h2>
+    <%= form_tag('update_terms', method: :post) do %>
+    <div class="form-group">
+      <fieldset class="inline">
+        <legend>
+          <label class="form-label" for="terms_label">Are there terms?</label><br/>
+        </legend>
+        <div class="multiple-choice">
+          <%= radio_button_tag :terms, 'Yes', @court_outcome.terms == true %>
+          <label for="terms">Yes</label>
+        </div>
+        <div class="multiple-choice">
+          <%= radio_button_tag :terms, 'No', @court_outcome.terms == false %>
+          <label for="terms">No</label>
+        </div>
+      </fieldset>
+    </div>
+    <div class="form-group">
+      <fieldset class="inline">
+        <legend>
+          <label class="form-label" for="disrepair_counter_claim_label">Is there a disrepair counter claim?</label><br/>
+        </legend>
+        <div class="multiple-choice">
+          <%= radio_button_tag :disrepair_counter_claim, 'Yes', @court_outcome.disrepair_counter_claim == true %>
+          <label for="disrepair_counter_claim">Yes</label>
+        </div>
+        <div class="multiple-choice">
+          <%= radio_button_tag :disrepair_counter_claim, 'No', @court_outcome.disrepair_counter_claim == false %>
+          <label for="disrepair_counter_claim">No</label>
+        </div>
+      </fieldset>
+    </div>
+    <%= submit_tag 'Add outcome', class: 'button' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/court_cases/show.html.erb
+++ b/app/views/court_cases/show.html.erb
@@ -46,7 +46,7 @@
     <div class="column-half">
         <div class="column-align-right">
           <% court_outcome_button_title = @court_case.court_outcome.nil? ? 'Add court outcome' : 'Edit court outcome' %>
-          <%= link_to court_outcome_button_title, new_court_case_path(@tenancy.ref), class:'button' %>
+          <%= link_to court_outcome_button_title, edit_court_outcome_path(@tenancy.ref), class:'button' %>
         </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,8 @@ Rails.application.routes.draw do
   post '/tenancies/:tenancy_ref/court_date/:court_case_id/update', to: 'court_cases#update_court_date', as: :update_court_date
   get '/tenancies/:tenancy_ref/court_outcome/:court_case_id/edit', to: 'court_cases#edit_court_outcome', as: :edit_court_outcome
   post '/tenancies/:tenancy_ref/court_outcome/:court_case_id/update', to: 'court_cases#update_court_outcome', as: :update_court_outcome
+  get '/tenancies/:tenancy_ref/court_outcome/:court_case_id/edit_terms', to: 'court_cases#edit_terms', as: :edit_court_outcome_terms
+  post '/tenancies/:tenancy_ref/court_outcome/:court_case_id/update_terms', to: 'court_cases#update_terms', as: :update_court_outcome_terms
   get '/tenancies/:tenancy_ref/court_cases/:court_case_id/show', to: 'court_cases#show', as: :show_court_case
 
   get '/tenancies/:tenancy_ref/court_cases/show_success/:message', to: 'court_cases#show_success', as: :show_success_court_case

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -21,7 +21,7 @@ describe 'Create Formal agreement' do
 
   after do
     FeatureFlag.deactivate('create_formal_agreements')
-    FeatureFlag.activate('create_informal_agreements')
+    FeatureFlag.deactivate('create_informal_agreements')
   end
 
   scenario 'creating a new Formal agreement' do

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -56,6 +56,14 @@ describe 'Create court case' do
     when_i_fill_in_the_court_outcome
     and_i_click_add_outcome
     then_i_should_see_the_court_case_page
+
+    when_i_click_to_edit_the_court_outcome
+    then_i_should_see_edit_court_outcome_page
+    and_the_existing_court_outcome_details
+
+    # when_i_fill_in_the_court_outcome_with_an_adjourned_outcome
+    # and_i_click_add_outcome
+    # then_i_should_see_the_court_case_page
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -145,7 +153,7 @@ describe 'Create court case' do
   end
 
   def when_i_fill_in_the_court_outcome
-    select('Suspension on terms', from: 'court_outcome')
+    choose('court_outcome_Suspension_on_terms')
     fill_in 'balance_on_court_outcome_date', with: '1000'
     fill_in 'strike_out_date', with: '10/07/2024'
   end
@@ -164,7 +172,23 @@ describe 'Create court case' do
     expect(page).to have_content('Suspension on terms')
     expect(page).to have_content('Strike out date')
     expect(page).to have_content('July 10th, 2024')
-    expect(page).to have_content('Edit court date')
+    expect(page).to have_content('Edit court outcome')
+  end
+
+  def when_i_click_to_edit_the_court_outcome
+    click_link 'Edit court outcome'
+  end
+
+  def and_the_existing_court_outcome_details
+    expect(find_field('court_outcome_Suspension_on_terms')).to be_checked
+    expect(find_field('strike_out_date').value).to eq('2024-07-10')
+    expect(find_field('balance_on_court_outcome_date').value).to eq('1000')
+  end
+
+  def when_i_fill_in_the_court_outcome_with_an_adjourned_outcome
+    # select('Adjourned generally with permission to restore', from: 'court_outcome')
+    # fill_in 'balance_on_court_outcome_date', with: '1500'
+    # fill_in 'strike_out_date', with: '10/08/2025'
   end
 
   def stub_my_cases_response
@@ -281,7 +305,7 @@ describe 'Create court case' do
           tenancyRef: '1234567/01',
           courtDate: '23/07/2020',
           courtOutcome: 'Suspension on terms',
-          balanceOnCourtOutcomeDate: nil,
+          balanceOnCourtOutcomeDate: '1000',
           strikeOutDate: '10/07/2024',
           terms: nil,
           disrepairCounterClaim: nil


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow officers to be able to add a court outcome with `terms` and `Disrepair counterclaim` where applicable
#### Next step
-  Add page to show court case history

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Remove some unnecessary css that's been introduced in the previous PR
- Use radio buttons as suggested in the design
- Add 2 step court outcome page with terms page
- Add acceptance tests around updating the court outcome with an `Adjourned` court outcome

## Things to check
- [x] Environment variables have been updated