### PR TITLE
mark formal agreements as court ordered agreements

### DIFF
--- a/app/views/agreements/_agreement_status.html.erb
+++ b/app/views/agreements/_agreement_status.html.erb
@@ -1,3 +1,7 @@
+<% if @agreement.formal? %>
+  <h3><u>Court ordered agreement</u></h3>
+<% end %>
+
 <div class="grid-row">
   <div class="column-half">
     <label class="govuk-label" for="status_label"><strong>Status</strong><br/></label>
@@ -14,7 +18,7 @@
     <label class="govuk-label" for="end_date"><%= show_end_date(total_arrears: @agreement.starting_balance,
                                                                 start_date: @agreement.start_date,
                                                                 frequency: @agreement.frequency,
-                                                                amount: @agreement.amount, 
+                                                                amount: @agreement.amount,
                                                                 initial_payment_amount: @agreement.initial_payment_amount) %><br/></label>
     </div>
 </div>

--- a/app/views/agreements/show_history.html.erb
+++ b/app/views/agreements/show_history.html.erb
@@ -19,6 +19,7 @@
   <div class="column-full">
     <table class="agreements_history-table fixed-layout">
       <thead>
+        <th class="type-column">Agreement type</th>
         <th class="status-column">Status</th>
         <th class="start-date-column">Start date</th>
         <th class="end-date-column">End date</th>
@@ -29,10 +30,19 @@
       <% @agreements.reverse_each do |agreement| %>
         <tbody class="summary-table__group agreements_history-table__group--summary">
           <tr>
-            <td><%= agreement.current_state.humanize %></td>
+            <td>
+              <% if agreement.formal? %>
+                Court ordered
+              <% else %>
+                Informal
+              <% end %>
+            </td>
+            <td>
+              <%= agreement.current_state.humanize %>
+            </td>
             <td><%= format_date(agreement.start_date) %></td>
             <td><%= show_end_date(total_arrears: agreement.starting_balance,
-                                                             start_date: agreement.start_date, 
+                                                             start_date: agreement.start_date,
                                                              frequency: agreement.frequency,
                                                              amount: agreement.amount,
                                                              initial_payment_amount: agreement.initial_payment_amount) %>

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -104,6 +104,7 @@ describe 'Create Formal agreement' do
   end
 
   def and_i_should_see_the_new_agreement
+    expect(page).to have_content('Court ordered agreement')
     expect(page).to have_content('Arrears Agreement')
     expect(page).to have_content('Status')
     expect(page).to have_content('Live')


### PR DESCRIPTION

## Context
<!-- Why are you making this change? What might surprise someone about it? -->

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
When a user is looking at an agreement, it is not clear when that agreement is court ordered
<img width="765" alt="Screenshot 2020-09-09 at 11 25 41" src="https://user-images.githubusercontent.com/8051117/92588061-614efb80-f290-11ea-8a45-cebbf3752790.png">
<img width="520" alt="Screenshot 2020-09-09 at 11 25 35" src="https://user-images.githubusercontent.com/8051117/92588077-657b1900-f290-11ea-8a86-62c54266bfdf.png">

## Changes in this pull request
- When agreement is formal, the agreement status will be shown as `Court ordered` 
- Display the agreement type in history

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] Environment variables have been updated
