### PR TITLE
Allow adding court times

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -8,9 +8,8 @@ class CourtCasesController < ApplicationController
   def create
     create_court_case_params = {
       tenancy_ref: tenancy_ref,
-      court_date: params.fetch(:court_date)
+      court_date: court_date
     }
-
     use_cases.create_court_case.execute(create_court_case_params: create_court_case_params)
 
     redirect_to show_success_court_case_path(message: 'Successfully created a new court case')
@@ -22,6 +21,7 @@ class CourtCasesController < ApplicationController
   def edit_court_date
     @tenancy = use_cases.view_tenancy.execute(tenancy_ref: tenancy_ref)
     @court_date = court_case.court_date&.to_date&.strftime('%F')
+    @court_time = court_case.court_date&.to_time&.strftime('%R')
   end
 
   def update_court_date
@@ -131,5 +131,11 @@ class CourtCasesController < ApplicationController
   def to_boolean(param)
     return true if param == 'Yes'
     return false if param == 'No'
+  end
+
+  def court_date
+    court_date = params.fetch(:court_date)
+    court_time = params.fetch(:court_time)
+    "#{court_date} #{court_time}"
   end
 end

--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -27,7 +27,7 @@ class CourtCasesController < ApplicationController
   def update_court_date
     update_court_case_params = {
       id: court_case_id,
-      court_date: params.fetch(:court_date)
+      court_date: court_date
     }
 
     use_cases.update_court_case.execute(court_case_params: update_court_case_params)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,6 +33,12 @@ module ApplicationHelper
     Date.parse(date).to_formatted_s(:long_ordinal)
   end
 
+  def format_time(time)
+    return '' if time.nil?
+
+    DateTime.parse(time).strftime('%R')
+  end
+
   def format_short_date(datetime)
     return '' if datetime.blank?
 

--- a/app/views/court_cases/_court_date_form.html.erb
+++ b/app/views/court_cases/_court_date_form.html.erb
@@ -20,6 +20,11 @@
         <label class="govuk-date-field" for="court_date"><strong>Court date</strong><br/></label>
         <%= date_field_tag :court_date, @court_date, required: true, class: 'form-control' %>
       </div>
+
+      <div class="form-group">
+        <label class="govuk-time-field" for="court_time"><strong>Court hearing time</strong><br/></label>
+        <%= time_field_tag :court_time, @court_time, required: true, class: 'form-control' %>
+      </div>
       
       <%= submit_tag button, class: 'button' %>
     <% end %>

--- a/app/views/court_cases/show.html.erb
+++ b/app/views/court_cases/show.html.erb
@@ -29,7 +29,7 @@
   </div>
   <div class="column-two-thirds">
       <ul>
-        <li><%= format_date(@court_case.court_date) %></li>
+        <li><%= format_date(@court_case.court_date) %> at <%= format_time(@court_case.court_date) %></li>
         <br/>
       </ul>
       <hr>

--- a/app/views/court_cases/show.html.erb
+++ b/app/views/court_cases/show.html.erb
@@ -29,7 +29,10 @@
   </div>
   <div class="column-two-thirds">
       <ul>
-        <li><%= format_date(@court_case.court_date) %> at <%= format_time(@court_case.court_date) %></li>
+        <li>
+          <% court_time_missing = format_time(@court_case.court_date) == '00:00' %>
+          <%= format_date(@court_case.court_date) %> <%= court_time_missing ? '' : "at #{format_time(@court_case.court_date)}" %>
+        </li>
         <br/>
       </ul>
       <hr>

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -49,6 +49,7 @@ describe 'Create Formal agreement' do
   def and_i_create_a_court_case_with_an_outcome_with_terms
     click_link 'Add court date'
     fill_in 'court_date', with: '21/07/2020'
+    fill_in 'court_time', with: '09:00'
     click_button 'Add'
 
     click_link 'Add court outcome'
