### PR TITLE
Allow creating variable payment agreements 

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -1,7 +1,25 @@
 class AgreementsController < ApplicationController
   protect_from_forgery
 
+  def payment_type
+    @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
+  end
+
+  def set_payment_type
+    payment_type = params.dig(:payment_type)
+
+    if payment_type
+      redirect_to new_agreement_path(tenancy_ref: tenancy_ref, payment_type: payment_type)
+    else
+      redirect_to agreement_payment_type_path(tenancy_ref: tenancy_ref)
+    end
+  end
+
   def new
+    @payment_type = params.dig(:payment_type)
+
+    redirect_to agreement_payment_type_path(tenancy_ref: tenancy_ref) if @payment_type.nil?
+
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
 
     @court_cases = use_cases.view_court_cases.execute(tenancy_ref: tenancy_ref)

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -42,8 +42,8 @@ class AgreementsController < ApplicationController
       start_date: agreement_params[:start_date],
       notes: agreement_params[:notes],
       court_case_id: agreement_params[:court_case_id],
-      initial_payment_amount: agreement_params[:lump_sum_amount],
-      initial_payment_date: agreement_params[:lump_sum_date]
+      initial_payment_amount: agreement_params[:initial_payment_amount],
+      initial_payment_date: agreement_params[:initial_payment_date]
     )
     redirect_to show_agreement_path(tenancy_ref: tenancy_ref, id: agreement.id) if agreement
   rescue Exceptions::IncomeApiError => e
@@ -98,8 +98,8 @@ class AgreementsController < ApplicationController
       :notes,
       :court_case_id,
       :payment_type,
-      :lump_sum_amount,
-      :lump_sum_date
+      :initial_payment_amount,
+      :initial_payment_date
     )
   end
 end

--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -3,6 +3,7 @@ class AgreementsController < ApplicationController
 
   def payment_type
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
+    @court_cases = use_cases.view_court_cases.execute(tenancy_ref: tenancy_ref)
   end
 
   def set_payment_type
@@ -40,7 +41,9 @@ class AgreementsController < ApplicationController
       frequency: agreement_params[:frequency],
       start_date: agreement_params[:start_date],
       notes: agreement_params[:notes],
-      court_case_id: agreement_params[:court_case_id]
+      court_case_id: agreement_params[:court_case_id],
+      initial_payment_amount: agreement_params[:lump_sum_amount],
+      initial_payment_date: agreement_params[:lump_sum_date]
     )
     redirect_to show_agreement_path(tenancy_ref: tenancy_ref, id: agreement.id) if agreement
   rescue Exceptions::IncomeApiError => e
@@ -93,7 +96,10 @@ class AgreementsController < ApplicationController
       :frequency,
       :start_date,
       :notes,
-      :court_case_id
+      :court_case_id,
+      :payment_type,
+      :lump_sum_amount,
+      :lump_sum_date
     )
   end
 end

--- a/app/views/agreements/form/_agreement_formal.html.erb
+++ b/app/views/agreements/form/_agreement_formal.html.erb
@@ -16,6 +16,7 @@
   <label class="govuk-label" style="font-weight:bold" for="starting_balance" id="starting_balance_label">Starting Balance</label><br/>
   <%= number_field_tag :starting_balance, @court_cases.last.balance_on_court_outcome_date, { class: 'form-control', required: true, disabled: true} %>
 </div>
+<hr>
 
 <%= render :partial => "agreements/form/agreement_informal" %>
 

--- a/app/views/agreements/form/_agreement_formal.html.erb
+++ b/app/views/agreements/form/_agreement_formal.html.erb
@@ -13,7 +13,9 @@
 </div>
 
 <div class="form-group">
-  <label class="govuk-label" style="font-weight:bold" for="starting_balance" id="starting_balance_label">Starting Balance</label><br/>
+  <label class="govuk-label" style="font-weight:bold" for="starting_balance" id="starting_balance_label">Starting Balance
+  <span class="form-hint">This is the balance on the court outcome date</span>
+  </label><br/>
   <%= number_field_tag :starting_balance, @court_cases.last.balance_on_court_outcome_date, { class: 'form-control', required: true, disabled: true} %>
 </div>
 <hr>

