### PR TITLE
Create send and view letter buttons and remove leasehold buttons from rents worktray

### DIFF
--- a/app/views/tenancies/income_collection/_buttons.html.erb
+++ b/app/views/tenancies/income_collection/_buttons.html.erb
@@ -1,0 +1,8 @@
+<div class="grid-row">
+  <div class="column-full">
+    <div class='other_actions tenancy_list column-align-center'>
+      <%= link_to 'Send letters', new_income_collection_letter_path, class: 'button' %>
+      <%= link_to  'View letters', documents_path, class: 'button' %>
+    </div>
+  </div>
+</div>

--- a/app/views/tenancies/index.html.erb
+++ b/app/views/tenancies/index.html.erb
@@ -4,12 +4,9 @@
   <%= worktray_title %>
 <% end %>
 
-<% if current_user.leasehold_services? %>
-  <%= render partial: 'tenancies/leasehold/buttons' %>
-<% end  %>
-
 <% unless @tenancies.nil? %>
   <% if current_user.income_collection? %>
+    <%= render partial: 'tenancies/income_collection/buttons' %>
     <%= render partial: 'tenancies/worktray/tabs' %>
   <% end %>
 

--- a/spec/request/worktray_spec.rb
+++ b/spec/request/worktray_spec.rb
@@ -23,9 +23,8 @@ describe 'Viewing the Worktray', type: :request do
       expect(response).not_to render_template('tenancies/worktray/worktray_table')
     end
 
-    it 'does render the leasehold button' do
+    it 'does not render the leasehold button' do
       get worktray_path
-
       expect(response).not_to render_template('leasehold/buttons')
     end
   end
@@ -43,6 +42,12 @@ describe 'Viewing the Worktray', type: :request do
       get worktray_path
 
       expect(response).not_to render_template('tenancies/worktray/worktray_table')
+    end
+
+    it 'does render the income collection button' do
+      get worktray_path
+
+      expect(response).not_to render_template('income_collection/buttons')
     end
 
     it 'does not render the leasehold button' do


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Small PR which adds two new buttons for the rents worktray to send bulk letters and to view them.
Also removes the leasehold buttons from the same worktray that appear when you are within both user groups
## Changes in this pull request
<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->

- Add send & view letters button partial to allow rents to go straight to the bulk letter sending tool
- Remove displaying of leasehold buttons on the worktray

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I have kept the leasehold button just in case we wish to use it within the V2 worktray however if not will delete it. Also a bit skeptical on the value of the worktray request spec tests, added a test nonetheless to keep to standard however I am unsure of the value of these tests
## Link to Jira card
<!-- https://hackney.atlassian.net/123-example-card -->

## Things to check

- [ ] Environment variables have been updated