@@ -66,7 +67,7 @@ describe 'Create Formal agreement' do
         courtCases: [{
                          id: 12,
                          tenancyRef: '1234567/01',
-                         courtDate: '2020-07-21T00:00:00.000Z',
+                         courtDate: '2020-07-21T09:00:00.000Z',
                          courtOutcome: 'ADT',
                          balanceOnCourtOutcomeDate: 1000,
                          strikeOutDate: nil,
@@ -75,7 +76,7 @@ describe 'Create Formal agreement' do
                      }, {
                          id: 13,
                          tenancyRef: '1234567/01',
-                         courtDate: '2020-08-22T00:00:00.000Z',
+                         courtDate: '2020-08-22T09:30:00.000Z',
                          courtOutcome: nil,
                          balanceOnCourtOutcomeDate: nil,
                          strikeOutDate: nil,
@@ -85,11 +86,13 @@ describe 'Create Formal agreement' do
     }.to_json])
 
     court_date = '22/08/2020'
+    court_time = '09:30'
 
-    stub_create_court_case_response(court_date)
+    stub_create_court_case_response("#{court_date} #{court_time}")
 
     click_link 'Cancel and create new court case'
     fill_in 'court_date', with: court_date
+    fill_in 'court_time', with: court_time
     click_button 'Add'
   end
 
@@ -265,7 +268,7 @@ describe 'Create Formal agreement' do
          .to_return(status: 200, headers: {})
   end
 
