### PR TITLE
Quick fix not to show old court details 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,4 +70,16 @@ class ApplicationController < ActionController::Base
     flash[:notice] = error.original_message.capitalize
     redirect_to request.referrer if request.referrer
   end
+
+  def court_case
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_case ||= court_cases&.last
+  end
+
+  def court_cases
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
+  end
 end

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -47,10 +47,8 @@ class TenanciesController < ApplicationController
       @agreement = @agreements.find { |agreement| %w[live breached].include?(agreement.current_state) }
     end
 
-    if FeatureFlag.active?('create_formal_agreements')
-      @court_cases = use_cases.view_court_cases.execute(tenancy_ref: tenancy_ref)
-      @court_case = @court_cases.last
-    end
+    @court_cases = court_cases
+    @court_case = court_case
 
     render :show
   end
@@ -58,6 +56,7 @@ class TenanciesController < ApplicationController
   def pause
     @pause_tenancy = use_cases.pause_tenancy.execute(tenancy_ref: params.fetch(:id))
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
+    @court_case = court_case
   rescue Exceptions::IncomeApiError::NotFoundError
     flash[:notice] = 'This tenancy is not eligible for pausing'
     redirect_to tenancy_path(id: params.fetch(:id))
@@ -83,5 +82,17 @@ class TenanciesController < ApplicationController
   # FIXME: stop filtering here, improve contact details
   def valid_tenancies(tenancies)
     tenancies.select { |t| t.primary_contact_name.present? }
+  end
+
+  def court_case
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_case ||= court_cases.last
+  end
+
+  def court_cases
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
   end
 end

--- a/app/controllers/tenancies_controller.rb
+++ b/app/controllers/tenancies_controller.rb
@@ -83,16 +83,4 @@ class TenanciesController < ApplicationController
   def valid_tenancies(tenancies)
     tenancies.select { |t| t.primary_contact_name.present? }
   end
-
-  def court_case
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_case ||= court_cases.last
-  end
-
-  def court_cases
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
-  end
 end

--- a/app/controllers/tenancies_email_controller.rb
+++ b/app/controllers/tenancies_email_controller.rb
@@ -2,6 +2,7 @@ class TenanciesEmailController < ApplicationController
   def show
     @email_templates = use_cases.list_email_templates.execute(tenancy_ref: params.fetch(:id))
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
+    @court_case = court_case
   end
 
   def create
@@ -21,5 +22,19 @@ class TenanciesEmailController < ApplicationController
 
     flash[:notice] = 'Successfully sent the tenant an Email'
     redirect_to tenancy_path(id: params.fetch(:id))
+  end
+
+  private
+
+  def court_case
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_case ||= court_cases.last
+  end
+
+  def court_cases
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
   end
 end

--- a/app/controllers/tenancies_email_controller.rb
+++ b/app/controllers/tenancies_email_controller.rb
@@ -23,18 +23,4 @@ class TenanciesEmailController < ApplicationController
     flash[:notice] = 'Successfully sent the tenant an Email'
     redirect_to tenancy_path(id: params.fetch(:id))
   end
-
-  private
-
-  def court_case
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_case ||= court_cases.last
-  end
-
-  def court_cases
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
-  end
 end

--- a/app/controllers/tenancies_sms_controller.rb
+++ b/app/controllers/tenancies_sms_controller.rb
@@ -2,6 +2,7 @@ class TenanciesSmsController < ApplicationController
   def show
     @sms_templates = use_cases.list_sms_templates.execute(tenancy_ref: params.fetch(:id))
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
+    @court_case = court_case
   end
 
   def create
@@ -25,5 +26,19 @@ class TenanciesSmsController < ApplicationController
       flash[:notice] = e.message
       redirect_to(create_tenancy_sms_path(id: params.fetch(:id)))
     end
+  end
+
+  private
+
+  def court_case
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_case ||= court_cases.last
+  end
+
+  def court_cases
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
   end
 end

--- a/app/controllers/tenancies_sms_controller.rb
+++ b/app/controllers/tenancies_sms_controller.rb
@@ -27,18 +27,4 @@ class TenanciesSmsController < ApplicationController
       redirect_to(create_tenancy_sms_path(id: params.fetch(:id)))
     end
   end
-
-  private
-
-  def court_case
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_case ||= court_cases.last
-  end
-
-  def court_cases
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
-  end
 end

--- a/app/controllers/tenancies_transactions_controller.rb
+++ b/app/controllers/tenancies_transactions_controller.rb
@@ -3,18 +3,4 @@ class TenanciesTransactionsController < ApplicationController
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
     @court_case = court_case
   end
-
-  private
-
-  def court_case
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_case ||= court_cases.last
-  end
-
-  def court_cases
-    return unless FeatureFlag.active?('create_formal_agreements')
-
-    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
-  end
 end

