### PR TITLE
Fix end date calculator after the hotfix

### DIFF
--- a/app/assets/javascripts/income_collection/EndDateCalculator.js
+++ b/app/assets/javascripts/income_collection/EndDateCalculator.js
@@ -5,10 +5,10 @@ window.EndDateCalculator = function EndDateCalculator (totalArrears, startDate, 
   if (new Date(startDate) == 'Invalid Date') return '';
 
   var numberOfInstalments = Math.ceil(parseFloat(totalArrears) / parseFloat(amount)) - 1;
-  const frequencyOfPayment = (frequency == 'Monthly') ? 'months' : 'weeks'
+  const frequencyOfPayment = (frequency.toLowerCase() == 'monthly') ? 'months' : 'weeks'
 
-  if (frequency == 'Fortnightly') numberOfInstalments = numberOfInstalments * 2;
-  if (frequency == '4 weekly') numberOfInstalments = numberOfInstalments * 4;
+  if (frequency.toLowerCase() == 'fortnightly') numberOfInstalments = numberOfInstalments * 2;
+  if (frequency.toLowerCase() == '4 weekly') numberOfInstalments = numberOfInstalments * 4;
 
   return moment(startDate).add(numberOfInstalments, frequencyOfPayment).format('D MMMM YYYY');
 };

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -43,8 +43,7 @@
 
   document.getElementById("frequency_selector").addEventListener('change', (event) => {
     var frequency_label = document.getElementById("frequency_selector").value;
-    document.getElementById('frequency_label').textContent = frequency_label + " instalment amount";
-
+    document.getElementById('frequency_label').textContent = frequency_label.charAt(0).toUpperCase() + frequency_label.slice(1) + " instalment amount";
     updateEndDate()
   });
 </script>


### PR DESCRIPTION
## Context
Hotfix changed the possible `frequency` values, these were used in the end date calculator(we don't have proper end to end test for JS) https://github.com/LBHackney-IT/LBH-IncomeCollection/commit/1e50cfa76a84c59a94830260080b6e14c243e510 

## Changes in this pull request
- Always use lowercase frequencies when calculating end-dates
- Also fixed the amount label(should be capitalised)


## Things to check
- [x] Environment variables have been updated
