### PR TITLE
 Show the correct end-date and content when its a formal agreement

### DIFF
--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -10,7 +10,10 @@
   <div class="column-full">
     <h1><%= 'Create agreement' %></h1>
     <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
-    <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
+    <% formal_agreement = @court_cases.present? && @court_cases.last.terms %>
+    <% if !formal_agreement %>
+      <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
+    <% end %>
     <hr>
   </div>
 </div>
@@ -18,7 +21,7 @@
 <div class="grid-row">
   <div class="column-full">
     <%= form_tag('create', method: :post) do %>
-      <% if @court_cases.present? && @court_cases.last.terms %>
+      <% if formal_agreement %>
         <%= hidden_field_tag :agreement_type, 'formal' %>
         <%= render :partial => "agreements/form/agreement_formal" %>
       <% else %>
@@ -33,7 +36,7 @@
 <script type="text/javascript">
   function updateEndDate() {
     var start_date = document.getElementById("start_date").value;
-    var arrears = '<%= @tenancy.current_balance %>';
+    var arrears = '<%= formal_agreement ? @court_cases.last.balance_on_court_outcome_date : @tenancy.current_balance %>';
     var frequency = document.getElementById("frequency_selector").value;
     var amount = document.getElementById("amount").value;
     document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount);

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -8,9 +8,10 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <h1><%= 'Create agreement' %></h1>
-    <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
     <% formal_agreement = @court_cases.present? && @court_cases.last.terms %>
+    <% title = formal_agreement ? 'Create court agreement' : 'Create informal agreement' %>
+    <h1><%= title %></h1>
+    <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
     <% if !formal_agreement %>
       <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
     <% end %>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -20,7 +20,7 @@
         <div class="column-full">
           <ul>
             <li><h2><%= 'Agreement details' %></h2></li>
-            <li><strong>Total balance owed: </strong> <%= number_to_currency(@agreement.starting_balance, unit: '£') %></li>
+            <li><strong>Starting balance: </strong> <%= number_to_currency(@agreement.starting_balance, unit: '£') %></li>
             <br/>
             <% if @agreement.variable_payment? %>
               <li><strong>Lump sum payment amount: </strong><br> <%= number_to_currency(@agreement.initial_payment_amount, unit: '£') %></li>

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -59,7 +59,6 @@ describe 'Create Formal agreement' do
   def then_i_should_see_create_agreement_page
     expect(page).to have_content('Create agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
-    expect(page).to have_content('Total arrears balance owed: £103.57')
     expect(page).to have_content('Court case related to this agreement')
     expect(page).to have_content('Court date: July 21st, 2020')
     expect(page).to have_content('Court outcome: Adjourned on Terms')

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -57,7 +57,7 @@ describe 'Create Formal agreement' do
   end
 
   def then_i_should_see_create_agreement_page
-    expect(page).to have_content('Create agreement')
+    expect(page).to have_content('Create court agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
     expect(page).to have_content('Court case related to this agreement')
     expect(page).to have_content('Court date: July 21st, 2020')

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -59,7 +59,7 @@ describe 'Create informal agreement' do
   end
 
   def then_i_should_see_create_agreement_page
-    expect(page).to have_content('Create agreement')
+    expect(page).to have_content('Create informal agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
     expect(page).to have_content('Total arrears balance owed: £103.57')
     expect(page).to have_content('Frequency of payments')

--- a/spec/features/income_collection/agreements/view_agreements_spec.rb
+++ b/spec/features/income_collection/agreements/view_agreements_spec.rb
@@ -104,7 +104,7 @@ describe 'View agreements' do
     expect(page).to have_content('Created by: Hackney User')
     expect(page).to have_content('Notes: Wen Ting is the master of rails')
 
-    expect(page).to have_content('Total balance owed: £170.60')
+    expect(page).to have_content('Starting balance: £170.60')
 
     expect(page).to have_content('Lump sum payment amount: £30.60')
     expect(page).to have_content('Lump sum payment date: December 11th, 2020')

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -204,7 +204,7 @@ describe 'Create court case' do
   end
 
   def then_i_should_see_create_agreement_page
-    expect(page).to have_content('Create agreement')
+    expect(page).to have_content('Create court agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
     expect(page).to have_content('Court case related to this agreement')
     expect(page).to have_content('Court date: July 23rd, 2020')

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -206,7 +206,6 @@ describe 'Create court case' do
   def then_i_should_see_create_agreement_page
     expect(page).to have_content('Create agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
-    expect(page).to have_content('Total arrears balance owed: £103.57')
     expect(page).to have_content('Court case related to this agreement')
     expect(page).to have_content('Court date: July 23rd, 2020')
     expect(page).to have_content('Court outcome: Adjourned generally with permission to restore')


### PR DESCRIPTION
## Context
The end-date calculator uses the total arrears when creating a new agreement, it should use the court balance when its a court agreement. 

## Changes in this pull request
- Update the JS that calls the end date calculator on the create agreement field
- Change the create agreement page title to make the type of agreement clear 

## Things to check
- [x] Environment variables have been updated
