### PR TITLE
Allow viewing an agreement with variable payments

### DIFF
--- a/app/views/agreements/_agreement_status.html.erb
+++ b/app/views/agreements/_agreement_status.html.erb
@@ -14,7 +14,8 @@
     <label class="govuk-label" for="end_date"><%= show_end_date(total_arrears: @agreement.starting_balance,
                                                                 start_date: @agreement.start_date,
                                                                 frequency: @agreement.frequency,
-                                                                amount: @agreement.amount) %><br/></label>
+                                                                amount: @agreement.amount, 
+                                                                initial_payment_amount: @agreement.initial_payment_amount) %><br/></label>
     </div>
 </div>
 <div class="grid-row">

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -21,6 +21,12 @@
           <ul>
             <li><h2><%= 'Agreement details' %></h2></li>
             <li><strong>Total balance owed: </strong> <%= number_to_currency(@agreement.starting_balance, unit: '£') %></li>
+            <br/>
+            <% if @agreement.variable_payment? %>
+              <li><strong>One-off payment amount: </strong><br> <%= number_to_currency(@agreement.initial_payment_amount, unit: '£') %></li>
+              <li><strong>One-off payment date:</strong> <%= format_date(@agreement.initial_payment_date) %></li>
+              <br/>
+            <% end %>
             <li><strong>Frequency of payment: </strong><br> <%= @agreement.frequency.humanize %></li>
             <li><strong>Instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
             <br/>
@@ -28,7 +34,8 @@
             <li><strong>End date: </strong><%= show_end_date(total_arrears: @agreement.starting_balance,
                                                              start_date: @agreement.start_date, 
                                                              frequency: @agreement.frequency,
-                                                             amount: @agreement.amount) %>
+                                                             amount: @agreement.amount,
+                                                             initial_payment_amount: @agreement.initial_payment_amount) %>
             </li>
           </ul>
         </div>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -23,8 +23,8 @@
             <li><strong>Total balance owed: </strong> <%= number_to_currency(@agreement.starting_balance, unit: '£') %></li>
             <br/>
             <% if @agreement.variable_payment? %>
-              <li><strong>One-off payment amount: </strong><br> <%= number_to_currency(@agreement.initial_payment_amount, unit: '£') %></li>
-              <li><strong>One-off payment date:</strong> <%= format_date(@agreement.initial_payment_date) %></li>
+              <li><strong>Lump sum payment amount: </strong><br> <%= number_to_currency(@agreement.initial_payment_amount, unit: '£') %></li>
+              <li><strong>Lump sum payment date:</strong> <%= format_date(@agreement.initial_payment_date) %></li>
               <br/>
             <% end %>
             <li><strong>Frequency of payment: </strong><br> <%= @agreement.frequency.humanize %></li>

--- a/app/views/agreements/show_history.html.erb
+++ b/app/views/agreements/show_history.html.erb
@@ -34,7 +34,8 @@
             <td><%= show_end_date(total_arrears: agreement.starting_balance,
                                                              start_date: agreement.start_date, 
                                                              frequency: agreement.frequency,
-                                                             amount: agreement.amount) %>
+                                                             amount: agreement.amount,
+                                                             initial_payment_amount: agreement.initial_payment_amount) %>
             </td>
             <td><%= number_to_currency(@tenancy.current_balance, unit: '£') %></td>
             <td>

--- a/lib/hackney/income/agreements_gateway.rb
+++ b/lib/hackney/income/agreements_gateway.rb
@@ -82,6 +82,8 @@ module Hackney
           t.created_by = agreement['createdBy']
           t.last_checked = agreement['lastChecked']
           t.notes = agreement['notes']
+          t.initial_payment_amount = agreement['initialPaymentAmount']
+          t.initial_payment_date = agreement['initialPaymentDate']
           t.history = agreement['history'].map do |state|
             Hackney::Income::Domain::AgreementState.new.tap do |s|
               s.date = state['date']

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -6,7 +6,7 @@ module Hackney
 
         attr_accessor :id, :tenancy_ref, :agreement_type, :starting_balance, :amount,
                       :start_date, :current_state, :created_at, :created_by, :frequency,
-                      :last_checked, :court_case_id, :notes, :history
+                      :last_checked, :court_case_id, :notes, :initial_payment_amount, :initial_payment_date, :history
 
         validates :tenancy_ref, :agreement_type, :amount, :frequency, :start_date, presence: true
 
@@ -41,6 +41,10 @@ module Hackney
 
         def breached?
           current_state == 'breached'
+        end
+
+        def variable_payment?
+          initial_payment_amount.present?
         end
       end
     end

--- a/spec/features/income_collection/agreements/view_agreements_spec.rb
+++ b/spec/features/income_collection/agreements/view_agreements_spec.rb
@@ -15,7 +15,7 @@ describe 'View agreements' do
 
   scenario 'viewing agreement' do
     given_i_am_logged_in