--- a/app/controllers/tenancies_transactions_controller.rb
+++ b/app/controllers/tenancies_transactions_controller.rb
@@ -1,5 +1,20 @@
 class TenanciesTransactionsController < ApplicationController
   def index
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: params.fetch(:id))
+    @court_case = court_case
+  end
+
+  private
+
+  def court_case
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_case ||= court_cases.last
+  end
+
+  def court_cases
+    return unless FeatureFlag.active?('create_formal_agreements')
+
+    @court_cases ||= use_cases.view_court_cases.execute(tenancy_ref: params.fetch(:id))
   end
 end

--- a/app/views/common/_tenancy_header.html.erb
+++ b/app/views/common/_tenancy_header.html.erb
@@ -12,8 +12,13 @@
       <li><strong>NoSP served:</strong> <%= format_date(@tenancy.nosp.served_date) %></li>
       <li><strong>NoSP expires:</strong> <%= format_date(@tenancy.nosp.expires_date) %></li>
       <li><strong>NoSP valid until:</strong> <%= format_date(@tenancy.nosp.valid_until_date) %></li>
-      <li><strong>Court Date:</strong> <%= format_date(@tenancy.court_date) %></li>
-      <li><strong>Court Outcome:</strong> <%= court_outcome_for_code(@tenancy.court_outcome) %></li>
+      <% if FeatureFlag.active?('create_formal_agreements') %>
+        <li><strong>Court Date:</strong> <%= format_date(@court_case&.court_date) %></li>
+        <li><strong>Court Outcome:</strong> <%= court_outcomes[@court_case&.court_outcome] %></li>
+      <% else %>
+        <li><strong>Court Date:</strong> <%= format_date(@tenancy.court_date) %></li>
+        <li><strong>Court Outcome:</strong> <%= court_outcome_for_code(@tenancy.court_outcome) %></li>
+      <% end %>
       <li><strong>Eviction Date:</strong> <%= format_date(@tenancy.eviction_date) %></li>
     </ul>
   </div>

--- a/app/views/tenancies/case/_tenancy_attributes.html.erb
+++ b/app/views/tenancies/case/_tenancy_attributes.html.erb
@@ -4,8 +4,10 @@
       <li><strong>NoSP served:</strong> <%= format_date(@tenancy.nosp.served_date) %></li>
       <li><strong>NoSP expires:</strong> <%= format_date(@tenancy.nosp.expires_date) %></li>
       <li><strong>NoSP valid until:</strong> <%= format_date(@tenancy.nosp.valid_until_date) %></li>
-      <li><strong>Court Date:</strong> <%= format_date(@tenancy.court_date) %></li>
-      <li><strong>Court Outcome:</strong> <%= court_outcome_for_code(@tenancy.court_outcome) %></li>
+      <% unless FeatureFlag.active?('create_formal_agreements') %>
+        <li><strong>Court Date:</strong> <%= format_date(@tenancy.court_date) %></li>
+        <li><strong>Court Outcome:</strong> <%= court_outcome_for_code(@tenancy.court_outcome) %></li>
+      <% end %>
       <li><strong>Eviction Date:</strong> <%= format_date(@tenancy.eviction_date) %></li>
     </ul>
   </div>

--- a/lib/hackney/income/domain/court_case.rb
+++ b/lib/hackney/income/domain/court_case.rb
@@ -47,6 +47,8 @@ module Hackney
         end
 
         def end_of_life?
+          return false if court_date.nil?
+
           court_outcome == CourtOutcomeCodes::SUSPENSION_ON_TERMS && court_date.to_date + 6.years <= Date.today
         end
       end

--- a/spec/lib/hackney/income/domain/court_case_spec.rb
+++ b/spec/lib/hackney/income/domain/court_case_spec.rb
@@ -46,6 +46,15 @@ describe Hackney::Income::Domain::CourtCase do
       end
     end
 
+    context 'when the court date is nil and outcome is suspended on terms' do
+      let(:court_date) { nil }
+      let(:court_outcome) { described_class::CourtOutcomeCodes::SUSPENSION_ON_TERMS }
+
+      it 'is expied' do
+        expect(subject.expired?).to be_falsy
+      end
+    end
+
     describe '#adjourned?' do
       context 'When its an adjourned outcome' do
         let(:court_outcome) do


### PR DESCRIPTION
## Context
There is a bug when we are checking if a court case has expired: it blows up when the court date is nil.
We don't want to render the old court cases anymore :feelsgood:  

## Changes in this pull request
- Fix court case expired bug
- Quick fix where we render old court cases we should render the new court case data once the feature flag is enabled

## Guidance to review
- We are going fast and introducing too many bugs as we don't have time to test edge cases 😨 

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check
- [X] Environment variables have been updated
