### PR TITLE
Remove spooky 'at' when there's no court date

### DIFF
--- a/app/views/court_cases/show.html.erb
+++ b/app/views/court_cases/show.html.erb
@@ -30,7 +30,7 @@
   <div class="column-two-thirds">
       <ul>
         <li>
-          <% court_time_missing = format_time(@court_case.court_date) == '00:00' %>
+          <% court_time_missing = format_time(@court_case.court_date) == '00:00' || format_time(@court_case.court_date) == '' %>
           <%= format_date(@court_case.court_date) %> <%= court_time_missing ? '' : "at #{format_time(@court_case.court_date)}" %>
         </li>
         <br/>


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When a court case has no court date (UH), you get a spooky 'at' because the logic around it wasn't tight enough 👻 

![image](https://user-images.githubusercontent.com/32230328/93479524-50d3fc00-f8f4-11ea-88c1-a3c2df5df72f.png)
## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
Fix the logic so you don't see 'at' when court date is nil