-    and_there_there_is_a_breached_informal_agreement
+    and_there_there_is_a_breached_informal_agreement_with_variable_payments
 
     when_i_visit_the_tenancy_page
     then_i_should_see_the_breached_agreement_status
@@ -31,7 +31,7 @@ describe 'View agreements' do
     and_i_should_see_the_agreement_state_history
   end
 
-  def and_there_there_is_a_breached_informal_agreement
+  def and_there_there_is_a_breached_informal_agreement_with_variable_payments
     breached_agreement =
       {
         "agreements": [
@@ -39,7 +39,7 @@ describe 'View agreements' do
             "id": 12,
             "tenancyRef": '1234567/01',
             "agreementType": 'informal',
-            "startingBalance": '140',
+            "startingBalance": '170.60',
             "amount": '20',
             "startDate": '2020-12-12',
             "frequency": 'weekly',
@@ -48,6 +48,8 @@ describe 'View agreements' do
             "createdBy": 'Hackney User',
             "lastChecked": '2020-07-19',
             "notes": 'Wen Ting is the master of rails',
+            "initialPaymentDate": '2020-12-11',
+            "initialPaymentAmount": '30.60',
             "history": [
               {
                 "state": 'breached',
@@ -102,7 +104,11 @@ describe 'View agreements' do
     expect(page).to have_content('Created by: Hackney User')
     expect(page).to have_content('Notes: Wen Ting is the master of rails')
 
-    expect(page).to have_content('Total balance owed: £140.0')
+    expect(page).to have_content('Total balance owed: £170.60')
+
+    expect(page).to have_content('One-off payment amount: £30.60')
+    expect(page).to have_content('One-off payment date: December 11th, 2020')
+
     expect(page).to have_content('Frequency of payment: Weekly')
     expect(page).to have_content('Instalment amount: £20')
     expect(page).to have_content('Start date: December 12th, 2020')

--- a/spec/features/income_collection/agreements/view_agreements_spec.rb
+++ b/spec/features/income_collection/agreements/view_agreements_spec.rb
@@ -106,8 +106,8 @@ describe 'View agreements' do
 
     expect(page).to have_content('Total balance owed: £170.60')
 
-    expect(page).to have_content('One-off payment amount: £30.60')
-    expect(page).to have_content('One-off payment date: December 11th, 2020')
+    expect(page).to have_content('Lump sum payment amount: £30.60')
+    expect(page).to have_content('Lump sum payment date: December 11th, 2020')
 
     expect(page).to have_content('Frequency of payment: Weekly')
     expect(page).to have_content('Instalment amount: £20')

--- a/spec/lib/hackney/income/agreement_gateway_spec.rb
+++ b/spec/lib/hackney/income/agreement_gateway_spec.rb
@@ -106,6 +106,8 @@ describe Hackney::Income::AgreementsGateway do
               createdBy: Faker::Number.number(digits: 8),
               createdAt: Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s,
               lastChecked: Faker::Date.between(from: 3.days.ago, to: 2.days.ago).to_s,
+              initialPaymentAmount: Faker::Commerce.price(range: 50...300),
+              initialPaymentDate: Faker::Date.between(from: 5.days.ago, to: 3.days.ago).to_s,
               history: [
                 {
                   state: 'live',
@@ -128,6 +130,8 @@ describe Hackney::Income::AgreementsGateway do
               createdBy: Faker::Number.number(digits: 8),
               createdAt: Faker::Date.between(from: 6.days.ago, to: 3.days.ago).to_s,
               lastChecked: Faker::Date.between(from: 3.days.ago, to: 2.days.ago).to_s,
+              initialPaymentAmount: nil,
+              initialPaymentDate: nil,
               history: [
                 {
                   state: 'live',
@@ -165,6 +169,8 @@ describe Hackney::Income::AgreementsGateway do
           expect(agreement.created_at).to eq(agreements_response[:agreements][i].fetch(:createdAt))
           expect(agreement.created_by).to eq(agreements_response[:agreements][i].fetch(:createdBy))
           expect(agreement.last_checked).to eq(agreements_response[:agreements][i].fetch(:lastChecked))
+          expect(agreement.initial_payment_amount).to eq(agreements_response[:agreements][i].fetch(:initialPaymentAmount))
+          expect(agreement.initial_payment_date).to eq(agreements_response[:agreements][i].fetch(:initialPaymentDate))
           expect(agreement.history.first.date).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:date))
           expect(agreement.history.first.state).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:state))
           expect(agreement.history.first.checked_balance).to eq(agreements_response[:agreements][i].fetch(:history).first.fetch(:checkedBalance))


### PR DESCRIPTION
## Context
As a caseworker, I want to be able to see when an agreement is a variable payment agreement, so I can see when the initial larger payment is expected to be paid. 

## Changes in this pull request
- Update agreement gateway to pull variable payment fields
- Allow showing variable payment details on agreement details and history pages 

![image](https://user-images.githubusercontent.com/22743709/92504641-da037880-f1fa-11ea-8c12-1f2796ef2556.png)


## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-464

## Things to check
- [x] Environment variables have been updated
