### PR TITLE
Add covid pause reason

### DIFF
--- a/app/helpers/pause_reason_filter_helper.rb
+++ b/app/helpers/pause_reason_filter_helper.rb
@@ -8,6 +8,7 @@ module PauseReasonFilterHelper
         'Promise of payment' => 'Promise of payment',
         'Deceased' => 'Deceased',
         'Missing Data' => 'Missing Data',
+        'C19 Court Order Breached' => 'C19 Court Order Breached',
         'Other' => 'Other'
       }, option
     )

--- a/app/helpers/tenancy_helper.rb
+++ b/app/helpers/tenancy_helper.rb
@@ -20,6 +20,7 @@ module TenancyHelper
       'Promise of payment' => 'POP',
       'Deceased' => 'DEC',
       'Missing Data' => 'RMD',
+      'C19 Court Order Breached' => 'CVB',
       'Other' => 'GEN'
     }
   end

--- a/lib/hackney/income/action_diary_entry_codes.rb
+++ b/lib/hackney/income/action_diary_entry_codes.rb
@@ -4,6 +4,7 @@ module Hackney
       def self.all_code_options
         [
           { name: 'Covid 19 Call', code: 'CVD', user_accessible: true },
+          { name: 'C19 Court Order Breached', code: 'CVB', user_accessible: true },
           { name: 'Court Breach Visit Made', code: 'CBV', user_accessible: true },
           { name: 'Arrears Cleared', code: 'Z00', user_accessible: false },
           { name: 'Old Stage One', code: '1RS', user_accessible: false },
@@ -46,6 +47,8 @@ module Hackney
           { name: 'Stage Two Complete', code: 'ZL2', user_accessible: false },
           { name: 'Stage Three Complete', code: 'ZL3', user_accessible: false },
           { name: 'Court Proceedings Complete', code: 'ZR6', user_accessible: false },
+          { name: 'Court Date Letter', code: 'CDL', user_accessible: true },
+          { name: 'Court Outcome Added', code: 'IC6', user_accessible: true },
           { name: 'Court Outcome Letter', code: 'IC5', user_accessible: true },
           { name: 'Court Warning Letter', code: 'IC4', user_accessible: true },
           { name: 'Stage Three (T)', code: '3TS', user_accessible: false },

--- a/spec/lib/hackney/income/action_diary_entry_codes_spec.rb
+++ b/spec/lib/hackney/income/action_diary_entry_codes_spec.rb
@@ -6,6 +6,7 @@ describe Hackney::Income::ActionDiaryEntryCodes do
       expect(described_class.code_dropdown_options)
         .to match_array([
                           ['Covid 19 Call', 'CVD'],
+                          ['C19 Court Order Breached', 'CVB'],
                           ['Court Breach Visit Made', 'CBV'],
                           ['Direct Debit Cancelled', 'DDC'],
                           ['Financial Inclusion Call', 'FIC'],
@@ -23,6 +24,8 @@ describe Hackney::Income::ActionDiaryEntryCodes do
                           ['Adjourned Generally', 'ADG'],
                           ['Adjourned on Terms', 'ADT'],
                           ['Charge Against Property', 'CAP'],
+                          ['Court Date Letter', 'CDL'],
+                          ['Court Outcome Added', 'IC6'],
                           ['Court Outcome Letter', 'IC5'],
                           ['Court Warning Letter', 'IC4'],
                           ['Promise of payment', 'POP'],


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Officers might need to pause cases, where there is a Court Order breach because of Covid.

This is the frontend change to allow it.

I also realised that I hadn't added the action codes for `Court Date Letter` and `Court Outcome Added` to the list of valid Action Codes.
## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- Adds Pause dropdown option for `C19 Court Order Breached`
<img src='https://user-images.githubusercontent.com/32230328/94128155-ae66cc00-fe51-11ea-9536-20304ef2a806.png' height='400' />

- Adds Action Codes for `C19 Court Order Breached`, `Court Date Letter` and `Court Outcome Added` to list of Action Diary Entry Code Options
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I'm not 100% confident with Action Diary related things, so please shout if it looks like I'm missing anything 😅 
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-519?atlOrigin=eyJpIjoiZTgwMzkzZjUxMmVkNDE2ZGE0ZjI1YWQ4NTc4NWVmMTYiLCJwIjoiaiJ9
## Things to check

- [x] Environment variables have been updated
