### PR TITLE
Allow sending agreement confirmation letter when a new informal agreement is created

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -19,7 +19,7 @@ class AgreementsController < ApplicationController
 
     return redirect_to new_agreement_path(agreement_params) if @agreement.invalid?
 
-    use_cases.create_agreement.execute(
+    agreement = use_cases.create_agreement.execute(
       created_by: @current_user.name,
       tenancy_ref: agreement_params[:tenancy_ref],
       agreement_type: agreement_params[:agreement_type],
@@ -29,15 +29,10 @@ class AgreementsController < ApplicationController
       notes: agreement_params[:notes],
       court_case_id: agreement_params[:court_case_id]
     )
-    redirect_to show_success_path
+    redirect_to show_agreement_path(tenancy_ref: tenancy_ref, id: agreement.id) if agreement
   rescue Exceptions::IncomeApiError => e
     flash[:notice] = "An error occurred: #{e.message}"
     redirect_to new_agreement_path(tenancy_ref: tenancy_ref, **agreement_params)
-  end
-
-  def show_success
-    flash[:notice] = 'Successfully created a new agreement'
-    redirect_to tenancy_path(id: tenancy_ref)
   end
 
   def show

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -50,7 +50,14 @@
       </div>
       <div class="grid-row">
         <div class="column-full">
-          <% unless @agreement.current_state == 'cancelled' %>
+          <% unless @agreement.cancelled? %>
+            <% unless @agreement.formal? %>
+              <%= form_tag(income_collection_letters_path, class: 'case-details__inline-block') do %>
+                <%= hidden_field_tag "template_id", 'informal_agreement_confirmation_letter' %>
+                <%= hidden_field_tag "tenancy_refs", @tenancy.ref %>
+                <%= submit_tag('Send agreement confirmation letter', class: 'button') %>
+              <% end %>
+            <% end %>
             <%= link_to 'Cancel and create new', new_agreement_path(@tenancy.ref), class:'button' %>
             <%= link_to 'Cancel', confirm_agreement_cancellation_path(tenancy_ref: @tenancy.ref, id: @agreement.id), class:'button' %>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,6 @@ Rails.application.routes.draw do
 
   get '/tenancies/:tenancy_ref/agreement/new', to: 'agreements#new', as: :new_agreement
   post '/tenancies/:tenancy_ref/agreement/create', to: 'agreements#create', as: :create_agreement
-  get '/tenancies/:tenancy_ref/agreement/show_success', to: 'agreements#show_success', as: :show_success
   get '/tenancies/:tenancy_ref/agreement/:id/show', to: 'agreements#show', as: :show_agreement
   get '/tenancies/:tenancy_ref/agreement/:id/cancel', to: 'agreements#confirm_cancellation', as: :confirm_agreement_cancellation
   post '/tenancies/:tenancy_ref/agreement/:id/cancel', to: 'agreements#cancel', as: :cancel_agreement

--- a/lib/hackney/income/agreements_gateway.rb
+++ b/lib/hackney/income/agreements_gateway.rb
@@ -29,7 +29,7 @@ module Hackney
 
         raise_error(response, "when trying to create a new agreement using '#{uri}'")
 
-        response.body
+        map_response_to_agreement_domain(JSON.parse(response.body))
       end
 
       def view_agreements(tenancy_ref:)
@@ -45,29 +45,7 @@ module Hackney
         agreements = JSON.parse(response.body)['agreements']
 
         agreements.map do |agreement|
-          Hackney::Income::Domain::Agreement.new.tap do |t|
-            t.id = agreement['id']
-            t.tenancy_ref = agreement['tenancyRef']
-            t.agreement_type = agreement['agreementType']
-            t.starting_balance = agreement['startingBalance']
-            t.amount = agreement['amount']
-            t.start_date = agreement['startDate']
-            t.frequency = agreement['frequency']
-            t.current_state = agreement['currentState']
-            t.created_at = agreement['createdAt']
-            t.created_by = agreement['createdBy']
-            t.last_checked = agreement['lastChecked']
-            t.notes = agreement['notes']
-            t.history = agreement['history'].map do |state|
-              Hackney::Income::Domain::AgreementState.new.tap do |s|
-                s.date = state['date']
-                s.state = state['state']
-                s.expected_balance = state['expectedBalance']
-                s.checked_balance = state['checkedBalance']
-                s.description = state['description']
-              end
-            end
-          end
+          map_response_to_agreement_domain(agreement)
         end
       end
 
@@ -88,6 +66,32 @@ module Hackney
 
       def raise_error(response, message)
         raise Exceptions::IncomeApiError.new(response), message unless response.is_a? Net::HTTPSuccess
+      end
+
+      def map_response_to_agreement_domain(agreement)
+        Hackney::Income::Domain::Agreement.new.tap do |t|
+          t.id = agreement['id']
+          t.tenancy_ref = agreement['tenancyRef']
+          t.agreement_type = agreement['agreementType']
+          t.starting_balance = agreement['startingBalance']
+          t.amount = agreement['amount']
+          t.start_date = agreement['startDate']
+          t.frequency = agreement['frequency']
+          t.current_state = agreement['currentState']
+          t.created_at = agreement['createdAt']
+          t.created_by = agreement['createdBy']
+          t.last_checked = agreement['lastChecked']
+          t.notes = agreement['notes']
+          t.history = agreement['history'].map do |state|
+            Hackney::Income::Domain::AgreementState.new.tap do |s|
+              s.date = state['date']
+              s.state = state['state']
+              s.expected_balance = state['expectedBalance']
+              s.checked_balance = state['checkedBalance']
+              s.description = state['description']
+            end
+          end
+        end
       end
     end
   end

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -43,6 +43,14 @@ module Hackney
           end
           @current_step || STEPS.first
         end
+
+        def formal?
+          agreement_type == 'formal'
+        end
+
+        def cancelled?
+          current_state == 'cancelled'
+        end
       end
     end
   end

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -34,6 +34,10 @@ describe 'Create Formal agreement' do
     when_i_select_the_agreement_type
     when_i_fill_in_the_agreement_details
     and_i_click_on_create
+    then_i_should_see_the_agreement_page
+    and_i_can_not_see_the_button_to_send_agreement_confirmation_letter
+
+    when_i_click_link_to_go_back_to_case_profile
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_new_agreement
     and_i_should_see_the_agreement_status
@@ -68,6 +72,18 @@ describe 'Create Formal agreement' do
 
   def and_i_click_on_create
     click_button 'Create'
+  end
+
+  def then_i_should_see_the_agreement_page
+    expect(page).to have_current_path(show_agreement_path(tenancy_ref: '1234567/01', id: '12'))
+  end
+
+  def and_i_can_not_see_the_button_to_send_agreement_confirmation_letter
+    expect(page).to_not have_button('Send agreement confirmation letter')
+  end
+
+  def when_i_click_link_to_go_back_to_case_profile
+    click_link 'Return to case profile'
   end
 
   def then_i_should_see_the_tenancy_page

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -32,6 +32,10 @@ describe 'Create informal agreement' do
     when_i_select_the_agreement_type
     when_i_fill_in_the_agreement_details
     and_i_click_on_create
+    then_i_should_see_the_agreement_page
+    and_i_can_see_a_button_to_send_agreement_confirmation_letter
+
+    when_i_click_link_to_go_back_to_case_profile
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_new_agreement
     and_i_should_see_the_agreement_status
@@ -81,6 +85,18 @@ describe 'Create informal agreement' do
 
   def and_i_click_on_create
     click_button 'Create'
+  end
+
+  def then_i_should_see_the_agreement_page
+    expect(page).to have_current_path(show_agreement_path(tenancy_ref: '1234567/01', id: '12'))
+  end
+
+  def and_i_can_see_a_button_to_send_agreement_confirmation_letter
+    expect(page).to have_button('Send agreement confirmation letter')
+  end
+
+  def when_i_click_link_to_go_back_to_case_profile
+    click_link 'Return to case profile'
   end
 
   def then_i_should_see_the_tenancy_page
@@ -290,6 +306,7 @@ describe 'Create informal agreement' do
         headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
       )
       .to_return({ status: 200, body: response_with_no_agreements_json },
+                 { status: 200, body: response_with_live_agreement_json },
                  { status: 200, body: response_with_live_agreement_json },
                  { status: 200, body: response_with_live_agreement_json },
                  status: 200, body: response_with_cancelled_agreement_json)