-  def stub_create_court_case_response(court_date = '21/07/2020')
+  def stub_create_court_case_response(court_date = '21/07/2020 09:00')
     request_body_json = {
       court_date: court_date,
       court_outcome: nil,
@@ -325,7 +328,7 @@ describe 'Create Formal agreement' do
       courtCases: [{
         id: 12,
         tenancyRef: '1234567/01',
-        courtDate: '21/07/2020',
+        courtDate: '21/07/2020 09:00',
         courtOutcome: nil,
         balanceOnCourtOutcomeDate: nil,
         strikeOutDate: nil,
@@ -338,7 +341,7 @@ describe 'Create Formal agreement' do
       courtCases: [{
                     id: 12,
                     tenancyRef: '1234567/01',
-                    courtDate: '2020-07-21T00:00:00.000Z',
+                    courtDate: '2020-07-21T09:00:00.000Z',
                     courtOutcome: 'ADT',
                     balanceOnCourtOutcomeDate: 1000,
                     strikeOutDate: nil,

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -267,7 +267,7 @@ describe 'Create court case' do
 
   def stub_update_court_case_response
     request_body_json = {
-      court_date: '23/07/2020',
+      court_date: '23/07/2020 12:34',
       court_outcome: nil,
       balance_on_court_outcome_date: nil,
       strike_out_date: nil,

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -35,8 +35,8 @@ describe 'Create court case' do
 
     when_i_click_on_edit_court_date
     then_i_should_see_edit_court_date_page
-    and_i_should_see_the_current_curt_date
-    when_i_fill_in_the_new_court_date
+    and_i_should_see_the_current_court_date_info
+    when_i_fill_in_the_new_court_date_and_time
     and_i_click_on_save
 
     then_i_should_see_the_tenancy_page
@@ -80,11 +80,13 @@ describe 'Create court case' do
   def then_i_should_see_add_court_date_page
     expect(page).to have_content('Add court date')
     expect(page).to have_content('Court date')
+    expect(page).to have_content('Court hearing time')
     expect(page).to have_button('Add')
   end
 
   def when_i_fill_in_the_court_date
     fill_in 'court_date', with: '21/07/2020'
+    fill_in 'court_time', with: '11:11'
   end
 
   def and_i_click_on_add
@@ -114,15 +116,18 @@ describe 'Create court case' do
   def then_i_should_see_edit_court_date_page
     expect(page).to have_content('Edit court date')
     expect(page).to have_content('Court date')
+    expect(page).to have_content('Court hearing time')
     expect(page).to have_button('Save')
   end
 
-  def and_i_should_see_the_current_curt_date
+  def and_i_should_see_the_current_court_date_info
     expect(find_field('court_date').value).to eq('2020-07-21')
+    expect(find_field('court_time').value).to eq('11:11')
   end
 
-  def when_i_fill_in_the_new_court_date
+  def when_i_fill_in_the_new_court_date_and_time
     fill_in 'court_date', with: '23/07/2020'
+    fill_in 'court_time', with: '12:34'
   end
 
   def and_i_click_on_save
@@ -168,7 +173,7 @@ describe 'Create court case' do
 
   def and_the_court_case_details
     expect(page).to have_content('Court date')
-    expect(page).to have_content('July 23rd, 2020')
+    expect(page).to have_content('July 23rd, 2020 at 12:34')
     expect(page).to have_content('Court outcome:')
     expect(page).to have_content('Outright Possession (with Date)')
     expect(page).to have_content('Strike out date:')
@@ -233,7 +238,7 @@ describe 'Create court case' do
 
   def stub_create_court_case_response
     request_body_json = {
-      court_date: '21/07/2020',
+      court_date: '21/07/2020 11:11',
       court_outcome: nil,
       balance_on_court_outcome_date: nil,
       strike_out_date: nil,
@@ -244,7 +249,7 @@ describe 'Create court case' do
     response_json = {
       id: 12,
       tenancyRef: '1234567/01',
-      courtDate: '21/07/2020',
+      courtDate: '21/07/2020 11:11',
       courtOutcome: nil,
       balanceOnCourtOutcomeDate: nil,
       strikeOutDate: nil,
@@ -318,7 +323,7 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '21/07/2020',
+          courtDate: '21/07/2020 11:11',
           courtOutcome: nil,
           balanceOnCourtOutcomeDate: nil,
           strikeOutDate: nil,
@@ -332,7 +337,7 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '23/07/2020',
+          courtDate: '23/07/2020 12:34',
           courtOutcome: nil,
           balanceOnCourtOutcomeDate: nil,
           strikeOutDate: nil,
@@ -346,7 +351,7 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '23/07/2020',
+          courtDate: '23/07/2020 12:34',
           courtOutcome: 'OPD',
           balanceOnCourtOutcomeDate: '1000',
           strikeOutDate: '10/07/2024',
@@ -360,7 +365,7 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '23/07/2020',
+          courtDate: '23/07/2020 12:34',
           courtOutcome: 'AGP',
           balanceOnCourtOutcomeDate: '1500',
           strikeOutDate: '10/08/2025',


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow caseworkers to be able to add the time of an upcoming court hearing - this is mainly for it to be used for the Court Date letter.
## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Added field in Court Date form for `court_time`
- Display `court_time` on the Court Case details page

<img src='https://user-images.githubusercontent.com/32230328/93240961-b309f100-f77c-11ea-9e8d-8dec4e8335af.png' height='350px'/>

To do:
- ~~Figure out if Time Zones matter~~ **I think they don't**
  - ~~If I'm currently in BST and add a court date that would be in GMT, will that affect the court time when we are in GMT?~~
  - ~~Is there a way to just ignore Time Zones?~~
  - **I think we don't need to do anything about them, since we just use `strftime` to turn DateTimes into strings and don't do anything with the Time Zones at all.**

- Check if the Court time needs to be displayed anywhere else
- Update CourtDate in API docs

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I realised while going around in circles to find a way to input time that my Rails frontend knowledge isn't so good - so any pointers there would be good!

Let me know if what I've said about Time Zones makes sense!
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-487?atlOrigin=eyJpIjoiNDA2ZTMzYWE4ZDM1NGZmN2E3YTk3NTMwZTQwZmQzNDQiLCJwIjoiaiJ9

## Things to check

- [x] Environment variables have been updated
