### PR TITLE
Allow creating one off payment agreements

### DIFF
--- a/app/views/agreements/form/_agreement.html.erb
+++ b/app/views/agreements/form/_agreement.html.erb
@@ -1,0 +1,60 @@
+<div class="grid-row">
+  <div class="column-full">
+    <% formal_agreement = @court_cases.present? && @court_cases.last.result_in_agreement? %>
+    <% title = formal_agreement ? 'Create court agreement' : 'Create informal agreement' %>
+    <h1><%= title %></h1>
+    <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
+    <% if !formal_agreement %>
+      <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
+    <% end %>
+    <hr>
+  </div>
+</div>
+
+<div class="grid-row">
+  <div class="column-full">
+    <%= form_tag('create', method: :post) do %>
+    <%= hidden_field_tag :payment_type, @payment_type %>
+      <% if formal_agreement %>
+        <%= hidden_field_tag :agreement_type, 'formal' %>
+        <%= render :partial => "agreements/form/agreement_formal" %>
+      <% else %>
+        <%= hidden_field_tag :agreement_type, 'informal' %>
+        <%= render :partial => "agreements/form/agreement_informal" %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
+<script type="text/javascript">
+  function updateEndDate() {
+    var start_date = document.getElementById("start_date").value;
+    var arrears = '<%= formal_agreement ? @court_cases.last.balance_on_court_outcome_date : @tenancy.current_balance %>';
+    var frequency = document.getElementById("frequency_selector").value;
+    var amount = document.getElementById("amount").value;
+    var lump_sum_amount = document.getElementById("initial_payment_amount") ? document.getElementById("initial_payment_amount").value : 0;
+    document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount, lump_sum_amount);
+  }
+
+  document.getElementById("amount").addEventListener('change', (event) => {
+    updateEndDate()
+  });
+
+  document.getElementById("start_date").addEventListener('change', (event) => {
+    updateEndDate()
+  });
+
+  document.getElementById("frequency_selector").addEventListener('change', (event) => {
+    var frequency_label = document.getElementById("frequency_selector").value;
+    document.getElementById('frequency_label').textContent = frequency_label.charAt(0).toUpperCase() + frequency_label.slice(1) + " instalment amount";
+    updateEndDate()
+  });
+
+  if(document.getElementById("initial_payment_amount")) {
+    document.getElementById("initial_payment_amount").addEventListener('change', (event) => {
+      updateEndDate()
+    });
+  }
+
+</script>

--- a/app/views/agreements/form/_agreement_informal.html.erb
+++ b/app/views/agreements/form/_agreement_informal.html.erb
@@ -8,7 +8,7 @@
 
   <div class="form-group">
     <label class="govuk-date-field" for="lump_sum_date"><strong>Lump sum payment date</strong><br/></label>
-    <%= date_field_tag :initial_payment_date, @agreement.initial_payment_date, class: 'form-control' %>
+    <%= date_field_tag :initial_payment_date, @agreement.initial_payment_date, required: true, class: 'form-control' %>
   </div>
   <hr>
 <% end %>
@@ -27,7 +27,7 @@
   <label class="govuk-date-field" for="start_date"><strong>Start date</strong><br/>
   <span class="form-hint">The first payment date</span>
   </label>
-  <%= date_field_tag :start_date, @agreement.start_date, class: 'form-control' %>
+  <%= date_field_tag :start_date, @agreement.start_date, required: true, class: 'form-control' %>
 </div>
 
 <div class="form-group">

--- a/app/views/agreements/form/_one_off_payment_agreement.html.erb
+++ b/app/views/agreements/form/_one_off_payment_agreement.html.erb
@@ -1,0 +1,32 @@
+<div class="grid-row">
+  <div class="column-full">
+    <% formal_agreement = @court_cases.present? && @court_cases.last.result_in_agreement? %>
+    <% title = formal_agreement ? 'Create court agreement' : 'Create informal agreement' %>
+    <h1><%= title %></h1>
+    <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
+    <hr>
+
+    <%= form_tag('create', method: :post) do %>
+    <%= hidden_field_tag :agreement_type, formal_agreement ? 'formal' : 'informal' %>
+    <%= hidden_field_tag :payment_type, @payment_type %>
+    <%= hidden_field_tag :frequency, :one_off %>
+      <div class="form-group">
+        <% hint_text = formal_agreement ? 'This is the balance on the court outcome date' : 'This is the total arrears balance owed'%>
+        <label class="govuk-label" style="font-weight:bold" for="starting_balance" id="starting_balance_label">Payment Amount
+        <span class="form-hint"><%= hint_text %></span>
+        </label><br/>
+        <% balance = formal_agreement ? @court_cases.last.balance_on_court_outcome_date : @tenancy.current_balance %>
+        <%= number_field_tag :starting_balance, balance, { class: 'form-control', required: true, disabled: true} %>
+        <%= hidden_field_tag :amount, balance %>
+      </div>
+      <div class="form-group">
+        <label class="govuk-date-field" for="start_date"><strong>Payment date</strong><br/></label>
+        <%= date_field_tag :start_date, @agreement.start_date, required: true, class: 'form-control' %>
+        
+      </div>
+
+      <%= submit_tag 'Create', class: 'button' %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/agreements/new.html.erb
+++ b/app/views/agreements/new.html.erb
@@ -6,63 +6,9 @@
   </div>
 </div>
 
