### PR TITLE
Redirect to create agreement page when adding valid court outcome

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -87,7 +87,12 @@ class CourtCasesController < ApplicationController
     use_cases.update_court_case.execute(court_case_params: update_court_outcome_terms_params)
 
     flash[:notice] = 'Successfully updated the court case'
-    redirect_to show_court_case_path(tenancy_ref: tenancy_ref, court_case_id: court_case_id)
+
+    if update_court_outcome_terms_params[:terms] == true
+      redirect_to new_agreement_path(tenancy_ref)
+    else
+      redirect_to show_court_case_path(tenancy_ref: tenancy_ref, court_case_id: court_case_id)
+    end
   rescue Exceptions::IncomeApiError => e
     flash[:notice] = "An error occurred: #{e.message}"
     redirect_to update_court_outcome_path(tenancy_ref: tenancy_ref, **update_court_outcome_terms_params)

--- a/spec/controllers/tenancies_controller_spec.rb
+++ b/spec/controllers/tenancies_controller_spec.rb
@@ -7,7 +7,7 @@ describe TenanciesController do
     stub_const('Hackney::Income::TenancyGateway', Hackney::Income::StubTenancyGatewayBuilder.build_stub)
     stub_const('Hackney::Income::TransactionsGateway', Hackney::Income::StubTransactionsGateway)
     stub_const('Hackney::Income::GetActionDiaryEntriesGateway', Hackney::Income::StubGetActionDiaryEntriesGateway)
-    stub_view_court_cases_response(tenancy_ref: '1234567')
+    stub_view_court_cases_responses(tenancy_ref: '1234567')
     sign_in
   end
 

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -13,7 +13,7 @@ describe 'Create informal agreement' do
     stub_create_agreement_response
     stub_view_agreements_response
     stub_cancel_agreement_response
-    stub_view_court_cases_response
+    stub_view_court_cases_responses
   end
 
   scenario 'creating a new informal agreement' do

--- a/spec/features/income_collection/agreements/view_agreements_spec.rb
+++ b/spec/features/income_collection/agreements/view_agreements_spec.rb
@@ -10,7 +10,7 @@ describe 'View agreements' do
     stub_tenancy_api_contacts
     stub_tenancy_api_actions
     stub_tenancy_api_tenancy
-    stub_view_court_cases_response
+    stub_view_court_cases_responses
   end
 
   scenario 'viewing agreement' do

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -12,7 +12,7 @@ describe 'Create court case' do
     stub_tenancy_api_tenancy
     stub_view_agreements_response
     stub_create_court_case_response
-    stub_view_court_cases_response
+    stub_view_court_cases_responses(responses: view_court_cases_responses)
     stub_update_court_case_response
     stub_update_court_outcome_response
   end
@@ -59,8 +59,7 @@ describe 'Create court case' do
     and_im_asked_to_select_terms_and_disrepair_counter_claim
     and_i_choose_yes_for_terms_and_no_for_disrepair_counter_claim
     and_i_click_add_outcome
-    then_i_should_see_the_court_case_page
-    and_the_updated_court_case_details
+    then_i_should_see_create_agreement_page
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -204,17 +203,18 @@ describe 'Create court case' do
     choose('disrepair_counter_claim_No')
   end
 
-  def and_the_updated_court_case_details
-    expect(page).to have_content('Court date')
-    expect(page).to have_content('July 23rd, 2020')
-    expect(page).to have_content('Balance on court date:')
-    expect(page).to have_content('£1,500')
-    expect(page).to have_content('Court outcome:')
-    expect(page).to have_content('Adjourned generally with permission to restore')
-    expect(page).to have_content('Strike out date:')
-    expect(page).to have_content('August 10th, 2025')
-    expect(page).to have_content('Terms: Yes')
-    expect(page).to have_content('Disrepair counter claim: No')
+  def then_i_should_see_create_agreement_page
+    expect(page).to have_content('Create agreement')
+    expect(page).to have_content('Agreement for: Alan Sugar')
+    expect(page).to have_content('Total arrears balance owed: £103.57')
+    expect(page).to have_content('Court case related to this agreement')
+    expect(page).to have_content('Court date: July 23rd, 2020')
+    expect(page).to have_content('Court outcome: Adjourned generally with permission to restore')
+    expect(page).to have_content('Frequency of payments')
+    expect(page).to have_content('Weekly instalment amount')
+    expect(page).to have_content('Start date')
+    expect(page).to have_content('End date')
+    expect(page).to have_content('Notes')
   end
 
   def stub_my_cases_response
