### PR TITLE
Display agreement end date on agreement summary

### DIFF
--- a/app/views/agreements/_agreement_status.html.erb
+++ b/app/views/agreements/_agreement_status.html.erb
@@ -1,11 +1,22 @@
-<label class="govuk-label" for="status_label"><strong>Status</strong><br/></label>
-<% status = if @agreement.current_state == 'breached' 
-              "#{@agreement.current_state.humanize} (#{@agreement.history.last.description})"  
-            else
-              @agreement.current_state.humanize
-            end
-%>
-<label class="govuk-label" for="status"><%= status %><br/></label>
+<div class="grid-row">
+  <div class="column-half">
+    <label class="govuk-label" for="status_label"><strong>Status</strong><br/></label>
+    <% status = if @agreement.current_state == 'breached'
+                  "#{@agreement.current_state.humanize} (#{@agreement.history.last.description})"
+                else
+                  @agreement.current_state.humanize
+                end
+    %>
+    <label class="govuk-label" for="status"><%= status %><br/></label>
+  </div>
+  <div class="column-half">
+    <label class="govuk-label" for="end_date_label"><strong>End date</strong><br/></label>
+    <label class="govuk-label" for="end_date"><%= show_end_date(total_arrears: @agreement.starting_balance,
+                                                                start_date: @agreement.start_date,
+                                                                frequency: @agreement.frequency,
+                                                                amount: @agreement.amount) %><br/></label>
+    </div>
+</div>
 <div class="grid-row">
   <div class="column-half">
     <label class="govuk-label" for="actual_balance_label"><br/><h2><strong>Current balance</strong></label>

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -99,6 +99,7 @@ describe 'Create Formal agreement' do
 
   def and_i_should_see_the_agreement_status
     expect(page).to have_content('Status Live')
+    expect(page).to have_content('End date December 26th, 2020')
     expect(page).to have_content("Current balance\n£53.57")
     expect(page).to have_content("Expected balance\n£53.57")
     expect(page).to have_content('Last checked')

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -126,6 +126,7 @@ describe 'Create informal agreement' do
 
   def and_i_should_see_the_agreement_status
     expect(page).to have_content('Status Live')
+    expect(page).to have_content('End date December 26th, 2020')
     expect(page).to have_content("Current balance\n£53.57")
     expect(page).to have_content("Expected balance\n£53.57")
     expect(page).to have_content('Last checked')


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Based on feedback from the users, it was requested that the end date of an agreement be added onto the agreement summary section on a tenancy page so they do not have to change page to the view details page to view this information.

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Add the agreement end date to the agreement status section 

### Before
![image](https://user-images.githubusercontent.com/43789512/92140639-4819fb00-ee09-11ea-9f99-5e05222395ca.png)


### After
![image](https://user-images.githubusercontent.com/43789512/92139788-2a986180-ee08-11ea-9005-31a3573fac7a.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Not really sure where in the box they would like to view this information so I put it to the left of the agreements status, recommendations would be nice if there is a better positioning.

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-471

## Things to check

- [ ] Environment variables have been updated
