### PR TITLE
Refactor court case controller update_court_outcome action

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -55,11 +55,11 @@ class CourtCasesController < ApplicationController
       strike_out_date: params.fetch(:strike_out_date)
     }
 
-    use_cases.update_court_case.execute(court_case_params: update_court_outcome_params)
-
     if Hackney::Income::Domain::CourtCase.new(court_outcome: court_outcome).adjourned?
-      redirect_to edit_court_outcome_terms_path(tenancy_ref: tenancy_ref, court_case_id: court_case_id)
+      redirect_to edit_court_outcome_terms_path(tenancy_ref: tenancy_ref, court_case_id: court_case_id, **update_court_outcome_params)
     else
+      use_cases.update_court_case.execute(court_case_params: update_court_outcome_params)
+
       flash[:notice] = 'Successfully updated the court case'
       redirect_to show_court_case_path(tenancy_ref: tenancy_ref, court_case_id: court_case_id)
     end
@@ -70,14 +70,20 @@ class CourtCasesController < ApplicationController
 
   def edit_terms
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
-    @court_outcome = court_case
+    @court_case = court_case
+    @court_outcome = params.fetch(:court_outcome)
+    @balance_on_court_outcome_date = params.fetch(:balance_on_court_outcome_date)
+    @strike_out_date = params.dig(:strike_out_date)
   end
 
   def update_terms
     update_court_outcome_terms_params = {
       id: court_case_id,
       terms: to_boolean(params.fetch(:terms)),
-      disrepair_counter_claim: to_boolean(params.fetch(:disrepair_counter_claim))
+      disrepair_counter_claim: to_boolean(params.fetch(:disrepair_counter_claim)),
+      court_outcome: params.fetch(:court_outcome),
+      balance_on_court_outcome_date: params.fetch(:balance_on_court_outcome_date),
+      strike_out_date: params.fetch(:strike_out_date)
     }
     use_cases.update_court_case.execute(court_case_params: update_court_outcome_terms_params)
 

--- a/app/views/court_cases/edit_terms.html.erb
+++ b/app/views/court_cases/edit_terms.html.erb
@@ -17,17 +17,20 @@
   <div class="column-full">
     <h2><%= 'Adjournement details' %></h2>
     <%= form_tag('update_terms', method: :post) do %>
+    <%= hidden_field_tag :court_outcome, @court_outcome %>
+    <%= hidden_field_tag :balance_on_court_outcome_date, @balance_on_court_outcome_date %>
+    <%= hidden_field_tag :strike_out_date, @strike_out_date %>
     <div class="form-group">
       <fieldset class="inline">
         <legend>
           <label class="form-label" for="terms_label">Are there terms?</label><br/>
         </legend>
         <div class="multiple-choice">
-          <%= radio_button_tag :terms, 'Yes', @court_outcome.terms == true %>
+          <%= radio_button_tag :terms, 'Yes', '@court_case&.terms == true' %>
           <label for="terms">Yes</label>
         </div>
         <div class="multiple-choice">
-          <%= radio_button_tag :terms, 'No', @court_outcome.terms == false %>
+          <%= radio_button_tag :terms, 'No', @court_case&.terms == false %>
           <label for="terms">No</label>
         </div>
       </fieldset>
@@ -38,11 +41,11 @@
           <label class="form-label" for="disrepair_counter_claim_label">Is there a disrepair counter claim?</label><br/>
         </legend>
         <div class="multiple-choice">
-          <%= radio_button_tag :disrepair_counter_claim, 'Yes', @court_outcome.disrepair_counter_claim == true %>
+          <%= radio_button_tag :disrepair_counter_claim, 'Yes', @court_case&.disrepair_counter_claim == true %>
           <label for="disrepair_counter_claim">Yes</label>
         </div>
         <div class="multiple-choice">
-          <%= radio_button_tag :disrepair_counter_claim, 'No', @court_outcome.disrepair_counter_claim == false %>
+          <%= radio_button_tag :disrepair_counter_claim, 'No', @court_case&.disrepair_counter_claim == false %>
           <label for="disrepair_counter_claim">No</label>
         </div>
       </fieldset>

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -296,14 +296,6 @@ describe 'Create court case' do
         court_outcome: 'AGP',
         balance_on_court_outcome_date: '1500',
         strike_out_date: '10/08/2025',
-        terms: nil,
-        disrepair_counter_claim: nil
-      }.to_json,
-      {
-        court_date: nil,
-        court_outcome: nil,
-        balance_on_court_outcome_date: nil,
-        strike_out_date: nil,
         terms: true,
         disrepair_counter_claim: false
       }.to_json


### PR DESCRIPTION
## Context
Minor refactor that was necessary because we validate the presence of `disrepair_counter_claim` and `terms` when creating/updating court cases. Also for better performance, rather than calling the update action on each step, we should only call once at the last step.

## Changes in this pull request
- Refactor controller actions in court cases controller