### PR TITLE
Fix recommended_actions_map for address_court_agreement_breach

### DIFF
--- a/app/helpers/recommended_actions_select_helper.rb
+++ b/app/helpers/recommended_actions_select_helper.rb
@@ -12,7 +12,7 @@ module RecommendedActionsSelectHelper
       update_court_outcome_action: 'Update Court Outcome',
       court_breach_no_payment: 'Court Breach - No Payment',
       court_breach_visit: 'Court Breach Visit',
-      address_court_breach: 'Address Court Breach',
+      address_court_agreement_breach: 'Address Court Agreement Breach',
       send_informal_agreement_breach_letter: 'Send Informal Agreement Breached Letter',
       informal_breached_after_letter: 'Informal Agreement Breach Letter Sent & Still Breached',
       review_failed_letter: 'Review Failed Letter',


### PR DESCRIPTION
## Context
Breached court order not showing a 'next recommended action'

## Changes in this pull request
- Fix `recommended_actions_map` for `address_court_agreement_breach`

## Guidance to review
Was debugging the classification rules for half a day, I ended up syncing data from prod because I couldn't see why the classification is off, turned out the classification was correct but the key in recommended_actions_map was incorrect...

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-500
## Things to check
- [x] Environment variables have been updated