--- a/app/views/agreements/form/_agreement_informal.html.erb
+++ b/app/views/agreements/form/_agreement_informal.html.erb
@@ -1,3 +1,16 @@
+<% if @payment_type == 'variable' %>
+  <div class="form-group">
+    <label class="govuk-label" style=font-weight:bold for="lump_sum_amount">Lump sum payment amount</label><br/>
+    <%= number_field_tag(:lump_sum_amount, @agreement.initial_payment_amount, { class: 'form-control', required: true, min: 1, max: @tenancy.current_balance, placeholder: '£', step: 0.01 }) %>
+  </div>
+
+  <div class="form-group">
+    <label class="govuk-date-field" for="lump_sum_date"><strong>Lump sum payment date</strong><br/></label>
+    <%= date_field_tag :lump_sum_date, @agreement.initial_payment_date, class: 'form-control' %>
+  </div>
+  <hr>
+<% end %>
+
 <div class="form-group">
   <label class="govuk-label" for="frequency"><strong>Frequency of payments</strong><br/></label>
   <%= select_tag(:frequency, options_for_select(frequency_of_payments, @agreement.frequency), { :class => 'form-control', id: 'frequency_selector' }) %>

--- a/app/views/agreements/form/_agreement_informal.html.erb
+++ b/app/views/agreements/form/_agreement_informal.html.erb
@@ -1,6 +1,8 @@
 <% if @payment_type == 'variable' %>
   <div class="form-group">
-    <label class="govuk-label" style=font-weight:bold for="lump_sum_amount">Lump sum payment amount</label><br/>
+    <label class="govuk-label" style=font-weight:bold for="lump_sum_amount">Lump sum payment amount
+    <span class="form-hint">A single payment, additional to the recurring payments</span>
+    </label><br/>
     <%= number_field_tag(:lump_sum_amount, @agreement.initial_payment_amount, { class: 'form-control', required: true, min: 1, max: @tenancy.current_balance, placeholder: '£', step: 0.01 }) %>
   </div>
 
@@ -22,12 +24,16 @@
 </div>
 
 <div class="form-group">
-  <label class="govuk-date-field" for="start_date"><strong>Start date</strong><br/></label>
+  <label class="govuk-date-field" for="start_date"><strong>Start date</strong><br/>
+  <span class="form-hint">The first payment date</span>
+  </label>
   <%= date_field_tag :start_date, @agreement.start_date, class: 'form-control' %>
 </div>
 
 <div class="form-group">
-  <label class="govuk-date-field" for="end_date"><strong>End date</strong><br/></label>
+  <label class="govuk-date-field" for="end_date"><strong>End date</strong><br/>
+  <span class="form-hint">Last payment date, automatically calculated</span>
+  </label>
   <label class="govuk-date-field" id="end_date_value"></label>
 </div>
 

--- a/app/views/agreements/form/_agreement_informal.html.erb
+++ b/app/views/agreements/form/_agreement_informal.html.erb
@@ -1,7 +1,7 @@
 <% if @payment_type == 'variable' %>
   <div class="form-group">
     <label class="govuk-label" style=font-weight:bold for="lump_sum_amount">Lump sum payment amount
-    <span class="form-hint">A single payment, additional to the recurring payments</span>
+    <span class="form-hint">A single payment, additional to the regular payments</span>
     </label><br/>
     <%= number_field_tag(:lump_sum_amount, @agreement.initial_payment_amount, { class: 'form-control', required: true, min: 1, max: @tenancy.current_balance, placeholder: '£', step: 0.01 }) %>
   </div>

--- a/app/views/agreements/form/_agreement_informal.html.erb
+++ b/app/views/agreements/form/_agreement_informal.html.erb
@@ -3,19 +3,19 @@
     <label class="govuk-label" style=font-weight:bold for="lump_sum_amount">Lump sum payment amount
     <span class="form-hint">A single payment, additional to the regular payments</span>
     </label><br/>
