### PR TITLE
Allow sending court date letter

### DIFF
--- a/app/views/tenancies/case/_court_cases.html.erb
+++ b/app/views/tenancies/case/_court_cases.html.erb
@@ -24,7 +24,12 @@
         <% if @court_case.nil? || @court_case.expired? %>
           No valid court case at this time
         <% else %>
-          <label class="govuk-label" for="court_date"><strong>Court date: </strong> <%= format_date(@court_case.court_date) %><br/></label>
+          <label class="govuk-label" for="court_date">
+            <strong>Court date: </strong>
+            <% court_time_missing = format_time(@court_case.court_date) == '00:00' || format_time(@court_case.court_date) == '' %>
+            <%= format_date(@court_case.court_date) %> <%= court_time_missing ? '' : "at #{format_time(@court_case.court_date)}" %>
+            <br/>
+          </label>
           <%= render :partial => 'court_cases/court_outcome' %>
         <% end %>
       </div>

--- a/app/views/tenancies/case/_court_cases.html.erb
+++ b/app/views/tenancies/case/_court_cases.html.erb
@@ -43,6 +43,13 @@
         <% elsif @court_case.court_outcome.nil? %>
           <% court_case_button_title = 'Edit court date' %>
           <%= link_to court_case_button_title, edit_court_date_path(@tenancy.ref, @court_case.id), class:'button' %>
+          <% if @court_case.future? %>
+              <%= form_tag(income_collection_letters_path, class: 'case-details__inline-block') do %>
+                <%= hidden_field_tag "template_id", 'court_date_letter' %>
+                <%= hidden_field_tag "tenancy_refs", @tenancy.ref %>
+                <%= submit_tag('Send court date letter', class: 'button') %>
+              <% end %>
+            <% end %>
           <% court_case_button_title = 'Add court outcome' %>
           <%= link_to court_case_button_title, edit_court_outcome_path(@tenancy.ref, @court_case.id), class:'button' %>
         <% else%>

--- a/lib/hackney/income/domain/court_case.rb
+++ b/lib/hackney/income/domain/court_case.rb
@@ -53,7 +53,7 @@ module Hackney
 
         def future?
           return false if court_date.nil?
-          
+
           court_date.to_datetime.future?
         end
 

--- a/lib/hackney/income/domain/court_case.rb
+++ b/lib/hackney/income/domain/court_case.rb
@@ -51,6 +51,12 @@ module Hackney
           ].include?(court_outcome)
         end
 
+        def future?
+          return false if court_date.nil?
+          
+          court_date.to_datetime.future?
+        end
+
         private
 
         def struck_out?

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -32,6 +32,7 @@ describe 'Create court case' do
     and_i_should_see_the_success_message
     and_i_should_see_the_view_history_link
     and_i_should_see_the_court_date_and_time
+    and_i_should_see_the_send_court_date_letter_button
 
     when_i_click_on_edit_court_date
     then_i_should_see_edit_court_date_page
@@ -42,6 +43,7 @@ describe 'Create court case' do
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_update_success_message
     and_i_should_see_the_updated_court_date_and_time
+    and_i_should_see_the_send_court_date_letter_button
 
     when_i_click_on_add_court_outcome
     then_i_should_see_edit_court_outcome_page
@@ -87,7 +89,7 @@ describe 'Create court case' do
   end
 
   def when_i_fill_in_the_court_date_and_time
-    fill_in 'court_date', with: '21/07/2020'
+    fill_in 'court_date', with: '21/07/3000'
     fill_in 'court_time', with: '11:11'
   end
 
@@ -108,7 +110,11 @@ describe 'Create court case' do
   end
 
   def and_i_should_see_the_court_date_and_time
-    expect(page).to have_content('Court date: July 21st, 2020 at 11:11')
+    expect(page).to have_content('Court date: July 21st, 3000 at 11:11')
+  end
+
+  def and_i_should_see_the_send_court_date_letter_button
+    expect(page).to have_button('Send court date letter')
   end
 
   def when_i_click_on_edit_court_date
@@ -123,12 +129,12 @@ describe 'Create court case' do
   end
 
   def and_i_should_see_the_current_court_date_info
-    expect(find_field('court_date').value).to eq('2020-07-21')
+    expect(find_field('court_date').value).to eq('3000-07-21')
     expect(find_field('court_time').value).to eq('11:11')
   end
 
   def when_i_fill_in_the_new_court_date_and_time