@@ -303,10 +303,10 @@ describe 'Create court case' do
     end
   end
 
-  def stub_view_court_cases_response
+  def view_court_cases_responses
     no_court_cases_response_json = {
       courtCases: []
- }.to_json
+  }.to_json
 
     one_court_case_response_json = {
       courtCases:
@@ -364,14 +364,13 @@ describe 'Create court case' do
         }]
     }.to_json
 
-    stub_request(:get, 'https://example.com/income/api/v1/court_cases/1234567%2F01/')
-      .to_return({ status: 200, body: no_court_cases_response_json },
-                 { status: 200, body: one_court_case_response_json },
-                 { status: 200, body: one_court_case_response_json },
-                 { status: 200, body: updated_court_case_response_json },
-                 { status: 200, body: court_case_with_court_outcome_response_json },
-                 { status: 200, body: court_case_with_court_outcome_response_json },
-                 { status: 200, body: court_case_with_court_outcome_response_json },
-                 status: 200, body: court_case_with_court_outcome_and_terms_response_json)
+    [no_court_cases_response_json,
+     one_court_case_response_json,
+     one_court_case_response_json,
+     updated_court_case_response_json,
+     court_case_with_court_outcome_response_json,
+     court_case_with_court_outcome_response_json,
+     court_case_with_court_outcome_response_json,
+     court_case_with_court_outcome_and_terms_response_json]
   end
 end

--- a/spec/features/page_navigation_spec.rb
+++ b/spec/features/page_navigation_spec.rb
@@ -12,7 +12,7 @@ describe 'Page navigation' do
     stub_income_api_my_cases
     stub_income_api_show_tenancy(tenancy_ref: 'TEST%2F01')
     stub_view_agreements_response(tenancy_ref: 'TEST%2F01')
-    stub_view_court_cases_response(tenancy_ref: 'TEST%2F01')
+    stub_view_court_cases_responses(tenancy_ref: 'TEST%2F01')
 
     stub_users_gateway
   end

--- a/spec/features/view_a_case_spec.rb
+++ b/spec/features/view_a_case_spec.rb
@@ -12,7 +12,7 @@ describe 'Viewing A Single Case' do
     stub_income_api_my_cases
     stub_income_api_show_tenancy
     stub_view_agreements_response(response: view_agreements_response)
-    stub_view_court_cases_response(response: view_court_cases_response)
+    stub_view_court_cases_responses(responses: view_court_cases_response)
 
     stub_users_gateway
   end
@@ -173,14 +173,14 @@ describe 'Viewing A Single Case' do
   end
 
   def view_court_cases_response
-    {
+    [{
       courtCases: [{
                     id: 1,
                     tenancyRef: '1234567/01',
                     courtDate: '2020-08-14T00:00:00.000Z',
                     courtOutcome: 'AAH'
                   }]
-    }.to_json
+    }.to_json]
   end
 
   def view_agreements_response

--- a/spec/support/api_response_helper.rb
+++ b/spec/support/api_response_helper.rb
@@ -76,12 +76,23 @@ def stub_view_agreements_response(tenancy_ref: '1234567%2F01', response: nil)
     .to_return(status: 200, body: response)
 end
 
-def stub_view_court_cases_response(tenancy_ref: '1234567%2F01', response: nil)
-  response ||= { "courtCases": [] }.to_json
+def stub_view_court_cases_responses(tenancy_ref: '1234567%2F01', responses: [nil])
+  stubbed_responses = create_response_hash(responses: responses)
 
   stub_request(:get, "https://example.com/income/api/v1/court_cases/#{tenancy_ref}/")
   .with(
     headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
   )
-  .to_return(status: 200, body: response)
+  .to_return(stubbed_responses)
+end
+
+def create_response_hash(responses:)
+  response_hashes = []
+  responses.each do |response|
+    response ||= { "courtCases": [] }.to_json
+
+    response_hashes << { status: 200, body: response }
+  end
+
+  response_hashes
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
If a user adds a court outcome with terms, they should be redirected to the page for creating formal agreements.

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Redirects to new agreement page in court case controller if the outcome has terms
- Tries to incorporate and extend Csaba's refactoring from #364 
  - Extend the `view court cases stub` to allow it to return multiple responses

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
My brain has been a bit slow the last few days 🐌  - mainly for the refactoring bit - please shout if it looks funky 😬
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-460?atlOrigin=eyJpIjoiNTIxOTUxYmJmZDAzNDJjNmI2NGY1ZWQzMGM4YjhmYzQiLCJwIjoiaiJ9

## Things to check

- [x] Environment variables have been updated