-<div class="grid-row">
-  <div class="column-full">
-    <% formal_agreement = @court_cases.present? && @court_cases.last.terms %>
-    <% title = formal_agreement ? 'Create court agreement' : 'Create informal agreement' %>
-    <h1><%= title %></h1>
-    <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
-    <% if !formal_agreement %>
-      <label class="govuk-label"><strong>Total arrears balance owed: </strong><%= number_to_currency(@tenancy.current_balance, unit: '£') %><br/></label>
-    <% end %>
-    <hr>
-  </div>
-</div>
-
-<div class="grid-row">
-  <div class="column-full">
-    <%= form_tag('create', method: :post) do %>
-    <%= hidden_field_tag :payment_type, @payment_type %>
-      <% if formal_agreement %>
-        <%= hidden_field_tag :agreement_type, 'formal' %>
-        <%= render :partial => "agreements/form/agreement_formal" %>
-      <% else %>
-        <%= hidden_field_tag :agreement_type, 'informal' %>
-        <%= render :partial => "agreements/form/agreement_informal" %>
-      <% end %>
-  <% end %>
-  </div>
-</div>
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment.js"></script>
-<script type="text/javascript">
-  function updateEndDate() {
-    var start_date = document.getElementById("start_date").value;
-    var arrears = '<%= formal_agreement ? @court_cases.last.balance_on_court_outcome_date : @tenancy.current_balance %>';
-    var frequency = document.getElementById("frequency_selector").value;
-    var amount = document.getElementById("amount").value;
-    var lump_sum_amount = document.getElementById("initial_payment_amount") ? document.getElementById("initial_payment_amount").value : 0;
-    document.getElementById('end_date_value').textContent = window.EndDateCalculator(arrears, start_date, frequency, amount, lump_sum_amount);
-  }
-
-  document.getElementById("amount").addEventListener('change', (event) => {
-    updateEndDate()
-  });
-
-  document.getElementById("start_date").addEventListener('change', (event) => {
-    updateEndDate()
-  });
-
-  document.getElementById("frequency_selector").addEventListener('change', (event) => {
-    var frequency_label = document.getElementById("frequency_selector").value;
-    document.getElementById('frequency_label').textContent = frequency_label.charAt(0).toUpperCase() + frequency_label.slice(1) + " instalment amount";
-    updateEndDate()
-  });
-
-  if(document.getElementById("initial_payment_amount")) {
-    document.getElementById("initial_payment_amount").addEventListener('change', (event) => {
-      updateEndDate()
-    });
-  }
-
-</script>
+<%= hidden_field_tag :payment_type, @payment_type %>
+<% if @payment_type == 'one_off' %>
+  <%= render :partial => "agreements/form/one_off_payment_agreement" %>
+<% else %>
+  <%= render :partial => "agreements/form/agreement" %>
+<%end%>

--- a/app/views/agreements/payment_type.html.erb
+++ b/app/views/agreements/payment_type.html.erb
@@ -8,7 +8,7 @@
 
 <div class="grid-row">
   <div class="column-full">
-    <% formal_agreement = @court_cases.present? && @court_cases.last.terms %>
+    <% formal_agreement = @court_cases.present? && @court_cases.last.result_in_agreement? %>
     <% title = formal_agreement ? 'Create court agreement' : 'Create informal agreement' %>
     <h1><%= title %></h1>
     <label class="govuk-label"><strong>Agreement for: </strong><%= @tenancy.primary_contact_name %><br/></label>
@@ -32,6 +32,12 @@
         <%= radio_button_tag :payment_type, :variable %>
         <label for="payment_type_variable">Variable payment
         <span class="form-hint">A single lump-sum payment followed by regular payments</span>
