### PR TITLE
Allow sending informal breach letter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,6 @@ guard:
 
 sync-uh-simulator-data:
 	docker exec -ti universal-housing-simulator_incomeapi_1 sh -c "export CAN_AUTOMATE_LETTERS=true && rake income:rent:sync:manual_sync"
+
+run-breach-detector:
+	docker exec -ti universal-housing-simulator_incomeapi_1 sh -c "rake income:update_all_agreement_state"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Your worktray in the app will probably be empty, so to get data in there run the
 make sync-uh-simulator-data
 ```
 
+The breach detector should run nighly in deployed environments, you can run the breach detector locally using:
+```sh
+make run-breach-detector
+```
+
 ## Run tests
 
 ```

--- a/app/views/agreements/_send_breach_letter_button.html.erb
+++ b/app/views/agreements/_send_breach_letter_button.html.erb
@@ -1,0 +1,7 @@
+<% if @agreement.informal? && @agreement.breached? %>
+  <%= form_tag(income_collection_letters_path, class: 'case-details__inline-block') do %>
+    <%= hidden_field_tag "template_id", 'informal_agreement_breach_letter' %>
+    <%= hidden_field_tag "tenancy_refs", @tenancy.ref %>
+    <%= submit_tag('Send agreement breach letter', class: 'button') %>
+  <% end %>
+<% end %>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -50,8 +50,9 @@
       </div>
       <div class="grid-row">
         <div class="column-full">
+          <%= render :partial => 'agreements/send_breach_letter_button' %>
           <% unless @agreement.cancelled? %>
-            <% unless @agreement.formal? %>
+            <% unless @agreement.formal? || @agreement.breached? %>
               <%= form_tag(income_collection_letters_path, class: 'case-details__inline-block') do %>
                 <%= hidden_field_tag "template_id", 'informal_agreement_confirmation_letter' %>
                 <%= hidden_field_tag "tenancy_refs", @tenancy.ref %>

--- a/app/views/tenancies/case/_agreements.html.erb
+++ b/app/views/tenancies/case/_agreements.html.erb
@@ -32,6 +32,9 @@
 
       <div class="grid-row">
         <div class="column-full">
+          <% if @agreement %>
+            <%= render :partial => 'agreements/send_breach_letter_button' %>
+          <% end %>
           <% agreement_button_title = @agreement.nil? ? 'Create agreement' : 'Cancel and create new' %>
           <%= link_to agreement_button_title, new_agreement_path(@tenancy.ref), class:'button' %>
         </div>

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -48,8 +48,16 @@ module Hackney
           agreement_type == 'formal'
         end
 
+        def informal?
+          !formal?
+        end
+
         def cancelled?
           current_state == 'cancelled'
+        end
+
+        def breached?
+          current_state == 'breached'
         end
       end
     end

--- a/spec/features/income_collection/agreements/view_agreements_spec.rb
+++ b/spec/features/income_collection/agreements/view_agreements_spec.rb
@@ -20,21 +20,23 @@ describe 'View agreements' do
 
   scenario 'viewing agreement' do
     given_i_am_logged_in
-    and_there_there_is_a_breached_agreement
+    and_there_there_is_a_breached_informal_agreement
 
     when_i_visit_the_tenancy_page
     then_i_should_see_the_breached_agreement_status
+    and_i_should_see_a_button_to_send_breach_letter
 
     when_i_click_on_view_details
     then_i_should_see_the_agreement_details_page
     and_i_should_see_the_agreement_status
     and_i_should_see_the_agreement_details
+    and_i_should_see_a_button_to_send_breach_letter
     and_i_should_see_a_button_to_cancel_and_create_new_agreement
     and_i_should_see_a_button_to_cancel_the_agreement
     and_i_should_see_the_agreement_state_history
   end
 
-  def and_there_there_is_a_breached_agreement
+  def and_there_there_is_a_breached_informal_agreement
     breached_agreement =
       {
         "agreements": [
@@ -77,6 +79,10 @@ describe 'View agreements' do
     expect(page).to have_content("Expected balance\n£100.0")
     expect(page).to have_content('Last checked')
     expect(page).to have_content('July 19th, 2020')
+  end
+
+  def and_i_should_see_a_button_to_send_breach_letter
+    expect(page).to have_button('Send agreement breach letter')
   end
 
   def when_i_click_on_view_details


### PR DESCRIPTION
## Context
We want to allow caseworkers to manually send informal agreement breach letters from the UI.

## Changes in this pull request
- Add informal agreement breach letter button to the case profile page and agreement details page
- Add Make command to run the breach detector from the console, allows manual testing locally 

### After
![image](https://user-images.githubusercontent.com/22743709/91552365-9750bf00-e923-11ea-9820-6da0ca9a11aa.png)
![image](https://user-images.githubusercontent.com/22743709/91552387-9f106380-e923-11ea-88a7-633b6af71a20.png)
![image](https://user-images.githubusercontent.com/22743709/91552421-ae8fac80-e923-11ea-855c-e70c0c3c319e.png)


## Guidance to review
To test this manually
Create a breached agreement retrospectively and run the breach detector

```sh
make run-breach-detector
```

## Things to check
- [x] Environment variables have been updated
