### PR TITLE
Court Case action diary sync

### DIFF
--- a/app/controllers/court_cases_controller.rb
+++ b/app/controllers/court_cases_controller.rb
@@ -8,7 +8,8 @@ class CourtCasesController < ApplicationController
   def create
     create_court_case_params = {
       tenancy_ref: tenancy_ref,
-      court_date: court_date
+      court_date: court_date,
+      username: username
     }
     use_cases.create_court_case.execute(create_court_case_params: create_court_case_params)
 

--- a/lib/hackney/income/court_cases_gateway.rb
+++ b/lib/hackney/income/court_cases_gateway.rb
@@ -18,7 +18,8 @@ module Hackney
           balance_on_court_outcome_date: create_court_case_params[:balance_on_court_outcome_date],
           strike_out_date: create_court_case_params[:strike_out_date],
           terms: create_court_case_params[:terms],
-          disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim]
+          disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim],
+          username: create_court_case_params[:username]
         }.to_json
 
         uri = URI.parse("#{@api_host}/v1/court_case/#{ERB::Util.url_encode(tenancy_ref)}/")

--- a/lib/hackney/income/create_court_case.rb
+++ b/lib/hackney/income/create_court_case.rb
@@ -13,7 +13,8 @@ module Hackney
           balance_on_court_outcome_date: create_court_case_params[:balance_on_court_outcome_date],
           strike_out_date: create_court_case_params[:strike_out_date],
           terms: create_court_case_params[:terms],
-          disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim]
+          disrepair_counter_claim: create_court_case_params[:disrepair_counter_claim],
+          username: create_court_case_params[:username]
         }
 
         @court_cases_gateway.create_court_case(create_court_case_params: create_court_case_params)

--- a/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
+++ b/spec/features/income_collection/agreements/creating_formal_agreement_spec.rb
@@ -402,7 +402,8 @@ describe 'Create Formal agreement' do
       balance_on_court_outcome_date: nil,
       strike_out_date: nil,
       terms: nil,
-      disrepair_counter_claim: nil
+      disrepair_counter_claim: nil,
+      username: 'Hackney User'
     }.to_json
 
     response_json = {

--- a/spec/features/income_collection/court_cases/creating_court_case_spec.rb
+++ b/spec/features/income_collection/court_cases/creating_court_case_spec.rb
@@ -255,7 +255,8 @@ describe 'Create court case' do
       balance_on_court_outcome_date: nil,
       strike_out_date: nil,
       terms: nil,
-      disrepair_counter_claim: nil
+      disrepair_counter_claim: nil,
+      username: 'Hackney User'
     }.to_json
 
     response_json = {

--- a/spec/lib/hackney/income/court_cases_gateway_spec.rb
+++ b/spec/lib/hackney/income/court_cases_gateway_spec.rb
@@ -5,6 +5,7 @@ describe Hackney::Income::CourtCasesGateway do
   let(:tenancy_ref) { "#{Faker::Lorem.characters(number: 6)}/#{Faker::Lorem.characters(number: 2)}" }
 
   describe '#create_court_case' do
+    let(:username) { Faker::Name.name }
     let(:request_params) do
       {
         tenancy_ref: tenancy_ref,
@@ -13,7 +14,8 @@ describe Hackney::Income::CourtCasesGateway do
         balance_on_court_outcome_date: nil,
         strike_out_date: nil,
         terms: nil,
-        disrepair_counter_claim: nil
+        disrepair_counter_claim: nil,
+        username: username
       }
     end
 
@@ -24,7 +26,8 @@ describe Hackney::Income::CourtCasesGateway do
         balance_on_court_outcome_date: request_params.fetch(:balance_on_court_outcome_date),
         strike_out_date: request_params.fetch(:strike_out_date),
         terms: request_params.fetch(:terms),
-        disrepair_counter_claim: request_params.fetch(:disrepair_counter_claim)
+        disrepair_counter_claim: request_params.fetch(:disrepair_counter_claim),
+        username: request_params.fetch(:username)
       }.to_json
     end
 

--- a/spec/lib/hackney/income/create_court_case_spec.rb
+++ b/spec/lib/hackney/income/create_court_case_spec.rb
@@ -10,7 +10,8 @@ describe Hackney::Income::CreateCourtCase do
       balance_on_court_outcome_date: nil,
       strike_out_date: nil,
       terms: nil,
-      disrepair_counter_claim: nil
+      disrepair_counter_claim: nil,
+      username: Faker::Name.name
     }
   end
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Second slice of adding a new action entry when a court case is added, The username is now passed to the API to allow an action diary write and sync

## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- front end now passes `username` through the request body to the back end

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->
https://hackney.atlassian.net/browse/MAAP-521
## Things to check

- [ ] Environment variables have been updated