+        </label>
+      </div>
+      <div class="multiple-choice">
+        <%= radio_button_tag :payment_type, :one_off %>
+        <label for="payment_type_one_off">One off payment
+        <span class="form-hint">A single lump-sum payment</span>
         </label>
       </div>
     </fieldset>

--- a/app/views/agreements/show.html.erb
+++ b/app/views/agreements/show.html.erb
@@ -20,23 +20,30 @@
         <div class="column-full">
           <ul>
             <li><h2><%= 'Agreement details' %></h2></li>
-            <li><strong>Starting balance: </strong> <%= number_to_currency(@agreement.starting_balance, unit: '£') %></li>
-            <br/>
-            <% if @agreement.variable_payment? %>
-              <li><strong>Lump sum payment amount: </strong><br> <%= number_to_currency(@agreement.initial_payment_amount, unit: '£') %></li>
-              <li><strong>Lump sum payment date:</strong> <%= format_date(@agreement.initial_payment_date) %></li>
+            <% if @agreement.one_off_payment? %>
+              <li><strong>One off payment</strong></li>
               <br/>
-            <% end %>
-            <li><strong>Frequency of payment: </strong><br> <%= @agreement.frequency.humanize %></li>
-            <li><strong>Instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
-            <br/>
-            <li><strong>Start date: </strong> <%= format_date(@agreement.start_date) %></li>
-            <li><strong>End date: </strong><%= show_end_date(total_arrears: @agreement.starting_balance,
-                                                             start_date: @agreement.start_date, 
-                                                             frequency: @agreement.frequency,
-                                                             amount: @agreement.amount,
-                                                             initial_payment_amount: @agreement.initial_payment_amount) %>
-            </li>
+              <li><strong>Payment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
+              <li><strong>Payment date: </strong> <%= format_date(@agreement.start_date) %></li>
+            <% else %>
+              <li><strong>Starting balance: </strong> <%= number_to_currency(@agreement.starting_balance, unit: '£') %></li>
+              <br/>
+              <% if @agreement.variable_payment? %>
+                <li><strong>Lump sum payment amount: </strong><br> <%= number_to_currency(@agreement.initial_payment_amount, unit: '£') %></li>
+                <li><strong>Lump sum payment date:</strong> <%= format_date(@agreement.initial_payment_date) %></li>
+                <br/>
+              <% end %>
+              <li><strong>Frequency of payment: </strong><br> <%= @agreement.frequency.humanize %></li>
+              <li><strong>Instalment amount:</strong> <%= number_to_currency(@agreement.amount, unit: '£') %></li>
+              <br/>
+              <li><strong>Start date: </strong> <%= format_date(@agreement.start_date) %></li>
+              <li><strong>End date: </strong><%= show_end_date(total_arrears: @agreement.starting_balance,
+                                                              start_date: @agreement.start_date, 
+                                                              frequency: @agreement.frequency,
+                                                              amount: @agreement.amount,
+                                                              initial_payment_amount: @agreement.initial_payment_amount) %>
+              </li>
+            <% end %> 
           </ul>
         </div>
     </div>

--- a/lib/hackney/income/domain/agreement.rb
+++ b/lib/hackney/income/domain/agreement.rb
@@ -48,6 +48,10 @@ module Hackney
         def variable_payment?
           initial_payment_amount.present?
         end
+
+        def one_off_payment?
+          frequency == 'one_off'
+        end
       end
     end
   end

--- a/lib/hackney/income/domain/court_case.rb
+++ b/lib/hackney/income/domain/court_case.rb
@@ -28,6 +28,10 @@ module Hackney
           @court_outcome = attributes[:court_outcome]
         end
 
+        def result_in_agreement?
+          terms.present? && !expired?
+        end
+
         def expired?
           return true if struck_out?
           return true if end_of_life?


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
As a caseworker, I want to be able to create agreements with a one-off payment, so when a tenant is able to pay off all their arrears on the given date, I don't need to monitor whether they paid or not.

## Changes in this pull request
- Fix bug that allows creating court agreements when the latest agreement is "expired"
- Allow creating one-off payment agreement

### After
![image](https://user-images.githubusercontent.com/22743709/93103330-6652e700-f6a4-11ea-9eda-58d640612721.png)

![image](https://user-images.githubusercontent.com/22743709/93108503-c64c8c00-f6aa-11ea-942b-2dd897fc7b1e.png)

![image](https://user-images.githubusercontent.com/22743709/93108561-d9f7f280-f6aa-11ea-9a36-d94d9f2c0cdd.png)

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-483

## Things to check
- [x] Environment variables have been updated