-    fill_in 'court_date', with: '23/07/2020'
+    fill_in 'court_date', with: '23/07/3000'
     fill_in 'court_time', with: '12:34'
   end
 
@@ -141,7 +147,7 @@ describe 'Create court case' do
   end
 
   def and_i_should_see_the_updated_court_date_and_time
-    expect(page).to have_content('Court date: July 23rd, 2020 at 12:34')
+    expect(page).to have_content('Court date: July 23rd, 3000 at 12:34')
   end
 
   def when_i_click_on_add_court_outcome
@@ -159,7 +165,7 @@ describe 'Create court case' do
   def when_i_fill_in_the_court_outcome
     choose('court_outcome_OPD')
     fill_in 'balance_on_court_outcome_date', with: '1000'
-    fill_in 'strike_out_date', with: '10/07/2024'
+    fill_in 'strike_out_date', with: '10/07/3024'
   end
 
   def and_i_click_add_outcome
@@ -175,11 +181,11 @@ describe 'Create court case' do
 
   def and_the_court_case_details
     expect(page).to have_content('Court date')
-    expect(page).to have_content('July 23rd, 2020 at 12:34')
+    expect(page).to have_content('July 23rd, 3000 at 12:34')
     expect(page).to have_content('Court outcome:')
     expect(page).to have_content('Outright Possession (with Date)')
     expect(page).to have_content('Strike out date:')
-    expect(page).to have_content('July 10th, 2024')
+    expect(page).to have_content('July 10th, 3024')
     expect(page).to have_content('Balance on court date:')
     expect(page).to have_content('£1,000')
   end
@@ -194,14 +200,14 @@ describe 'Create court case' do
 
   def and_the_existing_court_outcome_details
     expect(find_field('court_outcome_OPD')).to be_checked
-    expect(find_field('strike_out_date').value).to eq('2024-07-10')
+    expect(find_field('strike_out_date').value).to eq('3024-07-10')
     expect(find_field('balance_on_court_outcome_date').value).to eq('1000')
   end
 
   def when_i_fill_in_the_court_outcome_with_an_adjourned_outcome
     choose('court_outcome_AGP')
     fill_in 'balance_on_court_outcome_date', with: '1500'
-    fill_in 'strike_out_date', with: '10/08/2025'
+    fill_in 'strike_out_date', with: '10/08/3025'
   end
 
   def and_im_asked_to_select_terms_and_disrepair_counter_claim
@@ -224,7 +230,7 @@ describe 'Create court case' do
     expect(page).to have_content('Create court agreement')
     expect(page).to have_content('Agreement for: Alan Sugar')
     expect(page).to have_content('Court case related to this agreement')
-    expect(page).to have_content('Court date: July 23rd, 2020')
+    expect(page).to have_content('Court date: July 23rd, 3000')
     expect(page).to have_content('Court outcome: Adjourned generally with permission to restore')
     expect(page).to have_content('Frequency of payments')
     expect(page).to have_content('Weekly instalment amount')
@@ -244,7 +250,7 @@ describe 'Create court case' do
 
   def stub_create_court_case_response
     request_body_json = {
-      court_date: '21/07/2020 11:11',
+      court_date: '21/07/3000 11:11',
       court_outcome: nil,
       balance_on_court_outcome_date: nil,
       strike_out_date: nil,
@@ -255,7 +261,7 @@ describe 'Create court case' do
     response_json = {
       id: 12,
       tenancyRef: '1234567/01',
-      courtDate: '21/07/2020 11:11',
+      courtDate: '21/07/3000 11:11',
       courtOutcome: nil,
       balanceOnCourtOutcomeDate: nil,
       strikeOutDate: nil,
@@ -273,7 +279,7 @@ describe 'Create court case' do
 
   def stub_update_court_case_response
     request_body_json = {
-      court_date: '23/07/2020 12:34',
+      court_date: '23/07/3000 12:34',
       court_outcome: nil,
       balance_on_court_outcome_date: nil,
       strike_out_date: nil,
@@ -295,7 +301,7 @@ describe 'Create court case' do
         court_date: nil,
         court_outcome: 'OPD',
         balance_on_court_outcome_date: '1000',
-        strike_out_date: '10/07/2024',
+        strike_out_date: '10/07/3024',
         terms: nil,
         disrepair_counter_claim: nil
       }.to_json,
@@ -303,7 +309,7 @@ describe 'Create court case' do
         court_date: nil,
         court_outcome: 'AGP',
         balance_on_court_outcome_date: '1500',
-        strike_out_date: '10/08/2025',
+        strike_out_date: '10/08/3025',
         terms: true,
         disrepair_counter_claim: false
       }.to_json
@@ -329,7 +335,7 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '21/07/2020 11:11',
+          courtDate: '21/07/3000 11:11',
           courtOutcome: nil,
           balanceOnCourtOutcomeDate: nil,
           strikeOutDate: nil,
@@ -343,7 +349,7 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '23/07/2020 12:34',
+          courtDate: '23/07/3000 12:34',
           courtOutcome: nil,
           balanceOnCourtOutcomeDate: nil,
           strikeOutDate: nil,
@@ -357,10 +363,10 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '23/07/2020 12:34',
+          courtDate: '23/07/3000 12:34',
           courtOutcome: 'OPD',
           balanceOnCourtOutcomeDate: '1000',
-          strikeOutDate: '10/07/2024',
+          strikeOutDate: '10/07/3024',
           terms: nil,
           disrepairCounterClaim: nil
         }]