-    <%= number_field_tag(:lump_sum_amount, @agreement.initial_payment_amount, { class: 'form-control', required: true, min: 1, max: @tenancy.current_balance, placeholder: '£', step: 0.01 }) %>
+    <%= number_field_tag(:initial_payment_amount, @agreement.initial_payment_amount, { class: 'form-control', required: true, min: 1, max: @tenancy.current_balance, placeholder: '£', step: 0.01 }) %>
   </div>
 
   <div class="form-group">
     <label class="govuk-date-field" for="lump_sum_date"><strong>Lump sum payment date</strong><br/></label>
-    <%= date_field_tag :lump_sum_date, @agreement.initial_payment_date, class: 'form-control' %>
+    <%= date_field_tag :initial_payment_date, @agreement.initial_payment_date, class: 'form-control' %>
   </div>
   <hr>
 <% end %>
 
 <div class="form-group">
   <label class="govuk-label" for="frequency"><strong>Frequency of payments</strong><br/></label>
-  <%= select_tag(:frequency, options_for_select(frequency_of_payments, @agreement.frequency), { :class => 'form-control', id: 'frequency_selector' }) %>
+  <%= select_tag(:frequency, options_for_select(frequency_of_payments, @agreement.frequency&.downcase), { :class => 'form-control', id: 'frequency_selector' }) %>
 </div>
 
 <div class="form-group">

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -41,7 +41,7 @@
     var arrears = '<%= formal_agreement ? @court_cases.last.balance_on_court_outcome_date : @tenancy.current_balance %>';
     var frequency = document.getElementById("frequency_selector").value;
     var amount = document.getElementById("amount").value;
-    var lump_sum_amount = document.getElementById("lump_sum_amount") ? document.getElementById("lump_sum_amount").value : 0;
+    var lump_sum_amount = document.getElementById("initial_payment_amount") ? document.getElementById("initial_payment_amount").value : 0;
     document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount, lump_sum_amount);
   }
 
@@ -59,8 +59,8 @@
     updateEndDate()
   });
 
-  if(document.getElementById("lump_sum_amount")) {
-    document.getElementById("lump_sum_amount").addEventListener('change', (event) => {
+  if(document.getElementById("initial_payment_amount")) {
+    document.getElementById("initial_payment_amount").addEventListener('change', (event) => {
       updateEndDate()
     });
   }

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -41,7 +41,8 @@
     var arrears = '<%= formal_agreement ? @court_cases.last.balance_on_court_outcome_date : @tenancy.current_balance %>';
     var frequency = document.getElementById("frequency_selector").value;
     var amount = document.getElementById("amount").value;
-    document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount);
+    var lump_sum_amount = document.getElementById("lump_sum_amount") ? document.getElementById("lump_sum_amount").value : 0;
+    document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount, lump_sum_amount);
   }
 
   document.getElementById("amount").addEventListener('change', (event) => {
@@ -57,4 +58,11 @@
     document.getElementById('frequency_label').textContent = frequency_label.charAt(0).toUpperCase() + frequency_label.slice(1) + " instalment amount";
     updateEndDate()
   });
+
+  if(document.getElementById("lump_sum_amount")) {
+    document.getElementById("lump_sum_amount").addEventListener('change', (event) => {
+      updateEndDate()
+    });
+  }
+
 </script>

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -22,6 +22,7 @@
 <div class="grid-row">
   <div class="column-full">
     <%= form_tag('create', method: :post) do %>
+    <%= hidden_field_tag :payment_type, @payment_type %>
       <% if formal_agreement %>
         <%= hidden_field_tag :agreement_type, 'formal' %>
         <%= render :partial => "agreements/form/agreement_formal" %>

