### PR TITLE
Ask users to fill in the reason of cancellation when cancelling an agreement

### DIFF
--- a/app/controllers/agreements_controller.rb
+++ b/app/controllers/agreements_controller.rb
@@ -60,16 +60,21 @@ class AgreementsController < ApplicationController
   def confirm_cancellation
     tenancy_ref
     agreement_id
+    cancellation_reason
   end
 
   def cancel
-    use_cases.cancel_agreement.execute(agreement_id: agreement_id)
+    use_cases.cancel_agreement.execute(
+      agreement_id: agreement_id,
+      cancelled_by: @current_user.name,
+      cancellation_reason: cancellation_reason
+    )
 
     flash[:notice] = 'Successfully cancelled the agreement'
     redirect_to tenancy_path(id: tenancy_ref)
   rescue Exceptions::IncomeApiError => e
     flash[:notice] = "An error occurred while cancelling the agreement: #{e.message}"
-    render :confirm_cancellation, tenancy_ref: tenancy_ref, id: agreement_id
+    render :confirm_cancellation, tenancy_ref: tenancy_ref, id: agreement_id, cancellation_reason: @cancellation_reason
   end
 
   def show_history
@@ -85,6 +90,10 @@ class AgreementsController < ApplicationController
 
   def agreement_id
     @agreement_id ||= params.fetch(:id).to_i
+  end
+
+  def cancellation_reason
+    @cancellation_reason ||= params.dig(:cancellation_reason)
   end
 
   def agreement_params

--- a/app/views/agreements/confirm_cancellation.html.erb
+++ b/app/views/agreements/confirm_cancellation.html.erb
@@ -10,7 +10,13 @@
   <div class="column-full">
     <h1><%= 'Are you sure you want to cancel this agreement?' %></h1>
     <hr>
-    <%= link_to 'Yes', cancel_agreement_path(tenancy_ref: @tenancy_ref, id: @agreement_id), method: :post, class:'button' %>
+    <%= form_tag('cancel', method: :post) do %>
+      <div class="form-group">
+        <label class="govuk-label" for="cancellation_reason"><strong>Reason of cancellation</strong><br/></label>
+        <%= text_area_tag(:cancellation_reason, @cancellation_reason, { class: 'form-control', required: true  }) %>
+      </div>
+    <%= submit_tag 'Yes', class: 'button' %>
     <%= link_to 'No', show_agreement_path(tenancy_ref: @tenancy_ref, id: @agreement_id), class:'button' %>
+  <% end %>
   </div>
 </div>

--- a/lib/hackney/income/agreements_gateway.rb
+++ b/lib/hackney/income/agreements_gateway.rb
@@ -51,13 +51,18 @@ module Hackney
         end
       end
 
-      def cancel_agreement(agreement_id:)
+      def cancel_agreement(agreement_id:, cancelled_by:, cancellation_reason:)
+        body_data = {
+          cancelled_by: cancelled_by,
+          cancellation_reason: cancellation_reason
+        }.to_json
+
         uri = URI.parse("#{@api_host}/v1/agreements/#{ERB::Util.url_encode(agreement_id)}/cancel")
         req = Net::HTTP::Post.new(uri.path)
         req['Content-Type'] = 'application/json'
         req['X-Api-Key'] = @api_key
 
-        response = Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == 'https')) { |http| http.request(req) }
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == 'https')) { |http| http.request(req, body_data) }
 
         raise_error(response, "when trying to cancel the agreement using '#{uri}'")
 

--- a/lib/hackney/income/cancel_agreement.rb
+++ b/lib/hackney/income/cancel_agreement.rb
@@ -5,8 +5,12 @@ module Hackney
         @agreement_gateway = agreement_gateway
       end
 
-      def execute(agreement_id:)
-        @agreement_gateway.cancel_agreement(agreement_id: agreement_id)
+      def execute(agreement_id:, cancelled_by:, cancellation_reason:)
+        @agreement_gateway.cancel_agreement(
+          agreement_id: agreement_id,
+          cancelled_by: cancelled_by,
+          cancellation_reason: cancellation_reason
+        )
       end
     end
   end

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -66,7 +66,8 @@ describe 'Create informal agreement' do
     and_i_click_on_cancel
     then_i_am_asked_to_confirm_cancellation
 
-    when_i_confirm_to_cancel_the_agreement
+    when_i_fill_up_the_cancellation_reason
+    and_i_confirm_to_cancel_the_agreement
     then_i_should_see_the_tenancy_page
     and_i_should_not_see_a_live_agreement
     and_i_should_see_a_link_to_view_history
@@ -226,8 +227,12 @@ describe 'Create informal agreement' do
     expect(page).to have_content('Are you sure you want to cancel this agreement?')
   end
 
-  def when_i_confirm_to_cancel_the_agreement
-    click_link 'Yes'
+  def when_i_fill_up_the_cancellation_reason
+    fill_in 'cancellation_reason', with: 'needed to cancel'
+  end
+
+  def and_i_confirm_to_cancel_the_agreement
+    click_button 'Yes'
   end
 
   def and_i_should_not_see_a_live_agreement
@@ -558,8 +563,16 @@ describe 'Create informal agreement' do
   end
 
   def stub_cancel_agreement_response
+    request_body_json = {
+      cancelled_by: 'Hackney User',
+      cancellation_reason: 'needed to cancel'
+    }.to_json
+
     stub_request(:post, 'https://example.com/income/api/v1/agreements/13/cancel')
-         .with(headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] })
+         .with(
+           body: request_body_json,
+           headers: { 'X-Api-Key' => ENV['INCOME_API_KEY'] }
+         )
          .to_return(status: 200, headers: {})
   end
 end

--- a/spec/lib/hackney/income/cancel_agreement_spec.rb
+++ b/spec/lib/hackney/income/cancel_agreement_spec.rb
@@ -3,11 +3,17 @@ require 'rails_helper'
 describe Hackney::Income::CancelAgreement do
   let(:agreement_gateway) { instance_double(Hackney::Income::AgreementsGateway) }
   let(:agreement_id) { Faker::Lorem.characters(number: 6) }
+  let(:cancellation_reason) { Faker::Lorem.characters(number: 40) }
+  let(:cancelled_by) { Faker::Name.name }
 
   subject { described_class.new(agreement_gateway: agreement_gateway) }
 
   it 'should pass the required param to the gateway' do
-    expect(agreement_gateway).to receive(:cancel_agreement).with(agreement_id: agreement_id)
-    subject.execute(agreement_id: agreement_id)
+    expect(agreement_gateway).to receive(:cancel_agreement).with(
+      agreement_id: agreement_id,
+      cancelled_by: cancelled_by,
+      cancellation_reason: cancellation_reason
+    )
+    subject.execute(agreement_id: agreement_id, cancelled_by: cancelled_by, cancellation_reason: cancellation_reason)
   end
 end


### PR DESCRIPTION
## Context
As a credit controller, whenever I cancel or change an agreement I want to be able to add a note so that I can put in a reason for why it was cancelled or changed.

## Changes in this pull request
- Update `create agreement` use-case and `agreements gateway` to send `cancellation reason` and `cancelled by` in the request body
- Ask users to fill in the reason of cancellation when cancelling an agreement
![image](https://user-images.githubusercontent.com/22743709/93882164-bbf84680-fcd7-11ea-98b7-c5ee976c0484.png)


## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-280
## Things to check

- [x] Environment variables have been updated