@@ -371,10 +377,10 @@ describe 'Create court case' do
         [{
           id: 12,
           tenancyRef: '1234567/01',
-          courtDate: '23/07/2020 12:34',
+          courtDate: '23/07/3000 12:34',
           courtOutcome: 'AGP',
           balanceOnCourtOutcomeDate: '1500',
-          strikeOutDate: '10/08/2025',
+          strikeOutDate: '10/08/3025',
           terms: true,
           disrepairCounterClaim: false
         }]

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -25,13 +25,13 @@ describe 'Create court case' do
     and_i_click_on_add_court_date
 
     then_i_should_see_add_court_date_page
-    when_i_fill_in_the_court_date
+    when_i_fill_in_the_court_date_and_time
     and_i_click_on_add
 
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_success_message
     and_i_should_see_the_view_history_link
-    and_i_should_see_the_court_date
+    and_i_should_see_the_court_date_and_time
 
     when_i_click_on_edit_court_date
     then_i_should_see_edit_court_date_page
@@ -41,7 +41,7 @@ describe 'Create court case' do
 
     then_i_should_see_the_tenancy_page
     and_i_should_see_the_update_success_message
-    and_i_should_see_the_updated_court_date
+    and_i_should_see_the_updated_court_date_and_time
 
     when_i_click_on_add_court_outcome
     then_i_should_see_edit_court_outcome_page
@@ -86,7 +86,7 @@ describe 'Create court case' do
     expect(page).to have_button('Add')
   end
 
-  def when_i_fill_in_the_court_date
+  def when_i_fill_in_the_court_date_and_time
     fill_in 'court_date', with: '21/07/2020'
     fill_in 'court_time', with: '11:11'
   end
@@ -107,8 +107,8 @@ describe 'Create court case' do
     expect(page).to have_content('View history')
   end
 
-  def and_i_should_see_the_court_date
-    expect(page).to have_content('Court date: July 21st, 2020')
+  def and_i_should_see_the_court_date_and_time
+    expect(page).to have_content('Court date: July 21st, 2020 at 11:11')
   end
 
   def when_i_click_on_edit_court_date
@@ -140,8 +140,8 @@ describe 'Create court case' do
     expect(page).to have_content('Successfully updated the court case')
   end
 
-  def and_i_should_see_the_updated_court_date
-    expect(page).to have_content('Court date: July 23rd, 2020')
+  def and_i_should_see_the_updated_court_date_and_time
+    expect(page).to have_content('Court date: July 23rd, 2020 at 12:34')
   end
 
   def when_i_click_on_add_court_outcome