--- a/app/views/agreements/payment_type.html.erb
+++ b/app/views/agreements/payment_type.html.erb
@@ -1,0 +1,40 @@
+<% content_for :title do %><%= @tenancy_ref %> - Create agreement<% end %>
+
+<div class="grid-row">
+  <div class="column-full">
+    <%= link_to('Return to case profile', tenancy_path(id: @tenancy_ref), class: 'link--back') %>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <% formal_agreement = @court_cases.present? && @court_cases.last.terms %>
+    <% title = formal_agreement ? 'Create court agreement' : 'Create informal agreement' %>
+    <h1><%= title %></h1>
+    <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
+    <hr>
+  </div>
+</div>
+
+<%= form_tag('set_payment_type', method: :post) do %>
+  <div class="form-group">
+    <fieldset>
+      <legend>
+        <h2>Choose the payment type of the agreement</h2>
+      </legend>
+      <div class="multiple-choice">
+        <%= radio_button_tag :payment_type, :recurring %>
+        <label for="payment_type_recurring">Recurring payment
+        <span class="form-hint">For example, Weekly/Monthly payments</span>
+        </label>
+      </div>
+      <div class="multiple-choice">
+        <%= radio_button_tag :payment_type, :variable %>
+        <label for="payment_type_variable">Variable payment
+        <span class="form-hint">A single lump-sum payment followed by recurring payments</span>
+        </label>
+      </div>
+    </fieldset>
+  </div>
+  <%= submit_tag 'Continue', class: 'button' %>
+<% end %>

--- a/app/views/agreements/payment_type.html.erb
+++ b/app/views/agreements/payment_type.html.erb
@@ -23,15 +23,15 @@
         <h2>Choose the payment type of the agreement</h2>
       </legend>
       <div class="multiple-choice">
-        <%= radio_button_tag :payment_type, :recurring %>
-        <label for="payment_type_recurring">Recurring payment
+        <%= radio_button_tag :payment_type, :regular %>
+        <label for="payment_type_regular">Regular payment
         <span class="form-hint">For example, Weekly/Monthly payments</span>
         </label>
       </div>
       <div class="multiple-choice">
         <%= radio_button_tag :payment_type, :variable %>
         <label for="payment_type_variable">Variable payment
-        <span class="form-hint">A single lump-sum payment followed by recurring payments</span>
+        <span class="form-hint">A single lump-sum payment followed by regular payments</span>
         </label>
       </div>
     </fieldset>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
   post '/feature-flags/:feature_name/activate', to: 'feature_flags#activate', as: :activate_feature_flag
   post '/feature-flags/:feature_name/deactivate', to: 'feature_flags#deactivate', as: :deactivate_feature_flag
 
+  get '/tenancies/:tenancy_ref/agreement/new/payment_type', to: 'agreements#payment_type', as: :agreement_payment_type
+  post '/tenancies/:tenancy_ref/agreement/new/set_payment_type', to: 'agreements#set_payment_type', as: :set_agreement_payment_type
   get '/tenancies/:tenancy_ref/agreement/new', to: 'agreements#new', as: :new_agreement
   post '/tenancies/:tenancy_ref/agreement/create', to: 'agreements#create', as: :create_agreement
   get '/tenancies/:tenancy_ref/agreement/:id/show', to: 'agreements#show', as: :show_agreement

--- a/lib/hackney/income/agreements_gateway.rb
+++ b/lib/hackney/income/agreements_gateway.rb
@@ -9,7 +9,7 @@ module Hackney
         @api_key = api_key
       end
 
-      def create_agreement(tenancy_ref:, agreement_type:, frequency:, amount:, start_date:, created_by:, notes:, court_case_id:)
+      def create_agreement(tenancy_ref:, agreement_type:, frequency:, amount:, start_date:, created_by:, notes:, court_case_id:, initial_payment_amount:, initial_payment_date:)
         body_data = {
           agreement_type: agreement_type,
           frequency: frequency,
@@ -17,7 +17,9 @@ module Hackney
           start_date: start_date,
           created_by: created_by,
           notes: notes,
-          court_case_id: court_case_id
+          court_case_id: court_case_id,
+          initial_payment_amount: initial_payment_amount,
+          initial_payment_date: initial_payment_date
         }.to_json
 
         uri = URI.parse("#{@api_host}/v1/agreement/#{ERB::Util.url_encode(tenancy_ref)}/")

--- a/lib/hackney/income/create_agreement.rb
+++ b/lib/hackney/income/create_agreement.rb
@@ -5,7 +5,7 @@ module Hackney
         @agreement_gateway = agreement_gateway
       end
 
