### PR TITLE
Allow case workers to view court cases history

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -98,6 +98,11 @@ class CourtCasesController < ApplicationController
     redirect_to tenancy_path(id: tenancy_ref)
   end
 
+  def show_history
+    @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
+    @court_cases = use_cases.view_court_cases.execute(tenancy_ref: tenancy_ref)
+  end
+
   private
 
   def tenancy_ref

--- a/app/views/agreements/show_history.html.erb
+++ b/app/views/agreements/show_history.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= @tenancy_ref %> - View agreement<% end %>
+<% content_for :title do %><%= @tenancy_ref %> - View history of agreements<% end %>
 
 <div class="grid-row">
   <div class="column-full">

--- a/app/views/court_cases/show_history.html.erb
+++ b/app/views/court_cases/show_history.html.erb
@@ -1,0 +1,45 @@
+<% content_for :title do %><%= @tenancy_ref %> - View history of court cases<% end %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <%= link_to('Return to case profile', tenancy_path(id: @tenancy_ref), class: 'link--back') %>
+  </div>
+</div>
+
+
+<div class="grid-row">
+  <div class="column-full">
+    <h1><%= 'History of court cases' %></h1>
+    <hr>
+    <h4>All court cases associated with <%= @tenancy.primary_contact_name %></h4>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <table class="agreements_history-table fixed-layout">
+      <thead>
+        <th class="status-column">Status</th>
+        <th class="court-date-column">Court date</th>
+        <th class="strike-out-date-column">Strike out date</th>
+        <th class="balance-column">Balance</th>
+        <th class="court-outcome-column">Court outcome</th>
+        <th class="view-details-column"></th>
+      </thead>
+      <% @court_cases.to_enum.with_index.reverse_each do |court_case, i| %>
+        <tbody class="summary-table__group court_cases_history-table__group--summary">
+          <tr>
+            <td><%= i == (@court_cases.count - 1) ? 'Valid' : court_case.id %></td>
+            <td><%= format_date(court_case.court_date) %></td>
+            <td><%= format_date(court_case.strike_out_date) %></td>
+            <td><%= number_to_currency(court_case.balance_on_court_outcome_date, unit: '£') %></td>
+            <td>
+              <%= court_case.court_outcome %>
+            </td>
+            <td><%= link_to('View details', show_court_case_path(tenancy_ref: @tenancy.ref, court_case_id: court_case.id)) %></td>
+          </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+

--- a/app/views/court_cases/show_history.html.erb
+++ b/app/views/court_cases/show_history.html.erb
@@ -29,7 +29,11 @@
       <% @court_cases.to_enum.with_index.reverse_each do |court_case, i| %>
         <tbody class="summary-table__group court_cases_history-table__group--summary">
           <tr>
-            <td><%= i == (@court_cases.count - 1) ? 'Valid' : court_case.id %></td>
+            <% 
+              state = 'Expired' if court_case.expired? 
+              state = i == (@court_cases.count - 1) ? 'Valid' : court_case.id if state.nil?
+            %>
+            <td><%= state %></td>
             <td><%= format_date(court_case.court_date) %></td>
             <td><%= format_date(court_case.strike_out_date) %></td>
             <td><%= number_to_currency(court_case.balance_on_court_outcome_date, unit: '£') %></td>

--- a/app/views/tenancies/case/_court_cases.html.erb
+++ b/app/views/tenancies/case/_court_cases.html.erb
@@ -17,7 +17,7 @@
               <% end %>
               <% if @court_cases.present? %>
                 <div class="column-align-right">
-                  <u>View history</u>
+                  <%= link_to('View history', show_court_cases_history_path(tenancy_ref: @tenancy.ref)) %>
                 </div>
               <% end %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,8 +57,8 @@ Rails.application.routes.draw do
   get '/tenancies/:tenancy_ref/court_outcome/:court_case_id/edit_terms', to: 'court_cases#edit_terms', as: :edit_court_outcome_terms
   post '/tenancies/:tenancy_ref/court_outcome/:court_case_id/update_terms', to: 'court_cases#update_terms', as: :update_court_outcome_terms
   get '/tenancies/:tenancy_ref/court_cases/:court_case_id/show', to: 'court_cases#show', as: :show_court_case
-
   get '/tenancies/:tenancy_ref/court_cases/show_success/:message', to: 'court_cases#show_success', as: :show_success_court_case
+  get '/tenancies/:tenancy_ref/court_cases/history', to: 'court_cases#show_history', as: :show_court_cases_history
 
   get '/login', to: 'hackney_auth_session#new'
   get '/logout', to: 'hackney_auth_session#destroy'

--- a/lib/hackney/income/domain/court_case.rb
+++ b/lib/hackney/income/domain/court_case.rb
@@ -6,6 +6,12 @@ module Hackney
 
         attr_accessor :id, :tenancy_ref, :court_date, :court_outcome, :balance_on_court_outcome_date, :strike_out_date,
                       :terms, :disrepair_counter_claim
+
+        def expired?
+          return false if strike_out_date.nil?
+
+          strike_out_date.to_date <= Time.now
+        end
       end
     end
   end

--- a/spec/features/income_collection/court_cases/view_court_cases_spec.rb
+++ b/spec/features/income_collection/court_cases/view_court_cases_spec.rb
@@ -4,6 +4,7 @@ describe 'View agreements' do
   before do
     FeatureFlag.activate('create_informal_agreements')
     FeatureFlag.activate('create_formal_agreements')
+    Timecop.freeze('24/07/2021')
 
     create_jwt_token
 
