### PR TITLE
Update end date calculator for variable payment agreements

### DIFF
--- a/app/assets/javascripts/income_collection/EndDateCalculator.js
+++ b/app/assets/javascripts/income_collection/EndDateCalculator.js
@@ -1,8 +1,9 @@
 try { var moment = require('moment') } catch(err){}
 
-window.EndDateCalculator = function EndDateCalculator (totalArrears, startDate, frequency, amount) {
+window.EndDateCalculator = function EndDateCalculator (totalArrears, startDate, frequency, amount, initialPaymentAmount) {
   if (!totalArrears || !startDate || !frequency || !amount) return '';
   if (new Date(startDate) == 'Invalid Date') return '';
+  if (initialPaymentAmount) totalArrears = parseFloat(totalArrears) - parseFloat(initialPaymentAmount);
 
   var numberOfInstalments = Math.ceil(parseFloat(totalArrears) / parseFloat(amount)) - 1;
   const frequencyOfPayment = (frequency.toLowerCase() == 'monthly') ? 'months' : 'weeks'

--- a/app/helpers/agreement_helper.rb
+++ b/app/helpers/agreement_helper.rb
@@ -8,11 +8,12 @@ module AgreementHelper
     }
   end
 
-  def show_end_date(total_arrears:, start_date:, frequency:, amount:)
+  def show_end_date(total_arrears:, start_date:, frequency:, amount:, initial_payment_amount: nil)
     return nil if total_arrears.nil? || start_date.nil? || frequency.nil? || amount.nil?
 
+    total_arrears = BigDecimal(total_arrears.to_s) - BigDecimal(initial_payment_amount.to_s) if initial_payment_amount
     start_date = Date.parse(start_date)
-    number_of_instalments = total_arrears.to_f.fdiv(amount.to_f).ceil - 1
+    number_of_instalments = (BigDecimal(total_arrears.to_s) / BigDecimal(amount.to_s)).ceil - 1
     end_date = if frequency == 'weekly'
                  start_date + number_of_instalments.weeks
                elsif frequency == 'fortnightly'

--- a/spec/helpers/agreement_helper_spec.rb
+++ b/spec/helpers/agreement_helper_spec.rb
@@ -85,5 +85,33 @@ describe AgreementHelper do
         expect(helper.show_end_date(params)).to eq(expected_end_date)
       end
     end
+
+    context 'when there is an initial payment amount before or on the date of first instalment' do
+      let(:params) do
+        {
+          total_arrears: '50',
+          start_date: '2020-12-01',
+          frequency: 'weekly',
+          amount: '20',
+          initial_payment_amount: '30'
+        }
+      end
+      it 'calculates the end date for a single instalment' do
+        expected_end_date = 'December 1st, 2020'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+
+      it 'calculates end date when its exactly 2 instalments to complete' do
+        params[:total_arrears] = 70
+        expected_end_date = 'December 8th, 2020'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+
+      it 'calculates end date when the last payment is less than the agreed amount' do
+        params[:total_arrears] = 80
+        expected_end_date = 'December 15th, 2020'
+        expect(helper.show_end_date(params)).to eq(expected_end_date)
+      end
+    end
   end
 end

--- a/spec/javascript/EndDateCalculator.spec.js
+++ b/spec/javascript/EndDateCalculator.spec.js
@@ -89,6 +89,38 @@ describe('EndDateCalculator', function() {
       expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount)).toEqual(expectedEndDate)
     });
   }); 
+
+  describe('When there is an initial payment amount before or on the date of first instalment', function() {
+    it('calcules end date when arrears paid in a single instalment', function() {
+      var frequency = 'Weekly';
+      var totalArrears = '50';
+      var amount = '20';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '1 December 2020';
+      var initialPaymentAmount = '30';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount, initialPaymentAmount)).toEqual(expectedEndDate)
+    });
+
+    it('calculates end date when its exactly 2 instalments to complete', function() {
+      var frequency = 'Weekly';
+      var totalArrears = '70';
+      var amount = '20';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '8 December 2020';
+      var initialPaymentAmount = '30';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount, initialPaymentAmount)).toEqual(expectedEndDate)
+    });
+
+    it('calculates end date when the last payment is less than the agreed amount', function() {
+      var frequency = 'Weekly';
+      var totalArrears = '80';
+      var amount = '20';
+      var startDate = '2020-12-01';
+      var expectedEndDate = '15 December 2020';
+      var initialPaymentAmount = '30';
+      expect(window.EndDateCalculator(totalArrears, startDate, frequency, amount, initialPaymentAmount)).toEqual(expectedEndDate)
+    });
+  });
 });
 
 


### PR DESCRIPTION
## Context
As a caseworker, I want to be able to see the expected end date when variable payment agreements, so I know when the agreement ends.

## Changes in this pull request
- Update JS end date calculator
- Update agreement helper to show end date of a variable payment agreements

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-464

## Things to check
- [x] Environment variables have been updated