-      def execute(tenancy_ref:, agreement_type:, frequency:, amount:, start_date:, created_by:, notes:, court_case_id:)
+      def execute(tenancy_ref:, agreement_type:, frequency:, amount:, start_date:, created_by:, notes:, court_case_id:, initial_payment_amount:, initial_payment_date:)
         @agreement_gateway.create_agreement(
           tenancy_ref: tenancy_ref,
           agreement_type: agreement_type,
@@ -14,7 +14,9 @@ module Hackney
           start_date: start_date,
           created_by: created_by,
           notes: notes,
-          court_case_id: court_case_id
+          court_case_id: court_case_id,
+          initial_payment_amount: initial_payment_amount,
+          initial_payment_date: initial_payment_date
         )
       end
     end

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -21,6 +21,8 @@ module Hackney
           @start_date = attributes[:start_date].nil? ? (Date.today + 1.day).to_s : attributes[:start_date]
           @notes = attributes[:notes]
           @court_case_id = attributes[:court_case_id]
+          @initial_payment_amount = attributes[:initial_payment_amount]
+          @initial_payment_date = attributes[:initial_payment_date]
         end
 
         def start_date_display_date

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -23,8 +23,9 @@ describe 'Create Formal agreement' do
 
     when_i_visit_a_tenancy_with_arrears
     and_i_create_a_court_case_with_an_outcome_with_terms
-    then_i_should_see_create_agreement_page
-    then_i_should_see_the_starting_balance_field
+    then_i_am_asked_to_select_the_payment_type_of_the_agreement
+    and_i_should_see_create_agreement_page
+    and_i_should_see_the_starting_balance_field
 
     when_i_fill_in_the_agreement_details
     and_i_click_on_create
@@ -57,7 +58,12 @@ describe 'Create Formal agreement' do
     click_button 'Add outcome'
   end
 
