### PR TITLE
when court outcome needs an eviction date, show eviction button

### DIFF
--- a/app/helpers/court_outcomes_helper.rb
+++ b/app/helpers/court_outcomes_helper.rb
@@ -14,4 +14,8 @@ module CourtOutcomesHelper
       'WIT' => 'Withdrawn on the day'
     }
   end
+
+  def if_outcome_needs_eviction_date(outcome)
+    outcome == ('OPD' || 'OPF')
+  end
 end

--- a/app/views/court_cases/_court_outcome.html.erb
+++ b/app/views/court_cases/_court_outcome.html.erb
@@ -2,11 +2,14 @@
   <ul>
     <li><strong>Court outcome: </strong> <%= court_outcomes[@court_case.court_outcome] %> </li>
     <li><strong>Balance on court date: </strong> <%= number_to_currency(@court_case.balance_on_court_outcome_date, unit: '£') %></li>
-    <% if @court_case.can_have_terms? %> 
+    <% if @court_case.can_have_terms? %>
       <li><strong>Terms: </strong> <%= @court_case.terms ? 'Yes' : 'No' %></li>
       <li><strong>Disrepair counter claim: </strong> <%= @court_case.disrepair_counter_claim ? 'Yes' : 'No' %></li>
-    <% end %> 
+    <% end %>
     <li><strong>Strike out date: </strong><%= format_date(@court_case.strike_out_date) %></li>
     <br/>
   </ul>
+  <% if if_outcome_needs_eviction_date(@court_case.court_outcome) %>
+    <%= link_to 'Add an eviction date', new_court_case_path(@tenancy.ref), class:'button' %>
+  <% end %>
 <% end %>

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -52,6 +52,7 @@ describe 'Create court case' do
     then_i_should_see_the_court_case_page
 
     and_the_court_case_details
+    then_i_should_see_add_eviction_date_button
     then_i_should_see_send_outcome_letter_button
 
     when_i_click_to_edit_the_court_outcome
@@ -188,6 +189,10 @@ describe 'Create court case' do
     expect(page).to have_content('July 10th, 3024')
     expect(page).to have_content('Balance on court date:')
     expect(page).to have_content('£1,000')
+  end
+
+  def then_i_should_see_add_eviction_date_button
+    expect(page).to have_content('Add an eviction date')
   end
 
   def then_i_should_see_send_outcome_letter_button


### PR DESCRIPTION
# Depends on https://github.com/LBHackney-IT/LBH-IncomeCollection/pull/389 being merged in

## Context
<!-- Why are you making this change? What might surprise someone about it? -->
when court outcome needs an eviction date, show eviction button

<img width="529" alt="Screenshot 2020-09-24 at 11 00 05" src="https://user-images.githubusercontent.com/8051117/94131801-4b2b6880-fe56-11ea-8089-72310ca1ff8b.png">


## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
- when court outcome needs an eviction date, show eviction button

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] Environment variables have been updated
