### PR TITLE
Add court breach visit made action code

### DIFF
--- a/app/views/agreements/confirm_cancellation.html.erb
+++ b/app/views/agreements/confirm_cancellation.html.erb
@@ -15,8 +15,7 @@
         <label class="govuk-label" for="cancellation_reason"><strong>Reason of cancellation</strong><br/></label>
         <%= text_area_tag(:cancellation_reason, @cancellation_reason, { class: 'form-control', required: true  }) %>
       </div>
-    <%= submit_tag 'Yes', class: 'button' %>
-    <%= link_to 'No', show_agreement_path(tenancy_ref: @tenancy_ref, id: @agreement_id), class:'button' %>
+    <%= submit_tag 'Confirm and cancel', class: 'button' %>
   <% end %>
   </div>
 </div>

--- a/lib/hackney/income/action_diary_entry_codes.rb
+++ b/lib/hackney/income/action_diary_entry_codes.rb
@@ -4,6 +4,7 @@ module Hackney
       def self.all_code_options
         [
           { name: 'Covid 19 Call', code: 'CVD', user_accessible: true },
+          { name: 'Court Breach Visit Made', code: 'CBV', user_accessible: true },
           { name: 'Arrears Cleared', code: 'Z00', user_accessible: false },
           { name: 'Old Stage One', code: '1RS', user_accessible: false },
           { name: 'Old Stage Two', code: '2RS', user_accessible: false },

--- a/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_informal_agreement_spec.rb
@@ -232,7 +232,7 @@ describe 'Create informal agreement' do
   end
 
   def and_i_confirm_to_cancel_the_agreement
-    click_button 'Yes'
+    click_button 'Confirm and cancel'
   end
 
   def and_i_should_not_see_a_live_agreement

--- a/spec/lib/hackney/income/action_diary_entry_codes_spec.rb
+++ b/spec/lib/hackney/income/action_diary_entry_codes_spec.rb
@@ -6,6 +6,7 @@ describe Hackney::Income::ActionDiaryEntryCodes do
       expect(described_class.code_dropdown_options)
         .to match_array([
                           ['Covid 19 Call', 'CVD'],
+                          ['Court Breach Visit Made', 'CBV'],
                           ['Direct Debit Cancelled', 'DDC'],
                           ['Financial Inclusion Call', 'FIC'],
                           ['Financial Inclusion Interview', 'FIO'],


### PR DESCRIPTION
## Context
The current `Visit Made` action can be used for other visits than court breach visits, therefore we should't use this for determining the next recommended action for court breaches.

## Changes in this pull request
- Add a more specific `Court Breach Visit Made` action code 
- Unrelated change, updated the agreement cancellation button to better align with [gov UK design-system](https://design-system.service.gov.uk/components/button/)
![image](https://user-images.githubusercontent.com/22743709/93985210-aab54580-fd7c-11ea-98ac-9c74796b87ea.png)

## Link to Jira card
https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=30&projectKey=MAAP&modal=detail&selectedIssue=MAAP-520

## Things to check
- [x] Environment variables have been updated