-  def then_i_should_see_create_agreement_page
+  def then_i_am_asked_to_select_the_payment_type_of_the_agreement
+    choose('payment_type_recurring')
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_create_agreement_page
     expect(page).to have_content('Create court agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
     expect(page).to have_content('Court case related to this agreement')
@@ -71,7 +77,7 @@ describe 'Create Formal agreement' do
     expect(page).to have_content('Notes')
   end
 
-  def then_i_should_see_the_starting_balance_field
+  def and_i_should_see_the_starting_balance_field
     expect(page).to have_field('starting_balance', disabled: true)
     expect(find_field('starting_balance', disabled: true).value).to eq '1000'
   end

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -137,8 +137,9 @@ describe 'Create Formal agreement' do
       start_date: '12/12/2020',
       created_by: 'Hackney User',
       notes: 'Wen Ting is the master of rails',
-      court_case_id: '12'
-
+      court_case_id: '12',
+      initial_payment_amount: nil,
+      initial_payment_date: nil
     }.to_json
 
     response_json = {

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -59,7 +59,7 @@ describe 'Create Formal agreement' do
   end
 
   def then_i_am_asked_to_select_the_payment_type_of_the_agreement
-    choose('payment_type_recurring')
+    choose('payment_type_regular')
     click_button 'Continue'
   end
 

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -128,8 +128,8 @@ describe 'Create informal agreement' do
   end
 
   def and_i_fill_in_the_lump_sum_payment_details
-    fill_in 'lump_sum_amount', with: '80'
-    fill_in 'lump_sum_date', with: '12/12/2020'
+    fill_in 'initial_payment_amount', with: '80'
+    fill_in 'initial_payment_date', with: '12/12/2020'
   end
 
   def then_i_should_see_the_new_variable_payment_agreement_page

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -21,6 +21,7 @@ describe 'Create informal agreement' do
 
     when_i_visit_a_tenancy_with_arrears
     and_i_click_on_create_agreement
+    and_i_select_recurring_payment_agreement
     then_i_should_see_create_agreement_page
 
     when_i_fill_in_the_agreement_details
@@ -56,6 +57,11 @@ describe 'Create informal agreement' do
 
   def and_i_click_on_create_agreement
     click_link 'Create agreement'
+  end
+
+  def and_i_select_recurring_payment_agreement
+    choose('payment_type_recurring')
+    click_button 'Continue'
   end
 
   def then_i_should_see_create_agreement_page

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -22,7 +22,7 @@ describe 'Create informal agreement' do
 
     when_i_visit_a_tenancy_with_arrears
     and_i_click_on_create_agreement
-    and_i_select_recurring_payment_agreement
+    and_i_select_regular_payment_agreement
     then_i_should_see_create_agreement_page
     and_i_should_not_see_the_lump_sum_payment_fields
 
@@ -73,8 +73,8 @@ describe 'Create informal agreement' do
     click_link 'Create agreement'
   end
 
-  def and_i_select_recurring_payment_agreement
-    choose('payment_type_recurring')
+  def and_i_select_regular_payment_agreement
+    choose('payment_type_regular')
     click_button 'Continue'
   end
 

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -11,6 +11,7 @@ describe 'Create informal agreement' do
     stub_tenancy_api_actions
     stub_tenancy_api_tenancy
     stub_create_agreement_response
+    stub_cancel_and_create_agreement_response
     stub_view_agreements_response
     stub_cancel_agreement_response
     stub_view_court_cases_responses
@@ -23,10 +24,23 @@ describe 'Create informal agreement' do
     and_i_click_on_create_agreement
     and_i_select_recurring_payment_agreement
     then_i_should_see_create_agreement_page
+    and_i_should_not_see_the_lump_sum_payment_fields
 
     when_i_fill_in_the_agreement_details
     and_i_click_on_create
     then_i_should_see_the_agreement_page
+    and_i_can_see_a_button_to_send_agreement_confirmation_letter
+
+    when_i_click_to_cancel_and_create_a_new_agreement
+    and_i_select_variable_payment_agreement
+    then_i_should_see_create_agreement_page
+    and_i_should_see_the_lump_sum_payment_fields
+
+    when_i_fill_in_the_agreement_details
+    and_i_fill_in_the_lump_sum_payment_details
+    and_i_click_on_create
+    then_i_should_see_the_new_variable_payment_agreement_page
+    and_i_can_see_the_lump_sum_payment_details
     and_i_can_see_a_button_to_send_agreement_confirmation_letter
 
     when_i_click_link_to_go_back_to_case_profile
@@ -75,6 +89,11 @@ describe 'Create informal agreement' do
     expect(page).to have_content('Notes')
   end
 
+  def and_i_should_not_see_the_lump_sum_payment_fields
+    expect(page).not_to have_content('Lump sum payment amount')
+    expect(page).not_to have_content('Lump sum payment date')
+  end
+
   def when_i_fill_in_the_agreement_details
     select('Weekly', from: 'frequency')
     fill_in 'amount', with: '50'
@@ -92,6 +111,34 @@ describe 'Create informal agreement' do
 
   def and_i_can_see_a_button_to_send_agreement_confirmation_letter
     expect(page).to have_button('Send agreement confirmation letter')
+  end
+
+  def when_i_click_to_cancel_and_create_a_new_agreement
+    click_link 'Cancel and create new'
+  end
+
+  def and_i_select_variable_payment_agreement
+    choose('payment_type_variable')
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_the_lump_sum_payment_fields
+    expect(page).to have_content('Lump sum payment amount')
+    expect(page).to have_content('Lump sum payment date')
+  end
+
+  def and_i_fill_in_the_lump_sum_payment_details
+    fill_in 'lump_sum_amount', with: '80'
+    fill_in 'lump_sum_date', with: '12/12/2020'
+  end
+
+  def then_i_should_see_the_new_variable_payment_agreement_page
+    expect(page).to have_current_path(show_agreement_path(tenancy_ref: '1234567/01', id: '13'))
+  end
+
+  def and_i_can_see_the_lump_sum_payment_details
+    expect(page).to have_content('Lump sum payment amount: £80.0')
+    expect(page).to have_content('Lump sum payment date: December 12th, 2020')
   end
 
   def when_i_click_link_to_go_back_to_case_profile
@@ -113,7 +160,7 @@ describe 'Create informal agreement' do
   end
 
   def and_i_should_see_a_link_to_view_details
-    expect(page).to have_link(href: '/tenancies/1234567%2F01/agreement/12/show')
+    expect(page).to have_link(href: '/tenancies/1234567%2F01/agreement/13/show')
   end
 
   def and_i_should_see_a_link_to_view_history
@@ -126,7 +173,7 @@ describe 'Create informal agreement' do
 
   def and_i_should_see_the_agreement_status
     expect(page).to have_content('Status Live')
-    expect(page).to have_content('End date December 26th, 2020')
+    expect(page).to have_content('End date December 12th, 2020')
     expect(page).to have_content("Current balance\n£53.57")
     expect(page).to have_content("Expected balance\n£53.57")
     expect(page).to have_content('Last checked')
@@ -187,7 +234,9 @@ describe 'Create informal agreement' do
       start_date: '12/12/2020',
       created_by: 'Hackney User',
       notes: 'Wen Ting is the master of rails',
-      court_case_id: nil
+      court_case_id: nil,
+      initial_payment_amount: nil,
+      initial_payment_date: nil
     }.to_json
 
     response_json = {
@@ -202,6 +251,52 @@ describe 'Create informal agreement' do
       "createdAt": '2020-06-19',
       "createdBy": 'Hackney User',
       "lastChecked": '2020-06-19',
+      "history": [
+        {
+          "state": 'live',
+          "date": '2020-06-19',
+          "expectedBalance": '103.57',
+          "checkedBalance": '103.57',
+          "description": 'Agreement created'
+        }
+      ]
+    }.to_json
+
+    stub_request(:post, 'https://example.com/income/api/v1/agreement/1234567%2F01/')
+         .with(
+           body: request_body_json,
+           headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
+         )
+         .to_return(status: 200, body: response_json, headers: {})
+  end
+
+  def stub_cancel_and_create_agreement_response
+    request_body_json = {
+      agreement_type: 'informal',
+      frequency: 'weekly',
+      amount: '50',
+      start_date: '12/12/2020',
+      created_by: 'Hackney User',
+      notes: 'Wen Ting is the master of rails',
+      court_case_id: nil,
+      initial_payment_amount: '80',
+      initial_payment_date: '12/12/2020'
+    }.to_json
+
+    response_json = {
+      "id": 13,
+      "tenancyRef": '1234567/01',
+      "agreementType": 'informal',
+      "startingBalance": '103.57',
+      "amount": '50',
+      "startDate": '2020-12-12',
+      "frequency": 'weekly',
+      "currentState": 'live',
+      "createdAt": '2020-06-19',
+      "createdBy": 'Hackney User',
+      "lastChecked": '2020-06-19',
+      "initialPaymentAmount": '80',
+      "initialPaymentDate": '2020-12-12',
       "history": [
         {
           "state": 'live',
@@ -259,11 +354,49 @@ describe 'Create informal agreement' do
         ]
       }.to_json
 
+    response_with_live_variable_payment_agreement_json =
+      {
+        "agreements": [
+          {
+            "id": 13,
+            "tenancyRef": '1234567/01',
+            "agreementType": 'informal',
+            "startingBalance": '103.57',
+            "amount": '50',
+            "startDate": '2020-12-12',
+            "frequency": 'weekly',
+            "currentState": 'live',
+            "createdAt": '2020-06-19',
+            "createdBy": 'Hackney User',
+            "lastChecked": '2020-07-19',
+            "notes": 'Wen Ting is the master of rails',
+            "initialPaymentAmount": '80',
+            "initialPaymentDate": '2020-12-12',
+            "history": [
+              {
+                "state": 'live',
+                "date": '2020-06-19',
+                "expectedBalance": '103.57',
+                "checkedBalance": '103.57',
+                "description": 'Agreement created'
+              },
+              {
+                "state": 'live',
+                "date": '2020-07-19',
+                "expectedBalance": '53.57',
+                "checkedBalance": '53.57',
+                "description": 'Checked by the system'
+              }
+            ]
+          }
+        ]
+      }.to_json
+
     response_with_cancelled_agreement_json =
       {
         "agreements": [
           {
-            "id": 12,
+            "id": 13,
             "tenancyRef": '1234567/01',
             "agreementType": 'informal',
             "startingBalance": '103.57',
@@ -307,13 +440,14 @@ describe 'Create informal agreement' do
       )
       .to_return({ status: 200, body: response_with_no_agreements_json },
                  { status: 200, body: response_with_live_agreement_json },
-                 { status: 200, body: response_with_live_agreement_json },
-                 { status: 200, body: response_with_live_agreement_json },
+                 { status: 200, body: response_with_live_variable_payment_agreement_json },
+                 { status: 200, body: response_with_live_variable_payment_agreement_json },
+                 { status: 200, body: response_with_live_variable_payment_agreement_json },
                  status: 200, body: response_with_cancelled_agreement_json)
   end
 
   def stub_cancel_agreement_response
-    stub_request(:post, 'https://example.com/income/api/v1/agreements/12/cancel')
+    stub_request(:post, 'https://example.com/income/api/v1/agreements/13/cancel')
          .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
          .to_return(status: 200, headers: {})
   end

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -205,7 +205,7 @@ describe 'Create court case' do
   end
 
   def then_i_am_asked_to_select_the_payment_type_of_the_agreement
-    choose('payment_type_recurring')
+    choose('payment_type_regular')
     click_button 'Continue'
   end
 

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -59,7 +59,8 @@ describe 'Create court case' do
     and_im_asked_to_select_terms_and_disrepair_counter_claim
     and_i_choose_yes_for_terms_and_no_for_disrepair_counter_claim
     and_i_click_add_outcome
-    then_i_should_see_create_agreement_page
+    then_i_am_asked_to_select_the_payment_type_of_the_agreement
+    and_i_should_see_create_agreement_page
   end
 
   def when_i_visit_a_tenancy_with_arrears
@@ -203,7 +204,12 @@ describe 'Create court case' do
     choose('disrepair_counter_claim_No')
   end
 
-  def then_i_should_see_create_agreement_page
+  def then_i_am_asked_to_select_the_payment_type_of_the_agreement
+    choose('payment_type_recurring')
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_create_agreement_page
     expect(page).to have_content('Create court agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
     expect(page).to have_content('Court case related to this agreement')

--- a/spec/lib/hackney/income/agreement_gateway_spec.rb
+++ b/spec/lib/hackney/income/agreement_gateway_spec.rb
@@ -13,6 +13,8 @@ describe Hackney::Income::AgreementsGateway do
         start_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
         created_by: Faker::Name.name,
         notes: Faker::ChuckNorris.fact,
+        initial_payment_amount: Faker::Commerce.price(range: 10...100),
+        initial_payment_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
         court_case_id: nil
       }
     end
@@ -25,7 +27,9 @@ describe Hackney::Income::AgreementsGateway do
         start_date: request_params.fetch(:start_date),
         created_by: request_params.fetch(:created_by),
         notes: request_params.fetch(:notes),
-        court_case_id: request_params.fetch(:court_case_id)
+        court_case_id: request_params.fetch(:court_case_id),
+        initial_payment_amount: request_params.fetch(:initial_payment_amount),
+        initial_payment_date: request_params.fetch(:initial_payment_date)
       }.to_json
     end
 

--- a/spec/lib/hackney/income/create_agreement_spec.rb
+++ b/spec/lib/hackney/income/create_agreement_spec.rb
@@ -11,7 +11,9 @@ describe Hackney::Income::CreateAgreement do
       start_date: Faker::Date.between(from: 2.days.ago, to: Date.today),
       created_by: Faker::Name.name,
       notes: Faker::ChuckNorris.fact,
-      court_case_id: nil
+      court_case_id: nil,
+      initial_payment_amount: nil,
+      initial_payment_date: nil
     }
   end
 


### PR DESCRIPTION
## Context
As a caseworker, I want to be able to create agreements with variable payments, so I enter an initial lump-sum payment in addition to the recurring payments

## Changes in this pull request
- Ask for the payment type when creating a new agreement
- Update agreement gateway to allow creating variable payment agreement
- Update create agreement use case to allow creating variable agreements
- Allow creating variable payment agreement
- Add hint texts to agreement fields
- Add lump sum field to the JS that calls the end date calculator

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
### After
![image](https://user-images.githubusercontent.com/22743709/92713875-63c65980-f353-11ea-9bf6-52b63adeeceb.png)

![image](https://user-images.githubusercontent.com/22743709/92713989-86587280-f353-11ea-9a7c-fe017c0dd978.png)

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-464

## Things to check
- [x] Environment variables have been updated
