### PR TITLE
Allow creating formal one off payment agreements

### DIFF
--- a/app/views/agreements/form/_one_off_payment_agreement.html.erb
+++ b/app/views/agreements/form/_one_off_payment_agreement.html.erb
@@ -10,6 +10,7 @@
     <%= hidden_field_tag :agreement_type, formal_agreement ? 'formal' : 'informal' %>
     <%= hidden_field_tag :payment_type, @payment_type %>
     <%= hidden_field_tag :frequency, :one_off %>
+    <%= hidden_field_tag :court_case_id, @court_cases.last.id if formal_agreement %>
       <div class="form-group">
         <% hint_text = formal_agreement ? 'This is the balance on the court outcome date' : 'This is the total arrears balance owed'%>
         <label class="govuk-label" style="font-weight:bold" for="starting_balance" id="starting_balance_label">Payment Amount


### PR DESCRIPTION
## Context
The one-off payment form does not allow creating formal agreements because the court case id is missing from the form.

## Changes in this pull request
- Add `court_case_id` as a hidden field tag when it's a formal agreement

## Things to check
- [x] Environment variables have been updated