--- a/spec/lib/hackney/income/agreement_gateway_spec.rb
+++ b/spec/lib/hackney/income/agreement_gateway_spec.rb
@@ -30,10 +30,16 @@ describe Hackney::Income::AgreementsGateway do
     end
 
     context 'when sending a successful request to the API' do
+      let(:new_agreement_id) { Faker::Number.number(digits: 3) }
+
       before do
         stub_request(:post, "https://example.com/api/v1/agreement/#{ERB::Util.url_encode(request_params.fetch(:tenancy_ref))}/")
           .to_return(
-            status: 200
+            status: 200,
+            body: {
+              id: new_agreement_id,
+              history: []
+            }.to_json
           )
       end
 
@@ -47,6 +53,12 @@ describe Hackney::Income::AgreementsGateway do
           body: json_request_body,
           times: 1
         )
+      end
+
+      it 'should map the response into an agreement' do
+        new_agreement = subject.create_agreement(**request_params)
+
+        expect(new_agreement.id).to eq(new_agreement_id)
       end
     end
 


### PR DESCRIPTION
## Context
We want to allow caseworkers to send a confirmation letter when a new agreement is created, currently, there is only a confirmation letter for informal agreements.

## Changes in this pull request
- Change gateway to return an agreement object when a new agreement has created
- Redirect to the agreements details page to show the new agreement before sending the confirmation letter
- Add agreement confirmation letter button to the agreement details page
- Only show the send agreement confirmation letter when its an informal agreement

### After
![image](https://user-images.githubusercontent.com/22743709/91445456-0ec41700-e86e-11ea-9234-536b6379c1e5.png)
![image](https://user-images.githubusercontent.com/22743709/91445743-69f60980-e86e-11ea-9516-d3b7cd44807c.png)


## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-450

## Things to check
- [x] Environment variables have been updated