--- a/spec/features/income_collection/court_cases/view_court_cases_spec.rb
+++ b/spec/features/income_collection/court_cases/view_court_cases_spec.rb
@@ -43,7 +43,7 @@ describe 'View agreements' do
         {
         id: 14,
         tenancyRef: '1234567/01',
-        courtDate: '24/07/2020',
+        courtDate: '24/07/2020 09:00',
         courtOutcome: 'SOT',
         balanceOnCourtOutcomeDate: '1800',
         strikeOutDate: '24/07/2021',
@@ -53,7 +53,7 @@ describe 'View agreements' do
         {
           id: 15,
           tenancyRef: '1234567/01',
-          courtDate: '26/09/2020',
+          courtDate: '26/09/2020 12:34',
           courtOutcome: 'AGP',
           balanceOnCourtOutcomeDate: '1700',
           strikeOutDate: '10/07/2025',
@@ -73,7 +73,7 @@ describe 'View agreements' do
 
   def then_i_should_see_the_court_case_details
     expect(page).to have_content('Court date')
-    expect(page).to have_content('September 26th, 2020')
+    expect(page).to have_content('September 26th, 2020 at 12:34')
     expect(page).to have_content('Court outcome:')
     expect(page).to have_content('Adjourned generally with permission to restore')
     expect(page).to have_content('Strike out date:')

--- a/spec/lib/hackney/income/domain/court_case_spec.rb
+++ b/spec/lib/hackney/income/domain/court_case_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe Hackney::Income::Domain::CourtCase do
   let(:subject) do
     described_class.new.tap do |c|
@@ -54,34 +56,68 @@ describe Hackney::Income::Domain::CourtCase do
         expect(subject.expired?).to be_falsy
       end
     end
+  end
 
-    describe '#can_have_terms?' do
-      context 'When its an outcome that can have terms' do
-        let(:court_outcome) do
-          [
-            described_class::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
-            described_class::CourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
-            described_class::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
-            described_class::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING
-          ].sample
-        end
-
-        it 'returns true' do
-          expect(subject.can_have_terms?).to be_truthy
-        end
+  describe '#can_have_terms?' do
+    context 'When its an outcome that can have terms' do
+      let(:court_outcome) do
+        [
+          described_class::CourtOutcomeCodes::ADJOURNED_GENERALLY_WITH_PERMISSION_TO_RESTORE,
+          described_class::CourtOutcomeCodes::ADJOURNED_TO_NEXT_OPEN_DATE,
+          described_class::CourtOutcomeCodes::ADJOURNED_TO_ANOTHER_HEARING_DATE,
+          described_class::CourtOutcomeCodes::ADJOURNED_FOR_DIRECTIONS_HEARING
+        ].sample
       end
 
-      context 'When its not an adjourned outcome' do
-        let(:court_outcome) do
-          [
-            described_class::CourtOutcomeCodes::STRUCK_OUT,
-            described_class::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
-          ].sample
-        end
+      it 'returns true' do
+        expect(subject.can_have_terms?).to be_truthy
+      end
+    end
 
-        it 'returns false' do
-          expect(subject.can_have_terms?).to be_falsy
-        end
+    context 'When its not an adjourned outcome' do
+      let(:court_outcome) do
+        [
+          described_class::CourtOutcomeCodes::STRUCK_OUT,
+          described_class::CourtOutcomeCodes::WITHDRAWN_ON_THE_DAY
+        ].sample
+      end
+
+      it 'returns false' do
+        expect(subject.can_have_terms?).to be_falsy
+      end
+    end
+  end
+
+  describe '#future?' do
+    before do
+      Timecop.freeze('01/01/2020')
+    end
+
+    after do
+      Timecop.return
+    end
+
+    context 'When a court date is in the future ' do
+      let(:court_date) { DateTime.now + 30.days }
+
+      it 'returns true' do
+        expect(subject.future?).to be_truthy
+      end
+    end
+
+    context 'When a court date is not in the future' do
+      let(:court_date) { DateTime.now - 1.days }
+
+      it 'returns false' do
+        expect(subject.future?).to be_falsy
+      end
+    end
+
+    context 'When a court date is nil' do
+      let(:court_date) { nil }
+
+      it 'returns false' do
+        expect(subject.future?).to be_falsy
       end
     end
   end

--- a/spec/lib/hackney/income/domain/tenancy_list_item_spec.rb
+++ b/spec/lib/hackney/income/domain/tenancy_list_item_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 describe Hackney::Income::Domain::TenancyListItem do
   context 'when retrieving tenancy list items' do
     let(:subject) { described_class.new }


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
After adding a court date, an officer needs to be able to manually send a Court Date letter to the tenant.
## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Show court time on the tenancy page
- Show `Send court date letter` button if there is a court date that's in the future:
![image](https://user-images.githubusercontent.com/32230328/93502902-47a45880-f90f-11ea-939d-20df03216610.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-462?atlOrigin=eyJpIjoiZGMxNDhhNWE1NWZlNDEwZThjNDk5ODNiYzFiOWI5ZDEiLCJwIjoiaiJ9
## Things to check

- [x] Environment variables have been updated