@@ -19,6 +20,7 @@ describe 'View agreements' do
   after do
     FeatureFlag.deactivate('create_informal_agreements')
     FeatureFlag.deactivate('create_formal_agreements')
+    Timecop.return
   end
 
   scenario 'viewing court cases' do
@@ -111,6 +113,8 @@ describe 'View agreements' do
     court_cases_history_table = find('table')
 
     expect(court_cases_history_table).to have_content('Status')
+    expect(court_cases_history_table).to have_content('Valid')
+    expect(court_cases_history_table).to have_content('Expired')
 
     expect(court_cases_history_table).to have_content('Court date')
     expect(court_cases_history_table).to have_content('July 24th, 2020')

--- a/spec/features/income_collection/court_cases/view_court_cases_spec.rb
+++ b/spec/features/income_collection/court_cases/view_court_cases_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+describe 'View agreements' do
+  before do
+    FeatureFlag.activate('create_informal_agreements')
+    FeatureFlag.activate('create_formal_agreements')
+
+    create_jwt_token
+
+    stub_my_cases_response
+    stub_income_api_show_tenancy
+    stub_tenancy_api_payments
+    stub_tenancy_api_contacts
+    stub_tenancy_api_actions
+    stub_tenancy_api_tenancy
+    stub_view_agreements_response
+  end
+
+  after do
+    FeatureFlag.deactivate('create_informal_agreements')
+    FeatureFlag.deactivate('create_formal_agreements')
+  end
+
+  scenario 'viewing court cases' do
+    given_i_am_logged_in
+    and_there_are_existing_court_cases
+
+    when_i_visit_the_tenancy_page
+    then_i_should_see_the_court_case_details
+
+    when_i_click_on_view_details
+    then_i_should_see_the_court_case_details_page
+    and_i_should_see_the_court_case_details
+
+    when_i_visit_the_tenancy_page
+    when_i_click_on_view_history
+    then_i_should_see_the_court_case_history_page
+    and_i_should_see_the_history_with_of_court_cases
+  end
+
+  def and_there_are_existing_court_cases
+    court_cases_response = {
+      courtCases:
+      [
+        {
+        id: 14,
+        tenancyRef: '1234567/01',
+        courtDate: '24/07/2020',
+        courtOutcome: 'Suspension on terms',
+        balanceOnCourtOutcomeDate: '1800',
+        strikeOutDate: '24/07/2021',
+        terms: nil,
+        disrepairCounterClaim: nil
+      },
+        {
+          id: 15,
+          tenancyRef: '1234567/01',
+          courtDate: '26/09/2020',
+          courtOutcome: 'Adjourned generally with permission to restore',
+          balanceOnCourtOutcomeDate: '1700',
+          strikeOutDate: '10/07/2025',
+          terms: false,
+          disrepairCounterClaim: true
+        }
+    ]
+    }.to_json
+
+    stub_request(:get, 'https://example.com/income/api/v1/court_cases/1234567%2F01/')
+      .to_return(status: 200, body: court_cases_response)
+  end
+
+  def when_i_visit_the_tenancy_page
+    visit tenancy_path(id: '1234567/01')
+  end
+
+  def then_i_should_see_the_court_case_details
+    expect(page).to have_content('Court date')
+    expect(page).to have_content('September 26th, 2020')
+    expect(page).to have_content('Court outcome:')
+    expect(page).to have_content('Adjourned generally with permission to restore')
+    expect(page).to have_content('Strike out date:')
+    expect(page).to have_content('July 10th, 2025')
+    expect(page).to have_content('Balance on court date:')
+    expect(page).to have_content('£1,700')
+    expect(page).to have_content('Terms: No')
+    expect(page).to have_content('Disrepair counter claim: Yes')
+  end
+
+  def when_i_click_on_view_details
+    click_link 'View details'
+  end
+
+  def then_i_should_see_the_court_case_details_page
+    expect(page).to have_content('Alan Sugar')
+  end
+
+  def and_i_should_see_the_court_case_details
+    then_i_should_see_the_court_case_details
+  end
+
+  def when_i_click_on_view_history
+    click_link 'View history'
+  end
+
+  def then_i_should_see_the_court_case_history_page
+    expect(page).to have_content('History of court cases')
+    expect(page).to have_content('All court cases associated with Alan Sugar')
+  end
+
+  def and_i_should_see_the_history_with_of_court_cases
+    court_cases_history_table = find('table')
+
+    expect(court_cases_history_table).to have_content('Status')
+
+    expect(court_cases_history_table).to have_content('Court date')
+    expect(court_cases_history_table).to have_content('July 24th, 2020')
+    expect(court_cases_history_table).to have_content('September 26th, 2020')
+
+    expect(court_cases_history_table).to have_content('Strike out date')
+    expect(court_cases_history_table).to have_content('July 10th, 2025')
+
+    expect(court_cases_history_table).to have_content('Balance')
+    expect(court_cases_history_table).to have_content('£1,700')
+    expect(court_cases_history_table).to have_content('£1,800')
+
+    expect(court_cases_history_table).to have_content('Court outcome')
+    expect(court_cases_history_table).to have_content('Adjourned generally with permission to restore')
+    expect(court_cases_history_table).to have_content('Suspension on terms')
+
+    expect(court_cases_history_table).to have_link('View details').twice
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow officers to view the history of court cases

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Add court case history page

![image](https://user-images.githubusercontent.com/22743709/90632010-98933500-e21b-11ea-8250-64458f9ea841.png)

## Things to check
- [x] Environment variables have been updated

